### PR TITLE
Reorganize belief page sections per canonical rulebook

### DIFF
--- a/docs/BELIEF_PAGE_RULES.md
+++ b/docs/BELIEF_PAGE_RULES.md
@@ -1,0 +1,158 @@
+# ISE Belief Page Rules (Canonical)
+
+**This is the authoritative rulebook for generating any Idea Stock Exchange belief page, CBA, blog post, or scored argument content. Read before generating. Every rule has a specific failure mode it exists to prevent.**
+
+This document is referenced by:
+
+- `src/app/beliefs/[slug]/page.tsx` — the live belief page route
+- `src/features/belief-analysis/components/DefinitionsSection.tsx` — renders last per Rule 1
+- `templates/belief-analysis-template.html` — the PBworks / wiki template
+- Any skill, generator, or prompt that produces ISE belief pages
+
+If you change the rules here, update the code that implements them. If you change the code, update these rules.
+
+---
+
+## Rule 1: Definitions Go at the BACK
+
+Definitions, scoring concept explanations, and terminology glossaries live at the END of the page, never the top.
+
+**Why:** The page is a navigation tool into a scored argument network, not a tutorial. Readers come to see the structured argument, not to be taught what a Linkage Score is. Anyone who needs a definition clicks the link to that concept's own page. Definitions at the top are friction; they push the scored content below the fold.
+
+**How to apply:** If a page has a Definitions section, Scoring Concepts section, or anything labeled "What this is" — it goes AFTER arguments, evidence, values, interests, assumptions, CBA, resolution, and belief mapping. The last section before Contribute/footer, not the first.
+
+---
+
+## Rule 2: No Wikipedia-Style Summary or Background
+
+Do NOT write a "Background," "Summary," "Context," "Overview," or "Hook" section explaining what the topic is.
+
+**Why:** ISE does not compete with Wikipedia for topic explanation. People have a billion places to go for "what is public banking." ISE's only value proposition is the ReasonRank decomposition: chopping arguments into atomic scored parts. A background paragraph at the top dilutes that value proposition and makes ISE look like a worse Wikipedia.
+
+**How to apply:**
+
+- No prose intro before the Argument Trees section.
+- No callout boxes with historical context or framing.
+- Belief statement → Topic metadata → Argument Trees. That's it. Go straight to the decomposition.
+- If the user explicitly asks for a summary, ask them to clarify why. The answer is almost always "move straight to the arguments."
+
+---
+
+## Rule 3: Arguments Are SHORT LABELS, Not Sentences
+
+Every cell in the Reasons-to-Agree / Reasons-to-Disagree tables is a 2 to 6 word LABEL, not a sentence, not a paragraph, not a claim with evidence attached.
+
+**Why:** The pro/con column header provides context. If the column says "Reasons to Agree with Public Banking," the stance is already implied. Writing "Public banking would reduce the poverty tax on unbanked households because..." re-states the context and then dumps evidence into the wrong place. That turns every cell into a mini-essay, making the page a wall of text instead of a scannable network. ISE only works if each argument is atomic, linkable to its own page, and scannable at a glance.
+
+**How to apply:**
+
+GOOD argument labels:
+
+- "poverty tax on unbanked"
+- "postal infrastructure already exists"
+- "captures political influence"
+- "crowding out private banks"
+- "long-term cost"
+- "spoiler effect"
+- "ballot exhaustion"
+- "voter confusion"
+
+BAD argument labels (too long, re-states context, embeds evidence):
+
+- "Financial exclusion imposes a documented poverty tax on low-income households through check cashing fees, payday loans, and money orders..."
+- "The EITC, which requires earned income, raised single mothers' employment by 6 to 10 percent after the 1993 expansion..."
+- "RCV eliminates the spoiler effect — voters can rank their genuine first choice without wasting their vote on a non-viable candidate"
+
+Test: If the label contains a percentage, a citation, the word "because," or more than one clause, it's wrong. Strip it to the subject.
+
+---
+
+## Rule 4: Arguments Are NOT Evidence
+
+Arguments are logical claims. Evidence is empirical data. They go in DIFFERENT sections and fail differently.
+
+**Why:** Arguments fail logically (wrong reasoning, fallacies, non-sequiturs). Evidence fails empirically (bad data, weak methodology, small sample). Conflating them means a true data point piled into the argument column inflates the score without any logical scrutiny, and a weak argument in the evidence column looks T1 because it's labeled as evidence.
+
+**How to apply:**
+
+- Argument cell: a label naming a reason. No citations, no percentages, no study names.
+- Evidence Ledger row: Tier, Source, Stance, Which-Argument-It-Bears-On, Linkage. Data lives HERE.
+- If a cell in the Argument Tree contains "FDIC data," "Pew research shows," or a number, it's misfiled. Move the data to the Evidence Ledger and keep the label in the argument tree.
+
+---
+
+## Rule 5: No Broken Links. Ever.
+
+Never use `href="#"` placeholder links. Never link to a PBworks or blog page that does not exist. Never link to a canonical term if its canonical page hasn't been created yet.
+
+**Why:** Broken links destroy trust in the whole system. A reader who clicks three dead links will never click another. It is always better to show plain text than a link that goes to 404 or to the same page's top.
+
+**How to apply:**
+
+- If the target page exists: link to it.
+- If the target page doesn't exist yet: use plain text. No `<a href="#">`. No `<a href="">`. Just text.
+- When in doubt about whether a page exists, use plain text. It's safer to miss a link than to publish a broken one.
+- Internal anchor links (`href="#some-id"`) DO NOT WORK on PBworks because PBworks strips custom `id` attributes. Don't use them. Use plain text section labels instead.
+
+---
+
+## Rule 6: Score Columns Stay Empty Until Content Exists
+
+Do not assign scores (Truth, Linkage, Importance, argument score, net score) to cells that don't have actual scored arguments underneath them.
+
+**Why:** Fake scores make the page look populated when it isn't. Readers can't tell which numbers are real and which are placeholders, which destroys the value of the numbers that ARE real. Either a score is grounded in sub-argument scoring or the cell is blank.
+
+**How to apply:**
+
+- Placeholder cells: leave blank or use "[pending]" in italics.
+- Never use "+0" or "-0" as a default. That's a score, not a blank.
+- Never assign a confident-looking score to an argument that has no sub-arguments, no linked evidence, and no linkage evaluation.
+
+---
+
+## Rule 7: Symmetry Between Supporters and Opponents
+
+Every section with "Supporters" and "Opponents" (Values, Interests, Biases, Motivations) must have the same structure, same depth, and same rigor for both sides.
+
+**Why:** Asymmetric treatment is the single most common way debate systems fail at neutrality. If "Advertised vs Actual" appears under Supporters, it must appear under Opponents. If Opponents get three rows of biases, Supporters must get three rows. Any asymmetry signals to the reader that the page is biased.
+
+**How to apply:** Mirror the structure exactly. Both sides get the same table shape, the same number of labeled rows, the same analytical lenses.
+
+---
+
+## Canonical Section Order
+
+1. Belief Statement
+2. Topic metadata (category, magnitude, score)
+3. Argument Trees (Reasons to Agree vs. Reasons to Disagree)
+4. Evidence Ledger (text/data sources table, then visual/video evidence table)
+5. Core Values Conflict (Advertised vs Actual for BOTH sides)
+6. Interests and Motivations (Supporters vs Opponents; Shared vs Conflicting)
+7. Foundational Assumptions (Required to Accept vs Required to Reject)
+8. Objective Criteria
+9. Falsifiability Test
+10. Testable Predictions
+11. Cost-Benefit Analysis (Benefits vs Costs; Short-term vs Long-term)
+12. Resolution (Compromise Solutions vs Primary Obstacles)
+13. Biases (affecting Supporters vs affecting Opponents)
+14. Media Resources
+15. Legal Framework
+16. Belief Mapping (Upstream, Downstream, Similar)
+17. **Definitions and Scoring Concepts (LAST before footer)**
+18. Contribute / footer
+
+---
+
+## Pre-Generation Checklist
+
+Before outputting any ISE belief page, verify:
+
+- [ ] No summary or background section at the top
+- [ ] Definitions section is LAST, not first
+- [ ] Every argument cell is 2-6 words
+- [ ] No citations, percentages, or study names in argument cells
+- [ ] All evidence lives in the Evidence Ledger with tier assigned
+- [ ] Every link points to a page that exists OR is plain text
+- [ ] No `href="#"` anchors anywhere
+- [ ] Both sides have symmetric structure in Values, Interests, Biases
+- [ ] Score cells are blank for unpopulated arguments

--- a/src/app/beliefs/[slug]/page.tsx
+++ b/src/app/beliefs/[slug]/page.tsx
@@ -115,14 +115,14 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
           </div>
         </div>
 
-        {/* All analysis sections */}
+        {/*
+          Section order is CANONICAL per docs/BELIEF_PAGE_RULES.md.
+          Definitions live LAST, never first (Rule 1). No background/summary section
+          between the metadata box and the Argument Trees (Rule 2). Do not reorder
+          without updating the canonical rules doc.
+        */}
         <div className="space-y-12">
-          {/* 0. Definitions */}
-          <DefinitionsSection definitions={belief.definitions} />
-
-          <hr className="border-gray-200" />
-
-          {/* 1. Argument Trees */}
+          {/* 3. Argument Trees */}
           <ArgumentTreesSection
             arguments={belief.arguments}
             totalPro={scores.totalPro}
@@ -131,7 +131,7 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
 
           <hr className="border-gray-200" />
 
-          {/* 2. Evidence */}
+          {/* 4. Evidence Ledger */}
           <EvidenceSection
             evidence={belief.evidence}
             totalSupporting={scores.totalSupportingEvidence}
@@ -140,76 +140,68 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
 
           <hr className="border-gray-200" />
 
-          {/* 3. Objective Criteria */}
-          <ObjectiveCriteriaSection criteria={belief.objectiveCriteria} />
-
-          <hr className="border-gray-200" />
-
-          {/* 3b. Falsifiability Test */}
-          <FalsifiabilitySection falsifiability={belief.falsifiability} />
-
-          {/* 3c. Testable Predictions */}
-          <TestablePredictionsSection predictions={belief.testablePredictions} />
-
-          <hr className="border-gray-200" />
-
-          {/* 4. Core Values Conflict */}
+          {/* 5. Core Values Conflict (Advertised vs Actual for BOTH sides) */}
           <ValuesSection values={belief.valuesAnalysis} />
 
           <hr className="border-gray-200" />
 
-          {/* Conflict Resolution Framework */}
-          <div>
-            <h1 className="text-2xl font-bold text-[var(--foreground)] mb-6">
-              <Link href="/automate%20conflict%20resolution" className="text-[var(--accent)] hover:underline">
-                Conflict Resolution
-              </Link>{' '}
-              Framework
-            </h1>
-
-            <div className="space-y-10">
-              {/* 5. Interests & Motivations */}
-              <InterestsSection interests={belief.interestsAnalysis} />
-
-              {/* 6. Foundational Assumptions */}
-              <AssumptionsSection assumptions={belief.assumptions} />
-
-              {/* 7. Cost-Benefit Analysis */}
-              <CostBenefitSection cba={belief.costBenefitAnalysis} />
-
-              {/* 8. Short vs Long-Term Impacts */}
-              <ImpactSection impact={belief.impactAnalysis} />
-
-              {/* 9. Compromise Solutions */}
-              <CompromisesSection compromises={belief.compromises} />
-
-              {/* 10. Obstacles to Resolution */}
-              <ObstaclesSection obstacles={belief.obstacles} />
-
-              {/* 11. Biases */}
-              <BiasesSection biases={belief.biases} />
-            </div>
-          </div>
+          {/* 6. Interests and Motivations (Supporters vs Opponents; Shared vs Conflicting) */}
+          <InterestsSection interests={belief.interestsAnalysis} />
 
           <hr className="border-gray-200" />
 
-          {/* 12. Media Resources */}
+          {/* 7. Foundational Assumptions */}
+          <AssumptionsSection assumptions={belief.assumptions} />
+
+          <hr className="border-gray-200" />
+
+          {/* 8. Objective Criteria */}
+          <ObjectiveCriteriaSection criteria={belief.objectiveCriteria} />
+
+          <hr className="border-gray-200" />
+
+          {/* 9. Falsifiability Test */}
+          <FalsifiabilitySection falsifiability={belief.falsifiability} />
+
+          <hr className="border-gray-200" />
+
+          {/* 10. Testable Predictions */}
+          <TestablePredictionsSection predictions={belief.testablePredictions} />
+
+          <hr className="border-gray-200" />
+
+          {/* 11. Cost-Benefit Analysis (Benefits vs Costs; Short-term vs Long-term) */}
+          <CostBenefitSection cba={belief.costBenefitAnalysis} />
+          <ImpactSection impact={belief.impactAnalysis} />
+
+          <hr className="border-gray-200" />
+
+          {/* 12. Resolution (Compromise Solutions vs Primary Obstacles) */}
+          <CompromisesSection compromises={belief.compromises} />
+          <ObstaclesSection obstacles={belief.obstacles} />
+
+          <hr className="border-gray-200" />
+
+          {/* 13. Biases (affecting Supporters vs affecting Opponents) */}
+          <BiasesSection biases={belief.biases} />
+
+          <hr className="border-gray-200" />
+
+          {/* 14. Media Resources */}
           <MediaSection media={belief.mediaResources} />
 
           <hr className="border-gray-200" />
 
-          {/* 13. Legal Framework */}
+          {/* 15. Legal Framework */}
           <LegalSection legal={belief.legalEntries} />
 
           <hr className="border-gray-200" />
 
-          {/* 14. General to Specific Belief Mapping */}
+          {/* 16. Belief Mapping (Upstream, Downstream, Similar) */}
           <BeliefMappingSection
             upstreamMappings={belief.upstreamMappings}
             downstreamMappings={belief.downstreamMappings}
           />
-
-          {/* 15. Similar Beliefs */}
           <SimilarBeliefsSection
             similarTo={belief.similarTo}
             similarFrom={belief.similarFrom}
@@ -218,7 +210,12 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
 
           <hr className="border-gray-200" />
 
-          {/* 16. Contribute */}
+          {/* 17. Definitions and Scoring Concepts — LAST before footer (Rule 1) */}
+          <DefinitionsSection definitions={belief.definitions} />
+
+          <hr className="border-gray-200" />
+
+          {/* 18. Contribute / footer */}
           <ContributeSection />
 
           {/* Overall Score */}

--- a/src/features/belief-analysis/components/DefinitionsSection.tsx
+++ b/src/features/belief-analysis/components/DefinitionsSection.tsx
@@ -1,13 +1,31 @@
+import Link from 'next/link'
 import type { DefinitionItem } from '../types'
 
 interface DefinitionsSectionProps {
   definitions: DefinitionItem[]
 }
 
+/**
+ * Per BELIEF_PAGE_RULES.md Rule 1, this section renders LAST — after every
+ * scored analysis section and immediately before the Contribute footer.
+ * Definitions are a footnote for readers who need them, not a tutorial that
+ * pushes the argument network below the fold. Do not move this component
+ * above the Argument Trees.
+ */
 export default function DefinitionsSection({ definitions }: DefinitionsSectionProps) {
   return (
     <section>
-      <h1 className="text-2xl font-bold text-[var(--foreground)] mb-4">📖 Definitions</h1>
+      <h1 className="text-2xl font-bold text-[var(--foreground)] mb-4">
+        📖 Definitions and Scoring Concepts
+      </h1>
+      <p className="text-sm text-[var(--muted-foreground)] mb-4">
+        Terminology used on this page. For full definitions of scoring concepts
+        (<Link href="/truth" className="text-[var(--accent)] hover:underline">Truth</Link>,{' '}
+        <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Linkage</Link>,{' '}
+        <Link href="/Importance%20Score" className="text-[var(--accent)] hover:underline">Importance</Link>,{' '}
+        <Link href="/Evidence" className="text-[var(--accent)] hover:underline">Evidence tiers</Link>),
+        follow the link on each concept's own page.
+      </p>
       <table className="w-full border-collapse text-sm" style={{ borderColor: '#cccccc' }}>
         <thead>
           <tr>
@@ -25,8 +43,9 @@ export default function DefinitionsSection({ definitions }: DefinitionsSectionPr
             ))
           ) : (
             <tr>
-              <td className="border border-gray-300 px-3 py-2 text-[var(--muted-foreground)]">&nbsp;</td>
-              <td className="border border-gray-300 px-3 py-2 text-[var(--muted-foreground)]">&nbsp;</td>
+              <td className="border border-gray-300 px-3 py-2 text-[var(--muted-foreground)] italic" colSpan={2}>
+                No page-specific definitions yet. Contribute to clarify the terms this page uses.
+              </td>
             </tr>
           )}
         </tbody>

--- a/templates/belief-analysis-template.html
+++ b/templates/belief-analysis-template.html
@@ -1,26 +1,34 @@
+<!--
+  ISE Belief Analysis Template (canonical)
+  Section order and placement are governed by docs/BELIEF_PAGE_RULES.md.
+  Do NOT reorder without updating that rulebook.
+  Key invariants:
+    Rule 1: Definitions live LAST (just before Contribute), never first.
+    Rule 2: No Wikipedia-style Background/Summary/Overview section anywhere.
+    Rule 3: Argument cells are 2–6 word labels, not sentences.
+    Rule 4: Evidence and Arguments are in DIFFERENT sections.
+    Rule 5: No href="#" placeholders. Use plain text if the target page does not exist.
+    Rule 6: Score cells are blank until scored sub-arguments exist.
+    Rule 7: Supporters and Opponents get symmetric structure in Values, Interests, Biases.
+-->
 <p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">Belief: [Insert Belief Statement Here]</span></p>
 <p><span style="font-size: 150%;"><strong>Index</strong></span></p>
 <p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;"><img class="pluginslug" src="/plugin_helper.php?plugin=toc&amp;depth=3" alt="" /><br /></span></p>
 <p>&nbsp;</p>
 <div style="background-color: #f9f9f9; padding: 15px; border: 1px solid #ddd; margin-bottom: 20px;"><a href="/One%20Page%20Per%20Topic">Topic</a>: [Category] &gt; [Subcategory] Topic IDs: Dewey: [Number] Belief <a href="/beliefs%20grouped%20and%20eventually%20sorted%20along%20the%20the%20positivity%20continuum">Positivity</a> Towards Topic: <strong>[Scale -100% to +100%]</strong> Each section builds a complete analysis from multiple angles. <a href="https://github.com/myklob/ideastockexchange">View the full technical documentation on GitHub</a>.</div>
-<h1>📖 Definitions</h1>
-<table style="border-color: #cccccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr>
-<th style="text-align: center;" width="30%">Term</th><th style="text-align: center;" width="70%">Definition Used in This Analysis</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>&nbsp;<br /></td>
-<td>&nbsp;<br /></td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<!--
+  Rule 2: No Background / Summary / Context / Overview section here.
+  Go straight from metadata to the Argument Trees decomposition.
+-->
 <h1>🔍 <a href="/Reasons">Argument Trees</a></h1>
 <p>Each reason is a belief with its own page. Scoring is recursive based on <a href="/truth">truth</a>, <a href="/Linkage%20Scores">linkage</a>, and <a href="/Importance%20Score">importance</a>.</p>
+<!--
+  Rule 3: Each cell in the Reasons columns below must be a 2–6 word LABEL
+  (e.g., "poverty tax on unbanked", "captures political influence"). No
+  sentences, no percentages, no citations. Evidence lives in the Evidence
+  Ledger, not here (Rule 4). Leave score cells blank until sub-arguments
+  exist (Rule 6).
+-->
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #e6ffe6;">
@@ -90,8 +98,13 @@
 </table>
 <p>&nbsp;</p>
 <p>&nbsp;</p>
-<h1>🔬 <a href="/Evidence">Evidence</a></h1>
+<h1>🔬 <a href="/Evidence">Evidence Ledger</a></h1>
 <p><em>Key: <strong>T1</strong>=Peer-reviewed/Official, <strong>T2</strong>=Expert/Institutional, <strong>T3</strong>=Journalism/Surveys, <strong>T4</strong>=Opinion/Anecdote</em></p>
+<!--
+  Rule 4: Evidence is empirical data, not logical arguments. Each row records
+  Tier, Source, Stance, Which-Argument-It-Bears-On, and Linkage. If a row reads
+  like an argument label, it belongs in the Argument Trees, not here.
+-->
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #e6ffe6;">
@@ -169,6 +182,95 @@
 </table>
 <p>&nbsp;</p>
 <p>&nbsp;</p>
+<h2>⚖️&nbsp;<a href="/American%20values">Core Values Conflict</a></h2>
+<!--
+  Rule 7: Symmetry. Both columns MUST use the same structure — Advertised and
+  Actual rows for BOTH Supporters and Opponents. Do not give one side extra
+  analytical lenses.
+-->
+<table style="border-color: #cccccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr>
+<th width="50%">
+<p>Supporting Values</p>
+</th><th width="50%">
+<p>Opposing Values</p>
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>Advertised:</strong><br />1.<br /><br /><strong>Actual:</strong><br />1.</td>
+<td valign="top"><strong>Advertised:</strong><br />1.<br /><br /><strong>Actual:</strong><br />1.</td>
+</tr>
+</tbody>
+</table>
+<p>(What supporters claim vs. what actually motivates them)</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<h2>💡 <a href="/Interests">Interests &amp; Motivations</a></h2>
+<!--
+  Rule 7: Symmetry. Supporters and Opponents columns must mirror each other
+  in depth and structure.
+-->
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f0f0;">
+<th width="50%">
+<p style="text-align: center;">Supporters</p>
+</th> <th width="50%">
+<p style="text-align: center;">Opponents</p>
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">1.<br />2.<br />3.</td>
+<td valign="top">1.<br />2.<br />3.</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<h3><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 17px; font-weight: bold;">🔗 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 17px; font-weight: bold;" href="/Interests">Shared and Conflicting Interests</a></h3>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #e6f3ff;">
+<th style="text-align: center;" width="50%">
+<p>Shared Interests</p>
+</th> <th style="text-align: center;" width="50%">
+<p>Conflicting Interests</p>
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">1.<br />2.</td>
+<td valign="top">1.<br />2.</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📜 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/Assumptions">Foundational Assumptions</a></p>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f0f0;">
+<th style="text-align: center;" width="50%">
+<p>Required to Accept This Belief</p>
+</th> <th style="text-align: center;" width="50%">
+<p>Required to Reject This Belief</p>
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">1.<br />2.</td>
+<td valign="top">1.<br />2.</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
 <p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 17px; font-weight: bold;">📏 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 17px; font-weight: bold;" href="/Objective%20criteria%20scores">Best Objective Criteria</a></p>
 <p><em>For Measuring the Strength of this Belief</em></p>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
@@ -226,88 +328,6 @@
 </table>
 <p>&nbsp;</p>
 <p>&nbsp;</p>
-<h1><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/automate%20conflict%20resolution">Conflict Resolution</a><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;"> Framework</span></h1>
-<h2>💡 <a href="/Interests">Interest &amp; Motivations</a></h2>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #f0f0f0;">
-<th width="50%">
-<p style="text-align: center;">Supporters</p>
-</th> <th width="50%">
-<p style="text-align: center;">Opponents</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top">1.<br />2.<br />3.</td>
-<td valign="top">1.<br />2.<br />3.</td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<h2>⚖️&nbsp;<a href="/American%20values">Core Values Conflict</a></h2>
-<table style="border-color: #cccccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr>
-<th width="50%">
-<p>Supporting Values</p>
-</th><th width="50%">
-<p>Opposing Values</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top"><strong>Advertised:</strong><br />1.<br /><br /><strong>Actual:</strong><br />1.</td>
-<td valign="top"><strong>Advertised:</strong><br />1.<br /><br /><strong>Actual:</strong><br />1.</td>
-</tr>
-</tbody>
-</table>
-<p>(What supporters claim vs. what actually motivates them)</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<h2><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 17px; font-weight: bold;">🔗 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 17px; font-weight: bold;" href="/Interests">Shared and Conflicting Interests</a></h2>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #e6f3ff;">
-<th style="text-align: center;" width="50%">
-<p>Shared Interests</p>
-</th> <th style="text-align: center;" width="50%">
-<p>Conflicting Interests</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top">1.<br />2.</td>
-<td valign="top">1.<br />2.</td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
-&nbsp;
-<p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📜 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/Assumptions">Foundational Assumptions</a></p>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #f0f0f0;">
-<th style="text-align: center;" width="50%">
-<p>Required to Accept This Belief</p>
-</th> <th style="text-align: center;" width="50%">
-<p>Required to Reject This Belief</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top">1.<br />2.</td>
-<td valign="top">1.<br />2.</td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
 <h1><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📉 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/cost-benefit%20analysis">Cost-Benefit Analysis</a></h1>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
@@ -333,7 +353,6 @@
 </tbody>
 </table>
 <p>&nbsp;</p>
-&nbsp;
 <h2><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🎯 Short vs. Long-Term Impacts</span></h2>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
@@ -354,7 +373,8 @@
 </table>
 <p>&nbsp;</p>
 <p>&nbsp;</p>
-<h2>&nbsp;&nbsp;<span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🤝 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/Compromise">Best Compromise Solutions</a></h2>
+<h1><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/automate%20conflict%20resolution">Resolution</a></h1>
+<h2>🤝 <a href="/Compromise">Best Compromise Solutions</a></h2>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #e6f3ff;">
@@ -370,8 +390,7 @@
 </tbody>
 </table>
 <p>&nbsp;</p>
-<p>&nbsp;</p>
-<p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🚧 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/Obstacles%20to%20Resolution">Primary Obstacles to Resolution</a></p>
+<h2>🚧 <a href="/Obstacles%20to%20Resolution">Primary Obstacles to Resolution</a></h2>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #fff0f0;">
@@ -392,6 +411,10 @@
 <p>&nbsp;</p>
 <p>&nbsp;</p>
 <p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🧠 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/bias">Biases</a></p>
+<!--
+  Rule 7: Symmetry. Both columns MUST list the same number of biases with
+  comparable analytical rigor.
+-->
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #f0f0f0;">
@@ -450,7 +473,6 @@
 </tbody>
 </table>
 <p>&nbsp;</p>
-&nbsp;
 <h1>🧭 <a href="/Belief%20Sorting">General to Specific Belief Mapping</a></h1>
 <h3>🔹 Most General (Upstream)</h3>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
@@ -490,7 +512,6 @@
 </tbody>
 </table>
 <p>&nbsp;</p>
-<p>&nbsp;</p>
 <p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🔄 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/combine%20similar%20beliefs">Similar Beliefs</a></p>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
@@ -506,6 +527,28 @@
 <tr>
 <td valign="top">1.<br />2.</td>
 <td valign="top">1.<br />2.</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<!--
+  Rule 1: Definitions and Scoring Concepts render LAST, just before Contribute.
+  Readers come for the scored argument network; definitions are a footnote,
+  not a tutorial. Do not move this section above the Argument Trees.
+-->
+<h1>📖 Definitions and Scoring Concepts</h1>
+<p>Terminology used on this page. For the canonical explanations of scoring concepts (<a href="/truth">Truth</a>, <a href="/Linkage%20Scores">Linkage</a>, <a href="/Importance%20Score">Importance</a>, <a href="/Evidence">Evidence tiers</a>), follow the link on each concept's own page.</p>
+<table style="border-color: #cccccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr>
+<th style="text-align: center;" width="30%">Term</th><th style="text-align: center;" width="70%">Definition Used in This Analysis</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>&nbsp;<br /></td>
+<td>&nbsp;<br /></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
## Summary

Established and enforced a canonical section ordering for belief analysis pages by creating a formal rulebook (`docs/BELIEF_PAGE_RULES.md`) and refactoring the page layout to comply with it. The most significant change is moving the Definitions section from the top of the page to the end, immediately before the Contribute footer.

## Key Changes

- **Created `docs/BELIEF_PAGE_RULES.md`**: A comprehensive rulebook governing belief page structure with 7 core rules:
  - Rule 1: Definitions go at the BACK (not top)
  - Rule 2: No Wikipedia-style Background/Summary sections
  - Rule 3: Argument cells are 2–6 word labels, not sentences
  - Rule 4: Arguments and Evidence are in DIFFERENT sections
  - Rule 5: No broken links (`href="#"` placeholders forbidden)
  - Rule 6: Score cells stay empty until content exists
  - Rule 7: Symmetric structure for Supporters vs Opponents

- **Reorganized `src/app/beliefs/[slug]/page.tsx`**:
  - Moved `DefinitionsSection` from position 0 to position 17 (last before footer)
  - Reordered all analysis sections to match the canonical order (Argument Trees → Evidence → Values → Interests → Assumptions → Criteria → Falsifiability → Predictions → CBA → Resolution → Biases → Media → Legal → Belief Mapping → Definitions → Contribute)
  - Removed the "Conflict Resolution Framework" wrapper div that was grouping sections 5–11
  - Added detailed comments documenting the canonical section order per the rulebook

- **Updated `templates/belief-analysis-template.html`**:
  - Added HTML comments at the top documenting the 7 rules and section order invariants
  - Moved Definitions table from top to bottom (before Contribute)
  - Renamed "Evidence" section to "Evidence Ledger" for clarity
  - Reordered all sections to match canonical order
  - Added inline comments explaining Rules 2, 3, 4, and 7 at relevant sections
  - Restructured the "Conflict Resolution Framework" heading to be a simpler "Resolution" h1

- **Enhanced `src/features/belief-analysis/components/DefinitionsSection.tsx`**:
  - Added JSDoc comment explaining Rule 1 and why definitions render last
  - Updated heading to "📖 Definitions and Scoring Concepts"
  - Added explanatory paragraph with links to canonical scoring concept pages (Truth, Linkage, Importance, Evidence tiers)
  - Improved empty state message to encourage contribution

## Notable Implementation Details

- The canonical section order is now documented in a single source of truth (`docs/BELIEF_PAGE_RULES.md`) that is referenced by code comments in both the React component and the HTML template
- All 7 rules include explicit "Why" and "How to apply" sections to prevent future violations
- The refactoring preserves all existing content and functionality; it only changes the order and adds documentation
- The rulebook includes a pre-generation checklist for future belief page creation

https://claude.ai/code/session_016cH17FktfWcnVw3yYVYUrC