### PR TITLE
Restructure belief pages to canonical template with structured analysis tables

### DIFF
--- a/docs/BELIEF_PAGE_RULES.md
+++ b/docs/BELIEF_PAGE_RULES.md
@@ -139,23 +139,36 @@ Every section with "Supporters" and "Opponents" (Values, Interests, Biases, Moti
 ## Canonical Section Order
 
 1. Belief Statement
-2. Topic metadata (category, magnitude, score)
-3. Argument Trees (Reasons to Agree vs. Reasons to Disagree)
-4. Evidence Ledger (text/data sources table, then visual/video evidence table)
-5. Core Values Conflict (Advertised vs Actual for BOTH sides)
-6. Interests and Motivations (Supporters vs Opponents; Shared vs Conflicting)
-7. Foundational Assumptions (Required to Accept vs Required to Reject)
-8. Objective Criteria
-9. Falsifiability Test
-10. Testable Predictions
-11. Cost-Benefit Analysis (Benefits vs Costs; Short-term vs Long-term)
-12. Resolution (Compromise Solutions vs Primary Obstacles)
-13. Biases (affecting Supporters vs affecting Opponents)
-14. Media Resources
-15. Legal Framework
-16. Belief Mapping (Upstream, Downstream, Similar)
-17. **Definitions and Scoring Concepts (LAST before footer)**
-18. Contribute / footer
+2. Score + Topic line (Score: pro/con from sub-arguments | Topic: Category > Subcategory)
+3. Argument Trees (Reasons to Agree vs. Reasons to Disagree — labels only)
+4. Evidence Ledger
+   - 4a. Text and Data Sources (Tier / Source / Stance / Argument It Bears On / Linkage)
+   - 4b. Visual and Video Evidence (Type / Description / Stance / Source / Tier / Argument It Bears On / Linkage)
+5. Values Conflict Analysis
+   - 5a. Value Priority Rankings (Value / Supporters' Rank / Opponents' Rank / Gap / Self-Reported % / Confidence / Source)
+   - 5b. Shared Values, Different Priorities (Shared Value / Supporters' Priority Context / Opponents' Priority Context)
+   - 5c. Cross-Context Consistency Check (Value / Deprioritized By / Other Topic Where They Champion It / What This Suggests)
+   - 5d. Advertised vs. Actual Motivation (symmetric Supporters/Opponents)
+6. Interests and Motivations
+   - 6a. Interest Priority Rankings (same column shape as Values)
+   - 6b. Shared vs. Conflicting Interests (with "Why the Conflict Exists")
+   - 6c. How Interests Drive Value Rankings (Interest at Stake / Side / Value Elevated / Value Deprioritized / Confidence)
+7. Foundational Assumptions (Required to Accept vs. Required to Reject)
+8. Objective Criteria (Criterion / Current Status / Threshold for Agreement)
+9. Cost-Benefit Analysis (Benefits vs. Costs, then Short-Term vs. Long-Term)
+10. Resolution
+    - 10a. Best Compromise Solutions vs. Primary Obstacles
+    - 10b. Biases (Affecting Supporters vs. Affecting Opponents)
+11. Belief Mapping (Upstream / Downstream / Similar)
+12. Legal Framework (Supporting Laws vs. Contradicting Laws)
+13. **Definitions and Scoring Concepts (LAST before footer)**
+14. Contribute / footer
+
+**Removed from canonical order (intentionally):** Falsifiability Test, Testable
+Predictions, and Media Resources are no longer top-level sections. Falsifiability
+is implicit in the Objective Criteria thresholds. Testable Predictions, when
+relevant, render as objective criteria. Media items move into Visual and Video
+Evidence under the Evidence Ledger, paired with the argument they bear on.
 
 ---
 
@@ -168,6 +181,10 @@ Before outputting any ISE belief page, verify:
 - [ ] Every argument cell is 2-6 words
 - [ ] No citations, percentages, or study names in argument cells
 - [ ] All evidence lives in the Evidence Ledger with tier assigned
+- [ ] Visual/video items live in the Visual and Video Evidence sub-table, not in a separate Media section
+- [ ] Values section has all four sub-tables: Priority Rankings, Shared Values, Cross-Context, Advertised vs. Actual
+- [ ] Interests section has all three sub-tables: Priority Rankings, Shared vs. Conflicting (with Why), Interest -> Value Linkage
+- [ ] Resolution section bundles Compromise/Obstacles AND Biases together
 - [ ] Every link points to a page that exists OR is plain text
 - [ ] No `href="#"` anchors anywhere
 - [ ] Both sides have symmetric structure in Values, Interests, Biases

--- a/src/app/beliefs/[slug]/page.tsx
+++ b/src/app/beliefs/[slug]/page.tsx
@@ -8,19 +8,14 @@ import ValuesSection from '@/features/belief-analysis/components/ValuesSection'
 import InterestsSection from '@/features/belief-analysis/components/InterestsSection'
 import AssumptionsSection from '@/features/belief-analysis/components/AssumptionsSection'
 import CostBenefitSection from '@/features/belief-analysis/components/CostBenefitSection'
-import ImpactSection from '@/features/belief-analysis/components/ImpactSection'
 import CompromisesSection from '@/features/belief-analysis/components/CompromisesSection'
 import ObstaclesSection from '@/features/belief-analysis/components/ObstaclesSection'
 import BiasesSection from '@/features/belief-analysis/components/BiasesSection'
-import MediaSection from '@/features/belief-analysis/components/MediaSection'
 import LegalSection from '@/features/belief-analysis/components/LegalSection'
 import BeliefMappingSection from '@/features/belief-analysis/components/BeliefMappingSection'
 import SimilarBeliefsSection from '@/features/belief-analysis/components/SimilarBeliefsSection'
 import ContributeSection from '@/features/belief-analysis/components/ContributeSection'
-import StrengthSpectrumBar, { TwoAxisCoordinate } from '@/components/StrengthSpectrumBar'
 import DefinitionsSection from '@/features/belief-analysis/components/DefinitionsSection'
-import FalsifiabilitySection from '@/features/belief-analysis/components/FalsifiabilitySection'
-import TestablePredictionsSection from '@/features/belief-analysis/components/TestablePredictionsSection'
 
 interface BeliefPageProps {
   params: Promise<{ slug: string }>
@@ -35,6 +30,8 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
   }
 
   const scores = computeBeliefScores(belief)
+  const proPart = scores.totalPro.toFixed(1)
+  const conPart = scores.totalCon.toFixed(1)
 
   return (
     <div className="min-h-screen bg-white">
@@ -58,71 +55,48 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
       </nav>
 
       <main className="max-w-[960px] mx-auto px-4 py-8">
-        {/* Header */}
-        <h1 className="text-2xl font-bold text-[var(--foreground)] mb-4 leading-tight">
-          Belief: {belief.statement}
+        {/*
+          Header per the canonical template (docs/BELIEF_PAGE_RULES.md):
+            - Belief statement
+            - Score (pro/con from sub-arguments) + Topic line
+            - Then straight to Argument Trees. NO summary/background/hook (Rule 2).
+        */}
+        <h1 className="text-2xl font-bold text-[var(--foreground)] mb-3 leading-tight">
+          {belief.statement}
         </h1>
-
-        {/* Meta info box */}
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-8">
-          <div className="text-right space-y-1">
-            <p className="text-sm">
-              <Link href="/One%20Page%20Per%20Topic" className="text-[var(--accent)] hover:underline">Topic</Link>:{' '}
-              {belief.category || 'Uncategorized'}
-              {belief.subcategory && <> &gt; {belief.subcategory}</>}
-            </p>
-            {belief.deweyNumber && (
-              <p className="text-sm">Topic IDs: Dewey: {belief.deweyNumber}</p>
-            )}
-            <p className="text-sm">
-              Belief{' '}
-              <Link href="/beliefs%20grouped%20and%20eventually%20sorted%20along%20the%20the%20positivity%20continuum" className="text-[var(--accent)] hover:underline">
-                Positivity
-              </Link>{' '}
-              Towards Topic: <strong>{belief.positivity >= 0 ? '+' : ''}{belief.positivity.toFixed(0)}%</strong>
-            </p>
-            <div className="mt-2">
-              <p className="text-sm mb-1">
-                <Link href="/algorithms/strong-to-weak" className="text-[var(--accent)] hover:underline">
-                  Claim Strength
-                </Link>{' '}
-                on the Strong-to-Weak Spectrum:
-              </p>
-              <StrengthSpectrumBar
-                claimStrength={belief.claimStrength}
-                rawScore={scores.importanceWeightedScore}
-                showAdjusted={true}
-                showDetails={true}
-              />
-            </div>
-            <div className="mt-2">
-              <TwoAxisCoordinate
-                positivity={belief.positivity}
-                claimStrength={belief.claimStrength}
-              />
-            </div>
-            <p className="text-xs text-[var(--muted-foreground)] mt-2">
-              Each section builds a complete analysis from multiple angles.{' '}
-              <a
-                href="https://github.com/myklob/ideastockexchange"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-[var(--accent)] hover:underline"
-              >
-                View the full technical documentation on GitHub
-              </a>.
-            </p>
-          </div>
-        </div>
+        <p className="text-sm mb-8 leading-7">
+          <strong>Score:</strong>{' '}
+          <Link
+            href="/Argument%20scores%20from%20sub-argument%20scores"
+            className="text-[var(--accent)] hover:underline"
+          >
+            +{proPart} pro / -{conPart} con
+          </Link>{' '}
+          <span className="text-xs text-[var(--muted-foreground)]">
+            (computed from sub-argument scores)
+          </span>
+          <br />
+          <strong>Topic:</strong>{' '}
+          <Link href="/One%20Page%20Per%20Topic" className="text-[var(--accent)] hover:underline">
+            {belief.category || 'Uncategorized'}
+          </Link>
+          {belief.subcategory && <> &gt; {belief.subcategory}</>}
+        </p>
 
         {/*
           Section order is CANONICAL per docs/BELIEF_PAGE_RULES.md.
           Definitions live LAST, never first (Rule 1). No background/summary section
-          between the metadata box and the Argument Trees (Rule 2). Do not reorder
+          between the metadata and the Argument Trees (Rule 2). Do not reorder
           without updating the canonical rules doc.
+
+          Removed (intentionally) from the page per the new template:
+            - Standalone Falsifiability Test section (folded into Objective Criteria thresholds)
+            - Standalone Testable Predictions section (express predictions as objective criteria)
+            - Standalone Media Resources section (visual/video items live in the Evidence Ledger)
+            - Standalone Short vs. Long-Term Impact section (now a sub-table inside CBA)
         */}
         <div className="space-y-12">
-          {/* 3. Argument Trees */}
+          {/* 1. Argument Trees */}
           <ArgumentTreesSection
             arguments={belief.arguments}
             totalPro={scores.totalPro}
@@ -131,73 +105,51 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
 
           <hr className="border-gray-200" />
 
-          {/* 4. Evidence Ledger */}
+          {/* 2. Evidence Ledger (text/data + visual/video) */}
           <EvidenceSection
             evidence={belief.evidence}
             totalSupporting={scores.totalSupportingEvidence}
             totalWeakening={scores.totalWeakeningEvidence}
+            media={belief.mediaResources}
           />
 
           <hr className="border-gray-200" />
 
-          {/* 5. Core Values Conflict (Advertised vs Actual for BOTH sides) */}
+          {/* 3. Values Conflict Analysis (4 sub-tables) */}
           <ValuesSection values={belief.valuesAnalysis} />
 
           <hr className="border-gray-200" />
 
-          {/* 6. Interests and Motivations (Supporters vs Opponents; Shared vs Conflicting) */}
+          {/* 4. Interests and Motivations (3 sub-tables) */}
           <InterestsSection interests={belief.interestsAnalysis} />
 
           <hr className="border-gray-200" />
 
-          {/* 7. Foundational Assumptions */}
+          {/* 5. Foundational Assumptions */}
           <AssumptionsSection assumptions={belief.assumptions} />
 
           <hr className="border-gray-200" />
 
-          {/* 8. Objective Criteria */}
+          {/* 6. Objective Criteria (Criterion / Current Status / Threshold for Agreement) */}
           <ObjectiveCriteriaSection criteria={belief.objectiveCriteria} />
 
           <hr className="border-gray-200" />
 
-          {/* 9. Falsifiability Test */}
-          <FalsifiabilitySection falsifiability={belief.falsifiability} />
+          {/* 7. Cost-Benefit Analysis (Benefits/Costs + Short-Term vs Long-Term sub-table) */}
+          <CostBenefitSection cba={belief.costBenefitAnalysis} impact={belief.impactAnalysis} />
 
           <hr className="border-gray-200" />
 
-          {/* 10. Testable Predictions */}
-          <TestablePredictionsSection predictions={belief.testablePredictions} />
+          {/* 8. Resolution: Compromise + Obstacles, then Biases */}
+          <section className="space-y-8">
+            <CompromisesSection compromises={belief.compromises} />
+            <ObstaclesSection obstacles={belief.obstacles} />
+            <BiasesSection biases={belief.biases} />
+          </section>
 
           <hr className="border-gray-200" />
 
-          {/* 11. Cost-Benefit Analysis (Benefits vs Costs; Short-term vs Long-term) */}
-          <CostBenefitSection cba={belief.costBenefitAnalysis} />
-          <ImpactSection impact={belief.impactAnalysis} />
-
-          <hr className="border-gray-200" />
-
-          {/* 12. Resolution (Compromise Solutions vs Primary Obstacles) */}
-          <CompromisesSection compromises={belief.compromises} />
-          <ObstaclesSection obstacles={belief.obstacles} />
-
-          <hr className="border-gray-200" />
-
-          {/* 13. Biases (affecting Supporters vs affecting Opponents) */}
-          <BiasesSection biases={belief.biases} />
-
-          <hr className="border-gray-200" />
-
-          {/* 14. Media Resources */}
-          <MediaSection media={belief.mediaResources} />
-
-          <hr className="border-gray-200" />
-
-          {/* 15. Legal Framework */}
-          <LegalSection legal={belief.legalEntries} />
-
-          <hr className="border-gray-200" />
-
-          {/* 16. Belief Mapping (Upstream, Downstream, Similar) */}
+          {/* 9. Belief Mapping (Upstream / Downstream / Similar) */}
           <BeliefMappingSection
             upstreamMappings={belief.upstreamMappings}
             downstreamMappings={belief.downstreamMappings}
@@ -210,46 +162,18 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
 
           <hr className="border-gray-200" />
 
-          {/* 17. Definitions and Scoring Concepts — LAST before footer (Rule 1) */}
+          {/* 10. Legal Framework */}
+          <LegalSection legal={belief.legalEntries} />
+
+          <hr className="border-gray-200" />
+
+          {/* 11. Definitions and Scoring Concepts — LAST before footer (Rule 1) */}
           <DefinitionsSection definitions={belief.definitions} />
 
           <hr className="border-gray-200" />
 
-          {/* 18. Contribute / footer */}
+          {/* 12. Contribute / footer */}
           <ContributeSection />
-
-          {/* Overall Score */}
-          <div className="text-right space-y-1">
-            <p className="text-lg font-bold">
-              Score:{' '}
-              <Link
-                href="/Argument%20scores%20from%20sub-argument%20scores"
-                className="text-[var(--accent)] hover:underline"
-              >
-                {scores.overallScore >= 0 ? '+' : ''}{scores.overallScore.toFixed(1)}
-              </Link>
-              {' '}
-              <span className="text-sm font-normal text-[var(--muted-foreground)]">
-                (based on argument scores)
-              </span>
-            </p>
-            <p className="text-sm text-[var(--muted-foreground)]">
-              Strength-adjusted score:{' '}
-              <Link
-                href="/algorithms/strong-to-weak"
-                className="font-semibold text-[var(--accent)] hover:underline"
-              >
-                {(scores.strengthAdjustedScore * 100).toFixed(1)}%
-              </Link>
-              {' '}
-              <span className="text-xs">
-                (applies {Math.round((1 - 0.75 * belief.claimStrength) * 100)}% burden-of-proof factor for{' '}
-                {belief.claimStrength <= 0.3 ? 'Weak' :
-                 belief.claimStrength <= 0.65 ? 'Moderate' :
-                 belief.claimStrength <= 0.9 ? 'Strong' : 'Extreme'} claim)
-              </span>
-            </p>
-          </div>
         </div>
       </main>
     </div>

--- a/src/features/belief-analysis/components/CostBenefitSection.tsx
+++ b/src/features/belief-analysis/components/CostBenefitSection.tsx
@@ -1,9 +1,14 @@
 import Link from 'next/link'
-import type { CostBenefitData } from '../types'
+import type { CostBenefitData, ImpactData } from '../types'
 import SectionHeading from './SectionHeading'
 
 interface CostBenefitSectionProps {
   cba: CostBenefitData | null
+  /**
+   * Short vs. long-term impacts now render as a sub-table inside the CBA section
+   * rather than a separate top-level section, per the new canonical template.
+   */
+  impact?: ImpactData | null
 }
 
 function renderLines(text: string | null): React.ReactNode {
@@ -13,12 +18,12 @@ function renderLines(text: string | null): React.ReactNode {
   ))
 }
 
-function formatLikelihood(value: number | null): string {
-  if (value === null) return '-'
+function formatLikelihood(value: number | null | undefined): string {
+  if (value == null) return ''
   return `${(value * 100).toFixed(0)}%`
 }
 
-export default function CostBenefitSection({ cba }: CostBenefitSectionProps) {
+export default function CostBenefitSection({ cba, impact }: CostBenefitSectionProps) {
   return (
     <section>
       <SectionHeading
@@ -27,31 +32,81 @@ export default function CostBenefitSection({ cba }: CostBenefitSectionProps) {
         href="/cost-benefit%20analysis"
       />
 
-      <div className="overflow-x-auto">
+      <div className="mb-6 overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr>
-              <th className="px-3 py-2 text-left w-[40%] font-semibold bg-green-50">Potential Benefits</th>
-              <th className="px-3 py-2 text-center w-[10%] font-semibold bg-green-50">
-                <Link href="/Likelihood" className="text-[var(--accent)] hover:underline">Likelihood</Link>
+              <th className="px-3 py-2 text-left w-1/2 font-semibold bg-green-50">
+                🔔 Potential Benefits
               </th>
-              <th className="px-3 py-2 text-left w-[40%] font-semibold bg-red-50">Potential Costs</th>
-              <th className="px-3 py-2 text-center w-[10%] font-semibold bg-red-50">Likelihood</th>
+              <th className="px-3 py-2 text-left w-1/2 font-semibold bg-red-50">
+                🔘 Potential Costs
+              </th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td className="px-3 py-3 align-top text-sm">{renderLines(cba?.benefits ?? null)}</td>
-              <td className="px-3 py-3 align-top text-center text-sm font-mono">
-                {formatLikelihood(cba?.benefitLikelihood ?? null)}
+              <td className="px-3 py-3 align-top text-sm">
+                {renderLines(cba?.benefits ?? null)}
+                {cba?.benefitLikelihood != null && (
+                  <p className="text-xs text-[var(--muted-foreground)] mt-2">
+                    <Link href="/Likelihood" className="text-[var(--accent)] hover:underline">
+                      Likelihood
+                    </Link>
+                    : <span className="font-mono">{formatLikelihood(cba.benefitLikelihood)}</span>
+                  </p>
+                )}
               </td>
-              <td className="px-3 py-3 align-top text-sm">{renderLines(cba?.costs ?? null)}</td>
-              <td className="px-3 py-3 align-top text-center text-sm font-mono">
-                {formatLikelihood(cba?.costLikelihood ?? null)}
+              <td className="px-3 py-3 align-top text-sm">
+                {renderLines(cba?.costs ?? null)}
+                {cba?.costLikelihood != null && (
+                  <p className="text-xs text-[var(--muted-foreground)] mt-2">
+                    Likelihood: <span className="font-mono">{formatLikelihood(cba.costLikelihood)}</span>
+                  </p>
+                )}
               </td>
             </tr>
           </tbody>
         </table>
+      </div>
+
+      {/* Short vs. Long-Term sub-table (was separate ImpactSection) */}
+      <div>
+        <h3 className="text-base font-semibold mb-2 flex items-center gap-2">
+          <span>🎯</span> Short vs. Long-Term
+        </h3>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="px-3 py-2 text-left w-1/2 font-semibold">Short-Term (0-2 years)</th>
+                <th className="px-3 py-2 text-left w-1/2 font-semibold">Long-Term (5+ years)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-gray-200">
+                <td className="px-3 py-3 align-top text-sm">
+                  <strong>Immediate effects:</strong><br />
+                  {renderLines(impact?.shortTermEffects ?? null)}
+                </td>
+                <td className="px-3 py-3 align-top text-sm">
+                  <strong>Sustained effects:</strong><br />
+                  {renderLines(impact?.longTermEffects ?? null)}
+                </td>
+              </tr>
+              <tr>
+                <td className="px-3 py-3 align-top text-sm">
+                  <strong>Transition costs:</strong><br />
+                  {renderLines(impact?.shortTermCosts ?? null)}
+                </td>
+                <td className="px-3 py-3 align-top text-sm">
+                  <strong>Structural changes:</strong><br />
+                  {renderLines(impact?.longTermChanges ?? null)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </section>
   )

--- a/src/features/belief-analysis/components/EvidenceSection.tsx
+++ b/src/features/belief-analysis/components/EvidenceSection.tsx
@@ -1,77 +1,90 @@
 import Link from 'next/link'
-import type { EvidenceItem } from '../types'
+import type { EvidenceItem, MediaItem } from '../types'
 import SectionHeading from './SectionHeading'
 
 interface EvidenceSectionProps {
   evidence: EvidenceItem[]
   totalSupporting: number
   totalWeakening: number
+  /**
+   * Media items render in the Visual and Video Evidence sub-table per the new
+   * canonical template — they are evidence, tiered by underlying source. The
+   * separate Media Resources section is gone.
+   */
+  media?: MediaItem[]
 }
 
-function tierLabel(type: string): string {
-  switch (type) {
-    case 'T1': return 'T1'
-    case 'T2': return 'T2'
-    case 'T3': return 'T3'
-    case 'T4': return 'T4'
-    default: return type
+function tierBadge(type: string): React.ReactNode {
+  const styles: Record<string, string> = {
+    T1: 'bg-green-100 text-green-800',
+    T2: 'bg-blue-100 text-blue-800',
+    T3: 'bg-yellow-100 text-yellow-800',
+    T4: 'bg-red-100 text-red-800',
   }
-}
-
-function tierStyle(type: string): string {
-  switch (type) {
-    case 'T1': return 'bg-green-100 text-green-800'
-    case 'T2': return 'bg-blue-100 text-blue-800'
-    case 'T3': return 'bg-yellow-100 text-yellow-800'
-    case 'T4': return 'bg-red-100 text-red-800'
-    default: return 'bg-gray-100 text-gray-800'
-  }
-}
-
-function EvidenceRow({ item }: { item: EvidenceItem }) {
-  const evScore = (item.sourceIndependenceWeight * Math.log2(item.replicationQuantity + 1) *
-    item.conclusionRelevance * item.replicationPercentage).toFixed(2)
-  const linkage = (item.linkageScore * 100).toFixed(0)
-  const impact = item.impactScore.toFixed(1)
-
+  const label = ['T1', 'T2', 'T3', 'T4'].includes(type) ? type : 'T?'
+  const color = styles[label] ?? 'bg-gray-100 text-gray-800'
   return (
-    <tr className="border-b border-gray-200 hover:bg-gray-50 transition-colors">
-      <td className="px-3 py-3 text-sm">
-        {item.sourceUrl ? (
-          <a href={item.sourceUrl} target="_blank" rel="noopener noreferrer" className="text-[var(--accent)] hover:underline">
-            {item.description}
-          </a>
-        ) : (
-          item.description
-        )}
-      </td>
-      <td className="px-3 py-3 text-center text-sm font-mono">{evScore}</td>
-      <td className="px-3 py-3 text-center text-sm font-mono">{linkage}%</td>
-      <td className="px-3 py-3 text-center">
-        <span className={`text-xs font-bold px-2 py-0.5 rounded ${tierStyle(item.evidenceType)}`}>
-          {tierLabel(item.evidenceType)}
-        </span>
-      </td>
-      <td className="px-3 py-3 text-center text-sm font-bold font-mono">
-        {item.side === 'supporting' ? '+' : '-'}{Math.abs(Number(impact))}
-      </td>
-    </tr>
+    <span className={`inline-block text-xs font-bold px-2 py-0.5 rounded ${color}`}>
+      {label}
+    </span>
   )
 }
 
-function EmptyRow() {
-  return (
-    <tr className="border-b border-gray-200">
-      <td className="px-3 py-3 text-sm text-[var(--muted-foreground)] italic" colSpan={5}>
-        No evidence submitted yet.
-      </td>
-    </tr>
-  )
+function stanceLabel(side: string): string {
+  if (side === 'supporting') return 'Supports'
+  if (side === 'weakening') return 'Weakens'
+  return side
 }
 
-export default function EvidenceSection({ evidence, totalSupporting, totalWeakening }: EvidenceSectionProps) {
-  const supporting = evidence.filter(e => e.side === 'supporting')
-  const weakening = evidence.filter(e => e.side === 'weakening')
+function linkagePct(score: number | null | undefined): string {
+  if (score == null) return ''
+  return `${Math.round(score * 100)}%`
+}
+
+const MEDIA_TYPE_GLYPHS: Record<string, string> = {
+  image: '📊 Chart',
+  scientific_paper: '📊 Chart',
+  article: '📷 Photo',
+  song: '🎭 Meme / Cartoon',
+  poem: '🎭 Meme / Cartoon',
+  movie: '🎥 Video / Documentary',
+  podcast: '🎥 Video / Documentary',
+  book: '📚 Book',
+}
+
+function mediaTypeGlyph(mediaType: string): string {
+  return MEDIA_TYPE_GLYPHS[mediaType] ?? `📄 ${mediaType.replace(/_/g, ' ')}`
+}
+
+function mediaToTier(m: MediaItem): string {
+  // Underlying source determines tier per Rule 4 / Evidence Tiers.
+  if (m.reliabilityTier && /^T[1-4]$/.test(m.reliabilityTier)) return m.reliabilityTier
+  // Fallback by genre
+  switch (m.genreType) {
+    case 'peer_reviewed': return 'T1'
+    case 'expert_analysis':
+    case 'institutional_report': return 'T2'
+    case 'news_report':
+    case 'survey': return 'T3'
+    default: return 'T4'
+  }
+}
+
+export default function EvidenceSection({
+  evidence,
+  totalSupporting,
+  totalWeakening,
+  media = [],
+}: EvidenceSectionProps) {
+  const sortedEvidence = [...evidence].sort((a, b) => {
+    // T1 first, then T2 ... within tier sort by side (supporting first)
+    const tierOrder: Record<string, number> = { T1: 1, T2: 2, T3: 3, T4: 4 }
+    const at = tierOrder[a.evidenceType] ?? 5
+    const bt = tierOrder[b.evidenceType] ?? 5
+    if (at !== bt) return at - bt
+    if (a.side !== b.side) return a.side === 'supporting' ? -1 : 1
+    return Math.abs(b.impactScore) - Math.abs(a.impactScore)
+  })
 
   return (
     <section>
@@ -79,75 +92,158 @@ export default function EvidenceSection({ evidence, totalSupporting, totalWeaken
         emoji="&#x1F52C;"
         title="Evidence Ledger"
         href="/Evidence"
+        subtitle="Evidence is empirical data: studies, statistics, records, observations, and media. Each item is tiered by source quality and linked to the specific argument it bears on."
       />
-      <p className="text-sm text-[var(--muted-foreground)] mb-2">
-        Evidence is empirical data: studies, statistics, records, observations, and media.
-        Each item is tiered by source quality and paired with the argument it bears on.
+      <p className="text-xs text-[var(--muted-foreground)] mb-4">
         Tier reflects the underlying source, not the format — a meme visualizing a T1
-        study is T1; a pundit asserting a claim is T4 at best, and is an argument, not evidence.
-      </p>
-      <p className="text-xs text-[var(--muted-foreground)] italic mb-4">
-        Key: T1=Peer-reviewed/Official, T2=Expert/Institutional, T3=Journalism/Surveys, T4=Opinion/Anecdote
+        study is T1; a pundit asserting a claim is T4 at best, and is an argument, not
+        evidence.{' '}
+        <span className="italic">
+          T1 = Peer-reviewed / Official, T2 = Expert / Institutional,
+          T3 = Journalism / Surveys, T4 = Opinion / Anecdote.
+        </span>
       </p>
 
-      {/* Supporting Evidence */}
-      <div className="mb-6 overflow-x-auto">
-        <table className="w-full border-collapse border border-gray-300 text-sm">
-          <thead>
-            <tr className="bg-green-50">
-              <th className="px-3 py-2 text-left w-[50%] font-semibold">Top Supporting Evidence</th>
-              <th className="px-3 py-2 text-center w-[15%] font-semibold">Evidence Score</th>
-              <th className="px-3 py-2 text-center w-[13%] font-semibold">
-                <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Linkage Score</Link>
-              </th>
-              <th className="px-3 py-2 text-center w-[10%] font-semibold">Type</th>
-              <th className="px-3 py-2 text-center w-[12%] font-semibold">Impact</th>
-            </tr>
-          </thead>
-          <tbody>
-            {supporting.length > 0 ? (
-              supporting.map(item => <EvidenceRow key={item.id} item={item} />)
-            ) : (
-              <EmptyRow />
-            )}
-            <tr className="bg-gray-100 font-semibold">
-              <td colSpan={4} className="px-3 py-2 text-right text-sm">Total Contributing:</td>
-              <td className="px-3 py-2 text-center text-sm font-mono text-green-700">
-                +{totalSupporting.toFixed(1)}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      {/* 4a. Text and Data Sources */}
+      <div className="mb-8">
+        <h3 className="text-base font-semibold mb-2 flex items-center gap-2">
+          <span>📄</span> Text and Data Sources
+        </h3>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="px-3 py-2 text-center w-[8%] font-semibold">Tier</th>
+                <th className="px-3 py-2 text-left w-[40%] font-semibold">Source</th>
+                <th className="px-3 py-2 text-center w-[10%] font-semibold">Stance</th>
+                <th className="px-3 py-2 text-left w-[30%] font-semibold">Argument It Bears On</th>
+                <th className="px-3 py-2 text-center w-[12%] font-semibold">
+                  <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">
+                    Linkage
+                  </Link>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedEvidence.length > 0 ? (
+                sortedEvidence.map(item => (
+                  <tr key={item.id} className="border-b border-gray-200 hover:bg-gray-50 transition-colors">
+                    <td className="px-3 py-3 text-center align-top">{tierBadge(item.evidenceType)}</td>
+                    <td className="px-3 py-3 align-top">
+                      {item.sourceUrl ? (
+                        <a
+                          href={item.sourceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[var(--accent)] hover:underline"
+                        >
+                          {item.description}
+                        </a>
+                      ) : (
+                        item.description
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-center align-top text-xs">{stanceLabel(item.side)}</td>
+                    <td className="px-3 py-3 align-top text-xs text-[var(--muted-foreground)]">
+                      {/* Argument linkage is encoded in linkageScore; the actual argument
+                          this bears on lives on the argument page. */}
+                      &mdash;
+                    </td>
+                    <td className="px-3 py-3 text-center align-top font-mono text-xs">
+                      {linkagePct(item.linkageScore)}
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={5} className="px-3 py-3 text-sm text-[var(--muted-foreground)] italic">
+                    No evidence submitted yet.
+                  </td>
+                </tr>
+              )}
+              <tr className="bg-gray-100 font-semibold">
+                <td colSpan={4} className="px-3 py-2 text-right text-sm">
+                  Net Evidence Impact:
+                </td>
+                <td className="px-3 py-2 text-center text-sm font-mono">
+                  <span className="text-green-700">+{totalSupporting.toFixed(1)}</span>
+                  {' / '}
+                  <span className="text-red-700">-{totalWeakening.toFixed(1)}</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
 
-      {/* Weakening Evidence */}
-      <div className="overflow-x-auto">
-        <table className="w-full border-collapse border border-gray-300 text-sm">
-          <thead>
-            <tr className="bg-red-50">
-              <th className="px-3 py-2 text-left w-[50%] font-semibold">Top Weakening Evidence</th>
-              <th className="px-3 py-2 text-center w-[15%] font-semibold">Evidence Score</th>
-              <th className="px-3 py-2 text-center w-[13%] font-semibold">
-                <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Linkage Score</Link>
-              </th>
-              <th className="px-3 py-2 text-center w-[10%] font-semibold">Type</th>
-              <th className="px-3 py-2 text-center w-[12%] font-semibold">Impact</th>
-            </tr>
-          </thead>
-          <tbody>
-            {weakening.length > 0 ? (
-              weakening.map(item => <EvidenceRow key={item.id} item={item} />)
-            ) : (
-              <EmptyRow />
-            )}
-            <tr className="bg-gray-100 font-semibold">
-              <td colSpan={4} className="px-3 py-2 text-right text-sm">Total Weakening:</td>
-              <td className="px-3 py-2 text-center text-sm font-mono text-red-700">
-                -{totalWeakening.toFixed(1)}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      {/* 4b. Visual and Video Evidence (formerly the Media Resources section) */}
+      <div>
+        <h3 className="text-base font-semibold mb-2 flex items-center gap-2">
+          <span>📸</span> Visual and Video Evidence
+        </h3>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="px-3 py-2 text-left w-[15%] font-semibold">Type</th>
+                <th className="px-3 py-2 text-left w-[25%] font-semibold">Description</th>
+                <th className="px-3 py-2 text-center w-[10%] font-semibold">Stance</th>
+                <th className="px-3 py-2 text-left w-[18%] font-semibold">Source</th>
+                <th className="px-3 py-2 text-center w-[8%] font-semibold">Tier</th>
+                <th className="px-3 py-2 text-left w-[14%] font-semibold">Argument It Bears On</th>
+                <th className="px-3 py-2 text-center w-[10%] font-semibold">
+                  <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">
+                    Linkage
+                  </Link>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {media.length > 0 ? (
+                media.map(m => (
+                  <tr key={m.id} className="border-b border-gray-200 hover:bg-gray-50 transition-colors">
+                    <td className="px-3 py-3 align-top text-xs">{mediaTypeGlyph(m.mediaType)}</td>
+                    <td className="px-3 py-3 align-top">
+                      {m.url ? (
+                        <a
+                          href={m.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[var(--accent)] hover:underline"
+                        >
+                          {m.title}
+                        </a>
+                      ) : (
+                        m.title
+                      )}
+                      {m.author && (
+                        <span className="text-xs text-[var(--muted-foreground)]"> — {m.author}</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-center align-top text-xs capitalize">
+                      {m.side === 'agree' ? 'Supports' : m.side === 'disagree' ? 'Weakens' : m.side}
+                    </td>
+                    <td className="px-3 py-3 align-top text-xs text-[var(--muted-foreground)]">
+                      {m.author ?? ''}
+                    </td>
+                    <td className="px-3 py-3 text-center align-top">{tierBadge(mediaToTier(m))}</td>
+                    <td className="px-3 py-3 align-top text-xs text-[var(--muted-foreground)]">&mdash;</td>
+                    <td className="px-3 py-3 text-center align-top font-mono text-xs">
+                      {linkagePct(m.linkageScore)}
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={7} className="px-3 py-3 text-sm text-[var(--muted-foreground)] italic">
+                    No visual or video evidence submitted yet. Charts, photos, memes, video,
+                    and book imagery all belong here, tiered by underlying source.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
     </section>
   )

--- a/src/features/belief-analysis/components/InterestsSection.tsx
+++ b/src/features/belief-analysis/components/InterestsSection.tsx
@@ -1,4 +1,9 @@
-import type { InterestsAnalysisData } from '../types'
+import type {
+  InterestsAnalysisData,
+  InterestPriorityRankingItem,
+  SharedConflictingInterestItem,
+  InterestValueLinkItem,
+} from '../types'
 import SectionHeading from './SectionHeading'
 
 interface InterestsSectionProps {
@@ -12,53 +17,192 @@ function renderLines(text: string | null): React.ReactNode {
   ))
 }
 
+function rankCell(rank: number | null | undefined): string {
+  if (rank == null) return '—'
+  return `#${rank}`
+}
+
+function gapCell(a: number | null | undefined, b: number | null | undefined): string {
+  if (a == null || b == null) return '—'
+  return String(Math.abs(a - b))
+}
+
+function pctCell(supportersPct: number | null | undefined, opponentsPct: number | null | undefined): string {
+  if (supportersPct == null && opponentsPct == null) return ''
+  const s = supportersPct == null ? '—' : `${Math.round(supportersPct)}%`
+  const o = opponentsPct == null ? '—' : `${Math.round(opponentsPct)}%`
+  return `S ${s} / O ${o}`
+}
+
+function PriorityRankingsTable({ rows }: { rows: InterestPriorityRankingItem[] }) {
+  const data: Array<InterestPriorityRankingItem | null> = rows.length > 0
+    ? rows
+    : [null, null, null]
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-3 py-2 text-left font-semibold w-[22%]">Interest</th>
+            <th className="px-3 py-2 text-center font-semibold w-[13%]">Supporters&apos; Rank</th>
+            <th className="px-3 py-2 text-center font-semibold w-[13%]">Opponents&apos; Rank</th>
+            <th className="px-3 py-2 text-center font-semibold w-[10%]">Gap</th>
+            <th className="px-3 py-2 text-center font-semibold w-[14%]">Self-Reported %</th>
+            <th className="px-3 py-2 text-center font-semibold w-[14%]">Confidence</th>
+            <th className="px-3 py-2 text-left font-semibold w-[14%]">Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-b border-gray-200">
+              <td className="px-3 py-3 align-top">
+                {row?.interest ?? <span className="text-[var(--muted-foreground)] italic">[interest]</span>}
+              </td>
+              <td className="px-3 py-3 align-top text-center font-mono">{rankCell(row?.supportersRank)}</td>
+              <td className="px-3 py-3 align-top text-center font-mono">{rankCell(row?.opponentsRank)}</td>
+              <td className="px-3 py-3 align-top text-center font-mono">
+                {gapCell(row?.supportersRank, row?.opponentsRank)}
+              </td>
+              <td className="px-3 py-3 align-top text-center text-xs font-mono">
+                {row ? pctCell(row.selfReportedSupportersPct, row.selfReportedOpponentsPct) : ''}
+              </td>
+              <td className="px-3 py-3 align-top text-center text-xs font-mono">
+                {row?.confidence != null ? `${Math.round(row.confidence * 100)}%` : ''}
+              </td>
+              <td className="px-3 py-3 align-top text-xs text-[var(--muted-foreground)]">
+                {row?.source ?? ''}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function SharedVsConflictingTable({
+  rows,
+  fallbackShared,
+  fallbackConflicting,
+}: {
+  rows: SharedConflictingInterestItem[]
+  fallbackShared: string | null
+  fallbackConflicting: string | null
+}) {
+  // If there are no structured rows, fall back to the legacy free-text fields
+  // so existing data still renders without an empty section.
+  const data: Array<SharedConflictingInterestItem | null> = rows.length > 0
+    ? rows
+    : (fallbackShared || fallbackConflicting
+        ? [{
+            sharedInterest: fallbackShared,
+            conflictingInterest: fallbackConflicting,
+            whyConflictExists: null,
+          }]
+        : [null])
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr className="bg-blue-50">
+            <th className="px-3 py-2 text-left font-semibold w-[30%]">Shared Interests</th>
+            <th className="px-3 py-2 text-left font-semibold w-[30%]">Conflicting Interests</th>
+            <th className="px-3 py-2 text-left font-semibold w-[40%]">Why the Conflict Exists</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-b border-gray-200">
+              <td className="px-3 py-3 align-top">{renderLines(row?.sharedInterest ?? null)}</td>
+              <td className="px-3 py-3 align-top">{renderLines(row?.conflictingInterest ?? null)}</td>
+              <td className="px-3 py-3 align-top">{renderLines(row?.whyConflictExists ?? null)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function InterestValueLinksTable({ rows }: { rows: InterestValueLinkItem[] }) {
+  const data: Array<InterestValueLinkItem | null> = rows.length > 0
+    ? rows
+    : [null, null]
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-3 py-2 text-left font-semibold w-[20%]">Interest at Stake</th>
+            <th className="px-3 py-2 text-left font-semibold w-[20%]">Side</th>
+            <th className="px-3 py-2 text-left font-semibold w-[25%]">Value Elevated</th>
+            <th className="px-3 py-2 text-left font-semibold w-[25%]">Value Deprioritized</th>
+            <th className="px-3 py-2 text-center font-semibold w-[10%]">Confidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-b border-gray-200">
+              <td className="px-3 py-3 align-top">
+                {row?.interest ?? <span className="text-[var(--muted-foreground)] italic">[interest]</span>}
+              </td>
+              <td className="px-3 py-3 align-top capitalize">
+                {row ? (row.side === 'supporter' ? 'Supporters' : 'Opponents') : ''}
+              </td>
+              <td className="px-3 py-3 align-top">{row?.valueElevated ?? ''}</td>
+              <td className="px-3 py-3 align-top">{row?.valueDeprioritized ?? ''}</td>
+              <td className="px-3 py-3 align-top text-center text-xs font-mono">
+                {row?.confidence != null ? `${Math.round(row.confidence * 100)}%` : ''}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 export default function InterestsSection({ interests }: InterestsSectionProps) {
+  const priorityRankings = interests?.priorityRankings ?? []
+  const sharedVsConflicting = interests?.sharedVsConflicting ?? []
+  const interestValueLinks = interests?.interestValueLinks ?? []
+
   return (
     <section>
       <SectionHeading
         emoji="&#x1F4A1;"
-        title="Interest & Motivations"
+        title="Interests and Motivations"
         href="/Interests"
+        subtitle="Interests are what people actually need or want. Positions are what they demand. Shared interests are where compromise lives. Conflicting interests are where honesty about trade-offs is required."
       />
 
-      {/* Supporters vs Opponents */}
-      <div className="mb-6 overflow-x-auto">
-        <table className="w-full border-collapse border border-gray-300 text-sm">
-          <thead>
-            <tr className="bg-gray-100">
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Supporters</th>
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Opponents</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td className="px-3 py-3 align-top text-sm">{renderLines(interests?.supporterInterests ?? null)}</td>
-              <td className="px-3 py-3 align-top text-sm">{renderLines(interests?.opponentInterests ?? null)}</td>
-            </tr>
-          </tbody>
-        </table>
+      {/* 6a. Interest Priority Rankings */}
+      <div className="mb-6">
+        <h3 className="text-base font-semibold mb-2">Interest Priority Rankings</h3>
+        <PriorityRankingsTable rows={priorityRankings} />
       </div>
 
-      {/* Shared vs Conflicting Interests */}
-      <h3 className="text-lg font-bold text-[var(--foreground)] flex items-center gap-2 mb-3">
-        <span>&#x1F517;</span>
-        Shared and Conflicting Interests
-      </h3>
-      <div className="overflow-x-auto">
-        <table className="w-full border-collapse border border-gray-300 text-sm">
-          <thead>
-            <tr className="bg-blue-50">
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Shared Interests</th>
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Conflicting Interests</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td className="px-3 py-3 align-top text-sm">{renderLines(interests?.sharedInterests ?? null)}</td>
-              <td className="px-3 py-3 align-top text-sm">{renderLines(interests?.conflictingInterests ?? null)}</td>
-            </tr>
-          </tbody>
-        </table>
+      {/* 6b. Shared vs. Conflicting Interests with "Why the Conflict Exists" */}
+      <div className="mb-6">
+        <h3 className="text-base font-semibold mb-2">Shared vs. Conflicting Interests</h3>
+        <SharedVsConflictingTable
+          rows={sharedVsConflicting}
+          fallbackShared={interests?.sharedInterests ?? null}
+          fallbackConflicting={interests?.conflictingInterests ?? null}
+        />
+      </div>
+
+      {/* 6c. How Interests Drive Value Rankings */}
+      <div>
+        <h3 className="text-base font-semibold mb-1">How Interests Drive Value Rankings</h3>
+        <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
+          When your material interests are at stake, you conveniently deprioritize values
+          that would cost you. This table maps the linkage.
+        </p>
+        <InterestValueLinksTable rows={interestValueLinks} />
       </div>
     </section>
   )

--- a/src/features/belief-analysis/components/ObjectiveCriteriaSection.tsx
+++ b/src/features/belief-analysis/components/ObjectiveCriteriaSection.tsx
@@ -6,64 +6,60 @@ interface ObjectiveCriteriaSectionProps {
   criteria: ObjectiveCriteriaItem[]
 }
 
-function scoreBadge(score: number) {
-  const pct = Math.round(score * 100)
-  let color = 'text-red-600'
-  if (score >= 0.80) color = 'text-green-700'
-  else if (score >= 0.60) color = 'text-blue-700'
-  else if (score >= 0.40) color = 'text-orange-600'
-  return <span className={`font-mono font-semibold ${color}`}>{pct}%</span>
+function scorePct(score: number): string {
+  return `${Math.round(score * 100)}%`
 }
 
 export default function ObjectiveCriteriaSection({ criteria }: ObjectiveCriteriaSectionProps) {
   return (
     <section>
       <SectionHeading
-        emoji="&#x1F4CF;"
-        title="Best Scoring Objective Criteria"
+        emoji="&#x1F9EA;"
+        title="Objective Criteria"
         href="/algorithms/objective-criteria"
-        subtitle="For Measuring the Strength of this Belief"
+        subtitle="How would we know if this belief is true? Measurable tests both sides should agree on before the debate starts."
       />
 
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className="px-3 py-2 text-left font-semibold">Top Objective Criteria</th>
-              <th className="px-3 py-2 text-center font-semibold">
-                <abbr title="Does this actually measure what we think it measures?">Validity</abbr>
-              </th>
-              <th className="px-3 py-2 text-center font-semibold">
-                <abbr title="Can different people measure this consistently?">Reliability</abbr>
-              </th>
-              <th className="px-3 py-2 text-center font-semibold">
-                <abbr title="Is the data source neutral / free of conflicts of interest?">Independence</abbr>
-              </th>
-              <th className="px-3 py-2 text-center font-semibold">
-                <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">
-                  <abbr title="How strongly does this metric correlate with the ultimate goal?">Linkage</abbr>
-                </Link>
-              </th>
-              <th className="px-3 py-2 text-center font-semibold">Type</th>
-              <th className="px-3 py-2 text-center font-semibold">Total</th>
+              <th className="px-3 py-2 text-left font-semibold w-[40%]">Criterion</th>
+              <th className="px-3 py-2 text-left font-semibold w-[30%]">Current Status</th>
+              <th className="px-3 py-2 text-left font-semibold w-[30%]">Threshold for Agreement</th>
             </tr>
           </thead>
           <tbody>
             {criteria.length > 0 ? (
               criteria.map(c => (
                 <tr key={c.id} className="border-b border-gray-200 hover:bg-gray-50 transition-colors">
-                  <td className="px-3 py-3 text-sm">{c.description}</td>
-                  <td className="px-3 py-3 text-center text-sm">{scoreBadge(c.validityScore)}</td>
-                  <td className="px-3 py-3 text-center text-sm">{scoreBadge(c.reliabilityScore)}</td>
-                  <td className="px-3 py-3 text-center text-sm">{scoreBadge(c.independenceScore)}</td>
-                  <td className="px-3 py-3 text-center text-sm">{scoreBadge(c.linkageScore)}</td>
-                  <td className="px-3 py-3 text-center text-sm text-[var(--muted-foreground)]">{c.criteriaType || '—'}</td>
-                  <td className="px-3 py-3 text-center text-sm font-bold font-mono">{(c.totalScore * 100).toFixed(0)}%</td>
+                  <td className="px-3 py-3 align-top">
+                    <div className="text-sm">{c.description}</div>
+                    {c.totalScore > 0 && (
+                      <div className="text-xs text-[var(--muted-foreground)] mt-1">
+                        Quality: <span className="font-mono">{scorePct(c.totalScore)}</span>
+                        {c.criteriaType && (
+                          <span className="ml-2">
+                            ·{' '}
+                            <Link href="/algorithms/objective-criteria" className="text-[var(--accent)] hover:underline">
+                              {c.criteriaType}
+                            </Link>
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-3 align-top text-sm">
+                    {c.currentStatus ?? <span className="text-[var(--muted-foreground)] italic">—</span>}
+                  </td>
+                  <td className="px-3 py-3 align-top text-sm">
+                    {c.thresholdForAgreement ?? <span className="text-[var(--muted-foreground)] italic">—</span>}
+                  </td>
                 </tr>
               ))
             ) : (
               <tr>
-                <td className="px-3 py-3 text-sm text-[var(--muted-foreground)] italic" colSpan={7}>
+                <td className="px-3 py-3 text-sm text-[var(--muted-foreground)] italic" colSpan={3}>
                   No objective criteria defined yet.{' '}
                   <Link href="/algorithms/objective-criteria" className="text-[var(--accent)] hover:underline">
                     Learn how criteria work.

--- a/src/features/belief-analysis/components/ValuesSection.tsx
+++ b/src/features/belief-analysis/components/ValuesSection.tsx
@@ -1,4 +1,10 @@
-import type { ValuesAnalysisData } from '../types'
+import Link from 'next/link'
+import type {
+  ValuesAnalysisData,
+  ValuePriorityRankingItem,
+  SharedValuePriorityItem,
+  CrossContextConsistencyItem,
+} from '../types'
 import SectionHeading from './SectionHeading'
 
 interface ValuesSectionProps {
@@ -12,46 +18,228 @@ function renderLines(text: string | null): React.ReactNode {
   ))
 }
 
+function rankCell(rank: number | null | undefined): string {
+  if (rank == null) return '—'
+  return `#${rank}`
+}
+
+function gapCell(a: number | null | undefined, b: number | null | undefined): string {
+  if (a == null || b == null) return '—'
+  return String(Math.abs(a - b))
+}
+
+function pctCell(supportersPct: number | null | undefined, opponentsPct: number | null | undefined): string {
+  if (supportersPct == null && opponentsPct == null) return ''
+  const s = supportersPct == null ? '—' : `${Math.round(supportersPct)}%`
+  const o = opponentsPct == null ? '—' : `${Math.round(opponentsPct)}%`
+  return `S ${s} / O ${o}`
+}
+
+function PriorityRankingsTable({ rows }: { rows: ValuePriorityRankingItem[] }) {
+  const data: Array<ValuePriorityRankingItem | null> = rows.length > 0
+    ? rows
+    : [null, null, null]
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-3 py-2 text-left font-semibold w-[22%]">Value</th>
+            <th className="px-3 py-2 text-center font-semibold w-[13%]">Supporters&apos; Rank</th>
+            <th className="px-3 py-2 text-center font-semibold w-[13%]">Opponents&apos; Rank</th>
+            <th className="px-3 py-2 text-center font-semibold w-[10%]">Gap</th>
+            <th className="px-3 py-2 text-center font-semibold w-[14%]">Self-Reported %</th>
+            <th className="px-3 py-2 text-center font-semibold w-[14%]">Confidence</th>
+            <th className="px-3 py-2 text-left font-semibold w-[14%]">Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-b border-gray-200">
+              <td className="px-3 py-3 align-top">
+                {row?.value ?? <span className="text-[var(--muted-foreground)] italic">[value]</span>}
+              </td>
+              <td className="px-3 py-3 align-top text-center font-mono">{rankCell(row?.supportersRank)}</td>
+              <td className="px-3 py-3 align-top text-center font-mono">{rankCell(row?.opponentsRank)}</td>
+              <td className="px-3 py-3 align-top text-center font-mono">
+                {gapCell(row?.supportersRank, row?.opponentsRank)}
+              </td>
+              <td className="px-3 py-3 align-top text-center text-xs font-mono">
+                {row ? pctCell(row.selfReportedSupportersPct, row.selfReportedOpponentsPct) : ''}
+              </td>
+              <td className="px-3 py-3 align-top text-center text-xs font-mono">
+                {row?.confidence != null ? `${Math.round(row.confidence * 100)}%` : ''}
+              </td>
+              <td className="px-3 py-3 align-top text-xs text-[var(--muted-foreground)]">
+                {row?.source ?? ''}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function SharedValuesTable({ rows }: { rows: SharedValuePriorityItem[] }) {
+  const data: Array<SharedValuePriorityItem | null> = rows.length > 0 ? rows : [null, null]
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-3 py-2 text-left font-semibold w-[20%]">Shared Value</th>
+            <th className="px-3 py-2 text-left font-semibold w-[40%]">Supporters&apos; Priority Context</th>
+            <th className="px-3 py-2 text-left font-semibold w-[40%]">Opponents&apos; Priority Context</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-b border-gray-200">
+              <td className="px-3 py-3 align-top">
+                {row?.value ?? <span className="text-[var(--muted-foreground)] italic">[value]</span>}
+              </td>
+              <td className="px-3 py-3 align-top">{renderLines(row?.supportersContext ?? null)}</td>
+              <td className="px-3 py-3 align-top">{renderLines(row?.opponentsContext ?? null)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function CrossContextTable({ rows }: { rows: CrossContextConsistencyItem[] }) {
+  const data: Array<CrossContextConsistencyItem | null> = rows.length > 0 ? rows : [null, null]
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-3 py-2 text-left font-semibold w-[20%]">Value Deprioritized Here</th>
+            <th className="px-3 py-2 text-left font-semibold w-[15%]">Deprioritized By</th>
+            <th className="px-3 py-2 text-left font-semibold w-[30%]">Other Topic Where They Champion It</th>
+            <th className="px-3 py-2 text-left font-semibold w-[35%]">What This Suggests</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-b border-gray-200">
+              <td className="px-3 py-3 align-top">
+                {row?.value ?? <span className="text-[var(--muted-foreground)] italic">[value]</span>}
+              </td>
+              <td className="px-3 py-3 align-top capitalize">
+                {row ? (row.deprioritizedBy === 'supporter' ? 'Supporters' : 'Opponents') : ''}
+              </td>
+              <td className="px-3 py-3 align-top">
+                {row?.otherTopicSlug && row.otherTopic ? (
+                  <Link href={`/beliefs/${row.otherTopicSlug}`} className="text-[var(--accent)] hover:underline">
+                    {row.otherTopic}
+                  </Link>
+                ) : (
+                  row?.otherTopic ?? ''
+                )}
+              </td>
+              <td className="px-3 py-3 align-top">{renderLines(row?.whatThisSuggests ?? null)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 export default function ValuesSection({ values }: ValuesSectionProps) {
+  const priorityRankings = values?.priorityRankings ?? []
+  const sharedPriorities = values?.sharedPriorities ?? []
+  const crossContextChecks = values?.crossContextChecks ?? []
+
   return (
     <section>
       <SectionHeading
         emoji="&#x2696;&#xFE0F;"
-        title="Core Values Conflict"
+        title="Values Conflict Analysis"
         href="/American%20values"
+        subtitle="Most disagreements are not value conflicts. They are priority conflicts. Both sides usually hold the same values but rank them differently on this topic."
       />
 
-      <div className="overflow-x-auto">
-        <table className="w-full border-collapse border border-gray-300 text-sm">
-          <thead>
-            <tr className="bg-gray-100">
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Supporting Values</th>
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Opposing Values</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td className="px-3 py-3 align-top text-sm">
-                <strong>Advertised:</strong><br />
-                {renderLines(values?.supportingAdvertised ?? null)}
-                <br />
-                <strong>Actual:</strong><br />
-                {renderLines(values?.supportingActual ?? null)}
-              </td>
-              <td className="px-3 py-3 align-top text-sm">
-                <strong>Advertised:</strong><br />
-                {renderLines(values?.opposingAdvertised ?? null)}
-                <br />
-                <strong>Actual:</strong><br />
-                {renderLines(values?.opposingActual ?? null)}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      {/* 5a. Value Priority Rankings */}
+      <div className="mb-6">
+        <h3 className="text-base font-semibold mb-1">Value Priority Rankings on This Topic</h3>
+        <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
+          What values does each side prioritize when defending their position? The gap reveals
+          whether this is a genuine value conflict or a priority conflict driven by interests.
+        </p>
+        <PriorityRankingsTable rows={priorityRankings} />
+        <p className="text-xs text-[var(--muted-foreground)] mt-1">
+          <strong>Column key:</strong> Rank = priority assigned on THIS topic (1 = highest).
+          Gap = absolute ranking difference. Self-Reported % = share of each side that
+          names this value as motivating. Source = observer-attributed or self-reported.
+        </p>
       </div>
-      <p className="text-xs text-[var(--muted-foreground)] italic mt-2">
-        (What supporters claim vs. what actually motivates them)
-      </p>
+
+      {/* 5b. Shared Values, Different Priorities */}
+      <div className="mb-6">
+        <h3 className="text-base font-semibold mb-1">Shared Values, Different Priorities</h3>
+        <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
+          Values both sides hold but rank differently on this topic. The question is not
+          &ldquo;do they share this value?&rdquo; but &ldquo;why does the ranking shift here?&rdquo;
+        </p>
+        <SharedValuesTable rows={sharedPriorities} />
+      </div>
+
+      {/* 5c. Cross-Context Consistency Check */}
+      <div className="mb-6">
+        <h3 className="text-base font-semibold mb-1">Cross-Context Consistency Check</h3>
+        <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
+          Where does each side defend the values they deprioritize on THIS topic? The
+          hypocrisy detector, applied symmetrically.
+        </p>
+        <CrossContextTable rows={crossContextChecks} />
+      </div>
+
+      {/* 5d. Advertised vs. Actual Motivation (symmetric Supporters/Opponents) */}
+      <div>
+        <h3 className="text-base font-semibold mb-1">Advertised vs. Actual Motivation</h3>
+        <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
+          What each side claims drives them vs. what the evidence suggests actually drives them.
+        </p>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="px-3 py-2 text-center w-1/2 font-semibold">Supporters</th>
+                <th className="px-3 py-2 text-center w-1/2 font-semibold">Opponents</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-gray-200">
+                <td className="px-3 py-3 align-top text-sm">
+                  <strong>Advertised:</strong><br />
+                  {renderLines(values?.supportingAdvertised ?? null)}
+                </td>
+                <td className="px-3 py-3 align-top text-sm">
+                  <strong>Advertised:</strong><br />
+                  {renderLines(values?.opposingAdvertised ?? null)}
+                </td>
+              </tr>
+              <tr>
+                <td className="px-3 py-3 align-top text-sm">
+                  <strong>Actual (evidence-based):</strong><br />
+                  {renderLines(values?.supportingActual ?? null)}
+                </td>
+                <td className="px-3 py-3 align-top text-sm">
+                  <strong>Actual (evidence-based):</strong><br />
+                  {renderLines(values?.opposingActual ?? null)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </section>
   )
 }

--- a/src/features/belief-analysis/types.ts
+++ b/src/features/belief-analysis/types.ts
@@ -102,6 +102,16 @@ export interface ObjectiveCriteriaItem {
   linkageScore: number
   criteriaType: string | null
   totalScore: number
+  /**
+   * Where the metric currently sits — e.g., "labor-force participation flat at 62.5%".
+   * Optional; renders blank if not provided.
+   */
+  currentStatus?: string | null
+  /**
+   * The threshold both sides agreed (or could agree) constitutes resolution —
+   * e.g., "+2pp sustained over 3 years would settle the debate".
+   */
+  thresholdForAgreement?: string | null
 }
 
 export interface ValuesAnalysisData {
@@ -109,6 +119,50 @@ export interface ValuesAnalysisData {
   supportingActual: string | null
   opposingAdvertised: string | null
   opposingActual: string | null
+  /**
+   * Optional structured rankings — top-3 values per side with cross-ranking and gap.
+   * Empty array means "not yet collected"; the section renders placeholder rows.
+   */
+  priorityRankings?: ValuePriorityRankingItem[]
+  /** Values both sides hold but rank differently here, with per-side context. */
+  sharedPriorities?: SharedValuePriorityItem[]
+  /** Where each side defends the value they deprioritize on this topic — hypocrisy detector. */
+  crossContextChecks?: CrossContextConsistencyItem[]
+}
+
+/**
+ * One value with its rank under each side. Gap is supporters' rank minus opponents'
+ * rank in absolute terms (computed at render time if absent).
+ */
+export interface ValuePriorityRankingItem {
+  value: string
+  supportersRank: number | null
+  opponentsRank: number | null
+  /** Self-reported share (0-100) of each side that names this value as motivating. */
+  selfReportedSupportersPct?: number | null
+  selfReportedOpponentsPct?: number | null
+  /** Confidence we are correctly attributing this ranking (0-1). */
+  confidence?: number | null
+  /** "observer-attributed" or "self-reported". */
+  source?: 'observer-attributed' | 'self-reported' | null
+}
+
+export interface SharedValuePriorityItem {
+  value: string
+  supportersContext: string | null
+  opponentsContext: string | null
+}
+
+export interface CrossContextConsistencyItem {
+  value: string
+  /** Which side deprioritizes this value on the current topic. */
+  deprioritizedBy: 'supporter' | 'opponent'
+  /** Other belief / topic where this same side champions this value. */
+  otherTopic: string | null
+  /** Slug of the other belief if linkable; plain text otherwise. */
+  otherTopicSlug?: string | null
+  /** What the asymmetry suggests (interest-driven vs. principled). */
+  whatThisSuggests: string | null
 }
 
 export interface InterestsAnalysisData {
@@ -116,6 +170,37 @@ export interface InterestsAnalysisData {
   opponentInterests: string | null
   sharedInterests: string | null
   conflictingInterests: string | null
+  /** Optional structured rankings — same shape as Value Priority Rankings. */
+  priorityRankings?: InterestPriorityRankingItem[]
+  /** Per-conflict explanation of why the conflict exists. */
+  sharedVsConflicting?: SharedConflictingInterestItem[]
+  /** Maps interests at stake to the values each side elevates / deprioritizes. */
+  interestValueLinks?: InterestValueLinkItem[]
+}
+
+export interface InterestPriorityRankingItem {
+  interest: string
+  supportersRank: number | null
+  opponentsRank: number | null
+  selfReportedSupportersPct?: number | null
+  selfReportedOpponentsPct?: number | null
+  confidence?: number | null
+  source?: 'observer-attributed' | 'self-reported' | null
+}
+
+export interface SharedConflictingInterestItem {
+  sharedInterest: string | null
+  conflictingInterest: string | null
+  /** Material, structural, or circumstantial reason the conflict exists. */
+  whyConflictExists: string | null
+}
+
+export interface InterestValueLinkItem {
+  interest: string
+  side: 'supporter' | 'opponent'
+  valueElevated: string | null
+  valueDeprioritized: string | null
+  confidence?: number | null
 }
 
 export interface AssumptionItem {

--- a/templates/belief-analysis-template.html
+++ b/templates/belief-analysis-template.html
@@ -1,670 +1,596 @@
+<!-- page=Template -->
+<!-- content-type=text/html -->
 <!--
   ===== ISE BELIEF PAGE MASTER TEMPLATE =====
   Canonical rules: see docs/BELIEF_PAGE_RULES.md.
-  Do NOT reorder sections or fields without updating that rulebook.
+  Do NOT reorder sections, rename fields, or strip sub-tables without updating
+  that rulebook AND the React implementation in src/app/beliefs/[slug]/page.tsx.
 
-  HARD RULES (every generated page MUST follow):
+  HARD RULES (every generation must follow):
     1. NO summary / background / hook / overview at the top. Go straight to Argument Trees.
-    2. Definitions and Scoring Concepts go LAST, just before Contribute, never first.
+    2. Definitions and Scoring Concepts go LAST, never first.
     3. Argument cells are 2-6 word LABELS, not sentences.
     4. Arguments are NOT Evidence. Citations, stats, and studies go in the Evidence
        Ledger, paired with the argument they bear on, not in argument cells.
     5. No broken links. No href="#". Use plain text if the target page doesn't exist.
     6. Score cells stay blank until real sub-argument scoring exists. No "+0" placeholders.
-    7. Supporters and Opponents get symmetric structure everywhere (Values, Interests,
-       Biases, Assumptions) — same row count, same analytical lenses.
+    7. Supporters and Opponents get symmetric structure everywhere — Values, Interests,
+       Biases, Assumptions get the same row count and analytical lenses on both sides.
+
+  CANONICAL SECTION ORDER (must match BELIEF_PAGE_RULES.md):
+    Belief Statement -> Score + Topic ->
+    1. Argument Trees
+    2. Evidence Ledger (text/data, then visual/video)
+    3. Values Conflict Analysis
+       a. Value Priority Rankings
+       b. Shared Values, Different Priorities
+       c. Cross-Context Consistency Check
+       d. Advertised vs. Actual Motivation
+    4. Interests and Motivations
+       a. Interest Priority Rankings
+       b. Shared vs. Conflicting Interests (with Why the Conflict Exists)
+       c. How Interests Drive Value Rankings
+    5. Foundational Assumptions
+    6. Objective Criteria (Criterion / Current Status / Threshold for Agreement)
+    7. Cost-Benefit Analysis (Benefits vs Costs, then Short-Term vs Long-Term)
+    8. Resolution (Best Compromise vs Primary Obstacles, then Biases)
+    9. Belief Mapping (Upstream / Downstream / Similar)
+    10. Legal Framework
+    11. Definitions and Scoring Concepts (LAST before Contribute)
+    12. Contribute / footer
 
   SCORING FORMULA (applied per argument, computed recursively — never assigned):
     Argument Score = Evidence Quality x Logical Validity x Linkage Strength
-  Evidence without a valid argument, or an argument without supporting evidence, scores
-  near zero. Both layers are required for a confident score.
 -->
-<p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">Belief: [Insert Belief Statement Here]</span></p>
-<p><span style="font-size: 150%;"><strong>Index</strong></span></p>
-<p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;"><img class="pluginslug" src="/plugin_helper.php?plugin=toc&amp;depth=3" alt="" /><br /></span></p>
-<p>&nbsp;</p>
-<div style="background-color: #f9f9f9; padding: 15px; border: 1px solid #ddd; margin-bottom: 20px;"><a href="/One%20Page%20Per%20Topic">Topic</a>: [Category] &gt; [Subcategory] Topic IDs: Dewey: [Number] Belief <a href="/beliefs%20grouped%20and%20eventually%20sorted%20along%20the%20the%20positivity%20continuum">Positivity</a> Towards Topic: <strong>[Scale -100% to +100%]</strong> Each section builds a complete analysis from multiple angles. <a href="https://github.com/myklob/ideastockexchange">View the full technical documentation on GitHub</a>.</div>
+<div style="font-family:'Segoe UI', Arial, sans-serif; max-width:960px; margin:0 auto;">
+
+<style>
+  /* Belief page table styling: visible borders, header row, zebra stripes */
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 16px;
+  }
+  table th, table td {
+    border: 1px solid #b0b8c1;
+    padding: 8px 10px;
+    vertical-align: top;
+    text-align: left;
+  }
+  table thead th {
+    background-color: #f0f3f6;
+    font-weight: bold;
+  }
+  table tbody tr:nth-child(even) {
+    background-color: #fafbfc;
+  }
+</style>
+
+<h1>[Belief Statement Goes Here]</h1>
+<p>
+  <strong>Score:</strong> [+XX pro / -XX con | computed from <a href="https://myclob.pbworks.com/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">sub-argument scores</a>]<br />
+  <strong>Topic:</strong> <a href="https://myclob.pbworks.com/w/page/159323433/One%20Page%20Per%20Topic">[Category]</a> &gt; [Subcategory]
+</p>
+
+<h2>&nbsp;</h2>
+
+<!-- ===== ARGUMENT TREES ===== logical claims only. No data, no citations, no percentages. -->
 <!--
-  Rule 2: No Background / Summary / Context / Overview section here.
-  Go straight from metadata to the Argument Trees decomposition.
+  GOOD argument labels (2-6 words): "poverty tax on unbanked", "spoiler effect",
+    "long-term cost", "crowding out", "ballot exhaustion"
+  BAD (too long, embeds data, re-states stance):
+    "Financial exclusion imposes a documented poverty tax on low-income households
+     through check cashing fees..." — this is evidence mixed with argument. Wrong.
 -->
-<h1>🔍 <a href="/Reasons">Argument Trees</a></h1>
-<p>Each reason is a belief with its own page. Scoring is recursive based on <a href="/truth">truth</a>, <a href="/Linkage%20Scores">linkage</a>, and <a href="/Importance%20Score">importance</a>.</p>
-<!--
-  Rule 3: Each cell in the Reasons columns below must be a 2–6 word LABEL
-  (e.g., "poverty tax on unbanked", "captures political influence"). No
-  sentences, no percentages, no citations. Evidence lives in the Evidence
-  Ledger, not here (Rule 4). Leave score cells blank until sub-arguments
-  exist (Rule 6).
--->
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<h1>🔍 <a href="https://myclob.pbworks.com/Reasons">Argument Trees</a></h1>
+<p>Each label is a logical claim. Click to see full reasoning, sub-arguments, linkage score, and supporting evidence on its own belief page. No data citations live here — those belong in the Evidence Ledger below.</p>
+<table>
 <thead>
-<tr style="background-color: #e6ffe6;">
-<th style="text-align: center;" width="60%">
-<p>✅ Top <a href="/Scoring">Scoring</a> Reasons to Agree</p>
-</th> <th style="text-align: center;" width="15%">
-<p>Argument Score</p>
-</th> <th style="text-align: center;" width="13%">
-<p>🔗<a href="/w/page/159338766/Linkage%20Scores">Linkage Score</a></p>
-</th> <th style="text-align: center;" width="12%">
-<p>💥Impact</p>
-</th>
-</tr>
+  <tr>
+    <th width="50%">✅ Reasons to Agree</th>
+    <th width="50%">❌ Reasons to Disagree</th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr style="background-color: #f0f0f0;">
-<td colspan="3" align="right"><strong>Total Pro:</strong></td>
-<td>&nbsp;</td>
-</tr>
+  <tr>
+    <td>1. [short label]</td>
+    <td>1. [short label]</td>
+  </tr>
+  <tr>
+    <td>2. [short label]</td>
+    <td>2. [short label]</td>
+  </tr>
+  <tr>
+    <td>3. [short label]</td>
+    <td>3. [short label]</td>
+  </tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #ffe6e6;">
-<th style="text-align: center;" width="60%">
-<p>❌ Top <a href="/Scoring">Scoring</a> Reasons to Disagree</p>
-</th> <th style="text-align: center;" width="15%">
-<p>Argument Score</p>
-</th> <th style="text-align: center;" width="13%">
-<p><span style="font-size: 85%;">🔗</span><a href="/w/page/159338766/Linkage%20Scores">Linkage Score</a></p>
-</th> <th style="text-align: center;" width="12%">
-<p><span style="font-size: 75%;">💥</span>Impact</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr style="background-color: #f0f0f0;">
-<td colspan="3" align="right"><strong>Total Con:</strong></td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<h1>🔬 <a href="/Evidence">Evidence Ledger</a></h1>
-<p>Evidence is empirical data: studies, statistics, records, observations, and media. Each item is tiered by source quality and paired with the specific argument it bears on. Tier reflects the underlying source, not the format — a meme visualizing a T1 study is T1; a pundit asserting a claim is T4 at best, and is an argument, not evidence.</p>
-<p><em>Key: <strong>T1</strong>=Peer-reviewed/Official, <strong>T2</strong>=Expert/Institutional, <strong>T3</strong>=Journalism/Surveys, <strong>T4</strong>=Opinion/Anecdote</em></p>
-<!--
-  Rule 4: Evidence is empirical data, not logical arguments. Each row records
-  Tier, Source, Stance, Which-Argument-It-Bears-On, and Linkage. If a row reads
-  like an argument label, it belongs in the Argument Trees, not here.
--->
+<p><em>Arguments are logical claims scored by <a href="https://myclob.pbworks.com/w/page/159301147/Logical%20Validity%20Scores">logical validity</a> x <a href="https://myclob.pbworks.com/w/page/159338766/Linkage%20Scores">linkage</a> x evidence quality. Strong reasoning rises; fallacious arguments fade.</em></p>
+
+<h2>&nbsp;</h2>
+
+<!-- ===== EVIDENCE LEDGER ===== empirical data only. This is where citations go. -->
+<h1>🔬 <a href="https://myclob.pbworks.com/w/page/159353568/Evidence">Evidence Ledger</a></h1>
+<p>Evidence is empirical data: studies, statistics, records, observations, and media. Each item is tiered by source quality and linked to the specific argument it bears on. Tier reflects the underlying source, not the format — a meme visualizing a T1 study is T1; a pundit asserting a claim is T4 at best, and is an argument, not evidence.</p>
+
 <h3>📄 Text and Data Sources</h3>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<table>
 <thead>
-<tr style="background-color: #e6ffe6;">
-<th style="text-align: center;" width="30%">
-<p>✅ Top Supporting Evidence</p>
-</th> <th style="text-align: center;" width="10%">
-<p>Stance</p>
-</th> <th style="text-align: center;" width="20%">
-<p>Argument It Bears On</p>
-</th> <th style="text-align: center;" width="13%">
-<p>Evidence Score</p>
-</th> <th style="text-align: center;" width="10%">
-<p><span style="font-size: 85%;">🔗</span><a href="/w/page/159338766/Linkage%20Scores">Linkage</a></p>
-</th> <th style="text-align: center;" width="7%">
-<p>Tier</p>
-</th> <th style="text-align: center;" width="10%">
-<p>Impact</p>
-</th>
-</tr>
+  <tr>
+    <th>Tier</th><th>Source</th><th>Stance</th><th>Argument It Bears On</th><th>Linkage</th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td>&nbsp;</td>
-<td>Supports</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>T1</td>
-<td>&nbsp;</td>
-</tr>
-<tr>
-<td>&nbsp;</td>
-<td>Supports</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr style="background-color: #f0f0f0;">
-<td colspan="6" align="right"><strong>Total Contributing:</strong></td>
-<td>&nbsp;</td>
-</tr>
+  <tr>
+    <td><strong>T1</strong></td>
+    <td>[Peer-reviewed study or official data]</td>
+    <td>Supports</td>
+    <td>[argument label]</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><strong>T2</strong></td>
+    <td>[Expert analysis / institutional report]</td>
+    <td>Supports</td>
+    <td>[argument label]</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><strong>T3</strong></td>
+    <td>[Investigative journalism / survey]</td>
+    <td>Weakens</td>
+    <td>[argument label]</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><strong>T4</strong></td>
+    <td>[Opinion / anecdotal claim]</td>
+    <td>Supports</td>
+    <td>[argument label]</td>
+    <td>low confidence</td>
+  </tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #ffe6e6;">
-<th style="text-align: center;" width="30%">
-<p>❌ Top Weakening Evidence</p>
-</th> <th style="text-align: center;" width="10%">
-<p>Stance</p>
-</th> <th style="text-align: center;" width="20%">
-<p>Argument It Bears On</p>
-</th> <th style="text-align: center;" width="13%">
-<p>Evidence Score</p>
-</th> <th width="10%">
-<p style="text-align: center;">🔗<a href="/w/page/159338766/Linkage%20Scores">Linkage</a></p>
-</th> <th style="text-align: center;" width="7%">
-<p>Tier</p>
-</th> <th style="text-align: center;" width="10%">
-<p>Impact</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>&nbsp;</td>
-<td>Weakens</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr>
-<td>&nbsp;</td>
-<td>Weakens</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr style="background-color: #f0f0f0;">
-<td colspan="6" align="right"><strong>Total Weakening:</strong></td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
+
 <h3>📸 Visual and Video Evidence</h3>
-<!--
-  Visual evidence (charts, photos, memes, video, book imagery) is tiered by the
-  SOURCE it draws from, not the format. A meme visualizing a T1 study is T1.
-  A pundit asserting a claim on video is T4 at best, and that's an argument,
-  not evidence. Pair every visual with the argument it bears on.
+<table>
+<thead>
+  <tr>
+    <th>Type</th><th>Description</th><th>Stance</th><th>Source</th><th>Tier</th><th>Argument It Bears On</th><th>Linkage</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>📊 Chart</td>
+    <td>[What the data shows]</td>
+    <td>Supports</td>
+    <td>[Source]</td>
+    <td>T[1-4]</td>
+    <td>[argument label]</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>📷 Photo</td>
+    <td>[What the image documents]</td>
+    <td>Supports / Weakens</td>
+    <td>[Source]</td>
+    <td>T[1-4]</td>
+    <td>[argument label]</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>🎭 Meme / Cartoon</td>
+    <td>[What claim it conveys]</td>
+    <td>Supports / Weakens</td>
+    <td>[Source]</td>
+    <td>T4</td>
+    <td>[argument label]</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>🎥 Video / Documentary</td>
+    <td>[Title — Channel]</td>
+    <td>Supports / Weakens</td>
+    <td>[Platform]</td>
+    <td>T[2-4]</td>
+    <td>[argument label]</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>📚 Book</td>
+    <td>[Title — Author]</td>
+    <td>Supports / Weakens</td>
+    <td><a href="https://myclob.pbworks.com/w/page/21956965/Books">Books</a></td>
+    <td>T[1-4]</td>
+    <td>[argument label]</td>
+    <td></td>
+  </tr>
+</tbody>
+</table>
+
+<h2>&nbsp;</h2>
+
+<!-- ===== VALUES =====
+  The core insight: most "value conflicts" are really PRIORITY RANKING conflicts.
+  Both sides hold the same values. They rank them differently on THIS topic,
+  often because their interests push certain values up or down.
+
+  Structure (ALL FOUR sub-tables required, in this order):
+  1. Value Priority Rankings — top 3 values per side, with cross-ranking
+  2. Shared Values, Different Priorities — values both sides hold at different priority
+  3. Cross-Context Consistency Check — where each side defends the value they deprioritize here
+  4. Advertised vs. Actual Motivation — symmetric for both Supporters and Opponents
 -->
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<h1>⚖️ <a href="https://myclob.pbworks.com/w/page/21956745/American%20values">Values Conflict Analysis</a></h1>
+<p><em>Most disagreements are not value conflicts. They are priority conflicts. Both sides usually hold the same values but rank them differently on this topic. This section makes the ranking visible.</em></p>
+
+<h3>Value Priority Rankings on This Topic</h3>
+<p><em>What values does each side prioritize when defending their position? And how would the other side rank those same values? The gap between rankings reveals whether this is a genuine value conflict or a priority conflict driven by circumstances and interests.</em></p>
+<table>
 <thead>
-<tr style="background-color: #f0f3f6;">
-<th style="text-align: center;" width="12%"><p>Type</p></th>
-<th style="text-align: center;" width="22%"><p>Description</p></th>
-<th style="text-align: center;" width="10%"><p>Stance</p></th>
-<th style="text-align: center;" width="18%"><p>Source</p></th>
-<th style="text-align: center;" width="7%"><p>Tier</p></th>
-<th style="text-align: center;" width="20%"><p>Argument It Bears On</p></th>
-<th style="text-align: center;" width="11%"><p><span style="font-size: 85%;">🔗</span><a href="/w/page/159338766/Linkage%20Scores">Linkage</a></p></th>
-</tr>
+  <tr>
+    <th width="22%">Value</th>
+    <th width="13%">Supporters' Rank</th>
+    <th width="13%">Opponents' Rank</th>
+    <th width="10%">Gap</th>
+    <th width="14%">Self-Reported %</th>
+    <th width="14%">Confidence</th>
+    <th width="14%">Source</th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td>📊 Chart</td>
-<td>&nbsp;</td>
-<td>Supports</td>
-<td>&nbsp;</td>
-<td>T1</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr>
-<td>📷 Photo</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr>
-<td>🎭 Meme / Cartoon</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>T4</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr>
-<td>🎥 Video / Documentary</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr>
-<td>📚 Book</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td><a href="/Books">Books</a></td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
+  <tr>
+    <td>[value label]</td>
+    <td style="text-align:center;">#1</td>
+    <td style="text-align:center;">#3</td>
+    <td style="text-align:center;">2</td>
+    <td style="text-align:center;"></td>
+    <td style="text-align:center;"></td>
+    <td style="font-size:90%;"></td>
+  </tr>
+  <tr>
+    <td>[value label]</td>
+    <td style="text-align:center;">#2</td>
+    <td style="text-align:center;">#1</td>
+    <td style="text-align:center;">1</td>
+    <td style="text-align:center;"></td>
+    <td style="text-align:center;"></td>
+    <td style="font-size:90%;"></td>
+  </tr>
+  <tr>
+    <td>[value label]</td>
+    <td style="text-align:center;">#3</td>
+    <td style="text-align:center;">#2</td>
+    <td style="text-align:center;">1</td>
+    <td style="text-align:center;"></td>
+    <td style="text-align:center;"></td>
+    <td style="font-size:90%;"></td>
+  </tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<h2>⚖️&nbsp;<a href="/American%20values">Core Values Conflict</a></h2>
-<!--
-  Rule 7: Symmetry. Both columns MUST use the same structure — Advertised and
-  Actual rows for BOTH Supporters and Opponents. Do not give one side extra
-  analytical lenses.
+<p style="font-size:90%; color:#555;"><strong>Column key:</strong> Rank = priority each side assigns this value on THIS topic (1 = highest). Gap = absolute difference in ranking. Self-Reported % = what percentage of each side says this value motivates them (from surveys or user submissions). Confidence = how confident we are that each side would agree with our attribution. Source = observer-attributed (analyst assessment) or self-reported (survey/user-submitted).</p>
+
+<h3>Shared Values, Different Priorities</h3>
+<p><em>Values both sides hold but rank differently on this topic. The question is not "do they share this value?" (usually yes) but "why does the ranking shift here?" Often the answer is interests, not philosophy.</em></p>
+<table>
+<thead>
+  <tr>
+    <th width="20%">Shared Value</th>
+    <th width="40%">Supporters' Priority Context</th>
+    <th width="40%">Opponents' Priority Context</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>[value]</td>
+    <td>[why supporters rank this value where they do on this topic]</td>
+    <td>[why opponents rank this value where they do on this topic]</td>
+  </tr>
+  <tr>
+    <td>[value]</td>
+    <td></td>
+    <td></td>
+  </tr>
+</tbody>
+</table>
+
+<h3>Cross-Context Consistency Check</h3>
+<p><em>Where does each side defend the values they deprioritize on THIS topic? If supporters rank "public safety" low here but high on another issue, that's evidence this is an interest-driven ranking, not a principled philosophical position. This is the hypocrisy detector, applied symmetrically.</em></p>
+<table>
+<thead>
+  <tr>
+    <th width="20%">Value Deprioritized Here</th>
+    <th width="15%">Deprioritized By</th>
+    <th width="30%">Other Topic Where They Champion It</th>
+    <th width="35%">What This Suggests</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>[value]</td>
+    <td>Supporters</td>
+    <td>[other belief page where supporters rank this value #1]</td>
+    <td>[interest-driven ranking vs. principled position]</td>
+  </tr>
+  <tr>
+    <td>[value]</td>
+    <td>Opponents</td>
+    <td>[other belief page where opponents rank this value #1]</td>
+    <td></td>
+  </tr>
+</tbody>
+</table>
+
+<h3>Advertised vs. Actual Motivation</h3>
+<p><em>What each side claims drives them vs. what the evidence suggests actually drives them. Applied symmetrically to both sides.</em></p>
+<table>
+<thead>
+  <tr>
+    <th width="50%">Supporters</th>
+    <th width="50%">Opponents</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><strong>Advertised:</strong><br />1.<br />2.<br />3.</td>
+    <td><strong>Advertised:</strong><br />1.<br />2.<br />3.</td>
+  </tr>
+  <tr>
+    <td><strong>Actual (evidence-based):</strong><br />1.<br />2.<br />3.</td>
+    <td><strong>Actual (evidence-based):</strong><br />1.<br />2.<br />3.</td>
+  </tr>
+</tbody>
+</table>
+
+<h2>&nbsp;</h2>
+
+<!-- ===== INTERESTS =====
+  Conflict resolution principle: talk about interests, not positions.
+  Shared interests are where compromise lives.
+  Conflicting interests are where you have to be honest about the trade-off.
+  Interest-value linkage shows how material interests distort value rankings.
 -->
-<table style="border-color: #cccccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<h1>💡 <a href="https://myclob.pbworks.com/w/page/159301140/Interests">Interests and Motivations</a></h1>
+<p><em>Interests are what people actually need or want. Positions are what they demand. This section separates the two. Shared interests are where compromise lives. Conflicting interests are where honesty about trade-offs is required.</em></p>
+
+<h3>Interest Priority Rankings</h3>
+<table>
 <thead>
-<tr>
-<th width="50%">
-<p>Supporting Values</p>
-</th><th width="50%">
-<p>Opposing Values</p>
-</th>
-</tr>
+  <tr>
+    <th width="22%">Interest</th>
+    <th width="13%">Supporters' Rank</th>
+    <th width="13%">Opponents' Rank</th>
+    <th width="10%">Gap</th>
+    <th width="14%">Self-Reported %</th>
+    <th width="14%">Confidence</th>
+    <th width="14%">Source</th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td valign="top"><strong>Advertised:</strong><br />1.<br /><br /><strong>Actual:</strong><br />1.</td>
-<td valign="top"><strong>Advertised:</strong><br />1.<br /><br /><strong>Actual:</strong><br />1.</td>
-</tr>
+  <tr>
+    <td>[interest label]</td>
+    <td style="text-align:center;">#1</td>
+    <td style="text-align:center;">#3</td>
+    <td style="text-align:center;">2</td>
+    <td style="text-align:center;"></td>
+    <td style="text-align:center;"></td>
+    <td style="font-size:90%;"></td>
+  </tr>
+  <tr>
+    <td>[interest label]</td>
+    <td style="text-align:center;">#2</td>
+    <td style="text-align:center;">#1</td>
+    <td style="text-align:center;">1</td>
+    <td style="text-align:center;"></td>
+    <td style="text-align:center;"></td>
+    <td style="font-size:90%;"></td>
+  </tr>
+  <tr>
+    <td>[interest label]</td>
+    <td style="text-align:center;">#3</td>
+    <td style="text-align:center;">#2</td>
+    <td style="text-align:center;">1</td>
+    <td style="text-align:center;"></td>
+    <td style="text-align:center;"></td>
+    <td style="font-size:90%;"></td>
+  </tr>
 </tbody>
 </table>
-<p>(What supporters claim vs. what actually motivates them)</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<h2>💡 <a href="/Interests">Interests &amp; Motivations</a></h2>
-<!--
-  Rule 7: Symmetry. Supporters and Opponents columns must mirror each other
-  in depth and structure.
--->
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+
+<h3>Shared vs. Conflicting Interests</h3>
+<table>
 <thead>
-<tr style="background-color: #f0f0f0;">
-<th width="50%">
-<p style="text-align: center;">Supporters</p>
-</th> <th width="50%">
-<p style="text-align: center;">Opponents</p>
-</th>
-</tr>
+  <tr>
+    <th width="30%">Shared Interests</th>
+    <th width="30%">Conflicting Interests</th>
+    <th width="40%">Why the Conflict Exists</th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td valign="top">1.<br />2.<br />3.</td>
-<td valign="top">1.<br />2.<br />3.</td>
-</tr>
+  <tr>
+    <td>[interest both sides share]</td>
+    <td>[interest where they genuinely diverge]</td>
+    <td>[material, structural, or circumstantial reason]</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<h3><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 17px; font-weight: bold;">🔗 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 17px; font-weight: bold;" href="/Interests">Shared and Conflicting Interests</a></h3>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+
+<h3>How Interests Drive Value Rankings</h3>
+<p><em>When your material interests are at stake, you conveniently deprioritize values that would cost you. This table maps the linkage.</em></p>
+<table>
 <thead>
-<tr style="background-color: #e6f3ff;">
-<th style="text-align: center;" width="50%">
-<p>Shared Interests</p>
-</th> <th style="text-align: center;" width="50%">
-<p>Conflicting Interests</p>
-</th>
-</tr>
+  <tr>
+    <th width="20%">Interest at Stake</th>
+    <th width="20%">Side</th>
+    <th width="25%">Value Elevated</th>
+    <th width="25%">Value Deprioritized</th>
+    <th width="10%">Confidence</th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td valign="top">1.<br />2.</td>
-<td valign="top">1.<br />2.</td>
-</tr>
+  <tr>
+    <td>[interest]</td>
+    <td>Supporters</td>
+    <td>[value pushed up]</td>
+    <td>[value pushed down]</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>[interest]</td>
+    <td>Opponents</td>
+    <td>[value pushed up]</td>
+    <td>[value pushed down]</td>
+    <td></td>
+  </tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📜 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/Assumptions">Foundational Assumptions</a></p>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+
+<h2>&nbsp;</h2>
+
+<h1>📜 <a href="https://myclob.pbworks.com/Assumptions">Foundational Assumptions</a></h1>
+<table>
 <thead>
-<tr style="background-color: #f0f0f0;">
-<th style="text-align: center;" width="50%">
-<p>Required to Accept This Belief</p>
-</th> <th style="text-align: center;" width="50%">
-<p>Required to Reject This Belief</p>
-</th>
-</tr>
+  <tr>
+    <th width="50%">Required to Accept This Belief</th><th width="50%">Required to Reject This Belief</th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td valign="top">1.<br />2.</td>
-<td valign="top">1.<br />2.</td>
-</tr>
+  <tr><td>1.</td><td>1.</td></tr>
+  <tr><td>2.</td><td>2.</td></tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 17px; font-weight: bold;">📏 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 17px; font-weight: bold;" href="/Objective%20criteria%20scores">Best Objective Criteria</a></p>
-<p><em>For Measuring the Strength of this Belief</em></p>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+
+<h2>&nbsp;</h2>
+
+<h1>🧪 <a href="https://myclob.pbworks.com/w/page/159351732/Objective%20criteria%20scores">Objective Criteria</a></h1>
+<p>How would we know if this belief is true? Measurable tests both sides should agree on before the debate starts.</p>
+<table>
 <thead>
-<tr style="background-color: #f0f0f0;">
-<th style="text-align: center;" width="45%">
-<p>✅ Top Objective Criteria</p>
-</th> <th style="text-align: center;" width="15%">
-<p>Independence Score</p>
-</th> <th style="text-align: center;" width="15%">
-<p><span style="font-size: 85%;">🔗</span><a href="/w/page/159338766/Linkage%20Scores">Linkage Score</a></p>
-</th> <th style="text-align: center;" width="13%">
-<p>Criteria Type</p>
-</th> <th style="text-align: center;" width="12%">
-<p>Total Score</p>
-</th>
-</tr>
+  <tr>
+    <th>Criterion</th><th>Current Status</th><th>Threshold for Agreement</th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
+  <tr><td>1.</td><td></td><td></td></tr>
+  <tr><td>2.</td><td></td><td></td></tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<h2>🔬 Falsifiability Test</h2>
-<p>Conditions that would weaken or disprove the belief&nbsp;</p>
-<p>&nbsp;</p>
-<h2>🔮 Testable Predictions</h2>
-<table style="border-color: #cccccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+
+<h2>&nbsp;</h2>
+
+<h1>📉 <a href="https://myclob.pbworks.com/w/page/156187122/cost-benefit%20analysis">Cost-Benefit Analysis</a></h1>
+<table>
 <thead>
-<tr>
-<th>Prediction</th><th>Timeframe</th><th>Verification Method</th>
-</tr>
+  <tr>
+    <th width="50%">🔔 Potential Benefits</th><th width="50%">🔘 Potential Costs</th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td>&nbsp;<br /></td>
-<td>&nbsp;</td>
-<td>&nbsp;<br /></td>
-</tr>
+  <tr><td>1.</td><td>1.</td></tr>
+  <tr><td>2.</td><td>2.</td></tr>
+  <tr><td>3.</td><td>3.</td></tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<h1><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📉 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/cost-benefit%20analysis">Cost-Benefit Analysis</a></h1>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<h3>🎯 Short vs. Long-Term</h3>
+<table>
 <thead>
-<tr>
-<th style="background-color: #e6ffe6; text-align: center;" width="40%">
-<p>📕 Potential Benefits</p>
-</th> <th style="background-color: #e6ffe6; text-align: center;" width="10%">
-<p><a href="/Likelihood" target="_blank">Likelihood</a></p>
-</th> <th style="background-color: #ffe6e6; text-align: center;" width="40%">
-<p>📘 Potential Costs</p>
-</th> <th style="background-color: #ffe6e6; text-align: center;" width="10%">
-<p>Likelihood</p>
-</th>
-</tr>
+  <tr>
+    <th width="50%">Short-Term (0-2 years)</th><th width="50%">Long-Term (5+ years)</th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td valign="top">1. Improvements created:<br />2. Who gains:<br />3. Positive externalities:</td>
-<td valign="top">&nbsp;</td>
-<td valign="top">1. Problems created:<br />2. Who loses:<br />3. Negative externalities:</td>
-<td valign="top">&nbsp;</td>
-</tr>
+  <tr><td>1.</td><td>1.</td></tr>
+  <tr><td>2.</td><td>2.</td></tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<h2><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🎯 Short vs. Long-Term Impacts</span></h2>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+
+<h2>&nbsp;</h2>
+
+<h1>🤝 <a href="https://myclob.pbworks.com/w/page/162560439/Compromise">Resolution</a></h1>
+<table>
 <thead>
-<tr style="background-color: #f0f0f0;">
-<th style="text-align: center;" width="50%">
-<p>Short-Term (0-2 Years)</p>
-</th> <th style="text-align: center;" width="50%">
-<p>Long-Term (5+ Years)</p>
-</th>
-</tr>
+  <tr>
+    <th width="50%">Best Compromise Solutions</th><th width="50%"><a href="https://myclob.pbworks.com/w/page/162560430/Obstacles%20to%20Resolution">Primary Obstacles</a></th>
+  </tr>
 </thead>
 <tbody>
-<tr>
-<td valign="top">1. Immediate effects:<br />2. Transition costs:</td>
-<td valign="top">1. Sustained effects:<br />2. Structural changes:</td>
-</tr>
+  <tr><td>1.</td><td>1.</td></tr>
+  <tr><td>2.</td><td>2.</td></tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<h1><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/automate%20conflict%20resolution">Resolution</a></h1>
-<h2>🤝 <a href="/Compromise">Best Compromise Solutions</a></h2>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+
+<h3>🧠 <a href="https://myclob.pbworks.com/w/page/21956934/bias">Biases</a></h3>
+<table>
 <thead>
-<tr style="background-color: #e6f3ff;">
-<th style="text-align: center;">
-<p>Solutions Addressing Core Concerns</p>
-</th>
-</tr>
+  <tr><th width="50%">Affecting Supporters</th><th width="50%">Affecting Opponents</th></tr>
 </thead>
 <tbody>
-<tr>
-<td>1. How could we address both sides' core interests?<br />2. What creative solutions haven't been tried?<br />3. What partial implementations could test ideas?</td>
-</tr>
+  <tr><td>1.</td><td>1.</td></tr>
+  <tr><td>2.</td><td>2.</td></tr>
 </tbody>
 </table>
-<p>&nbsp;</p>
-<h2>🚧 <a href="/Obstacles%20to%20Resolution">Primary Obstacles to Resolution</a></h2>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #fff0f0;">
-<th style="text-align: center;" width="50%">
-<p>Barriers to Supporter Honesty</p>
-</th> <th style="text-align: center;" width="50%">
-<p>Barriers to Opposition Honesty</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top">1. What prevents acknowledging costs?<br />2. Incentives for extreme positions?</td>
-<td valign="top">1. What prevents acknowledging benefits?<br />2. Incentives for extreme positions?</td>
-</tr>
-</tbody>
+
+<h2>&nbsp;</h2>
+
+<h1>🧭 <a href="https://myclob.pbworks.com/w/page/162560445/Belief%20Sorting">Belief Mapping</a></h1>
+<h3>🔹 Upstream (More General)</h3>
+<table>
+<thead><tr><th width="50%">Support</th><th width="50%">Oppose</th></tr></thead>
+<tbody><tr><td>1.</td><td>1.</td></tr></tbody>
 </table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🧠 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/bias">Biases</a></p>
-<!--
-  Rule 7: Symmetry. Both columns MUST list the same number of biases with
-  comparable analytical rigor.
--->
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #f0f0f0;">
-<th style="text-align: center;" width="50%">
-<p>Affecting Supporters</p>
-</th> <th style="text-align: center;" width="50%">
-<p>Affecting Opponents</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top">1. Confirmation bias?<br />2. Motivated reasoning?<br />3. Availability heuristic?</td>
-<td valign="top">1. Confirmation bias?<br />2. Motivated reasoning?<br />3. Availability heuristic?</td>
-</tr>
-</tbody>
+<h3>🔹 Downstream (More Specific)</h3>
+<table>
+<thead><tr><th width="50%">Support</th><th width="50%">Oppose</th></tr></thead>
+<tbody><tr><td>1.</td><td>1.</td></tr></tbody>
 </table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<p>&nbsp;<span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📚 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/media">Media Resources</a></p>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr>
-<th style="background-color: #e6ffe6; text-align: center;" width="50%">
-<p>📈 Supporting</p>
-</th> <th style="background-color: #ffe6e6; text-align: center;" width="50%">
-<p>📉 Opposing</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top"><strong><a href="/Books">Books</a></strong><br />1.<br /><br /><strong>Articles</strong><br />1.<br /><br /><strong><a href="/Podcasts">Podcasts</a></strong><br />1.<br /><br /><strong><a href="/Movies">Movies</a></strong><br />1.<br /><br /><strong><a href="/Songs%20that%20agree">Songs</a></strong><br />1.</td>
-<td valign="top"><strong><a href="/Books">Books</a></strong><br />1.<br /><br /><strong>Articles</strong><br />1.<br /><br /><strong><a href="/Podcasts">Podcasts</a></strong><br />1.<br /><br /><strong><a href="/Movies">Movies</a></strong><br />1.<br /><br /><strong><a href="/Songs%20that%20agree">Songs</a></strong><br />1.</td>
-</tr>
-</tbody>
+<h3>🔄 <a href="https://myclob.pbworks.com/w/page/21957126/combine%20similar%20beliefs">Similar Beliefs</a></h3>
+<table>
+<thead><tr><th width="50%">More Extreme</th><th width="50%">More Moderate</th></tr></thead>
+<tbody><tr><td>1.</td><td>1.</td></tr></tbody>
 </table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<h1>⚖️ <a href="/Local%2C%20federal%2C%20and%20international%20laws%20that%20agree">Legal Framework</a></h1>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #f0f0f0;">
-<th style="text-align: center;" width="50%">
-<p>Supporting Laws</p>
-</th> <th style="text-align: center;" width="50%">
-<p>Contradicting Laws</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top">1. Local, state, federal laws that support this<br />2. International treaties</td>
-<td valign="top">1. Local, state, federal laws that contradict this<br />2. International treaties</td>
-</tr>
-</tbody>
+
+<h2>&nbsp;</h2>
+
+<h1>⚖️ <a href="https://myclob.pbworks.com/w/page/159554427/Local%2C%20federal%2C%20and%20international%20laws%20that%20agree">Legal Framework</a></h1>
+<table>
+<thead><tr><th width="50%">Supporting Laws</th><th width="50%">Contradicting Laws</th></tr></thead>
+<tbody><tr><td>1.</td><td>1.</td></tr></tbody>
 </table>
-<p>&nbsp;</p>
-<h1>🧭 <a href="/Belief%20Sorting">General to Specific Belief Mapping</a></h1>
-<h3>🔹 Most General (Upstream)</h3>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #f0f0f0;">
-<th style="text-align: center;" width="50%">
-<p>Support</p>
-</th> <th style="text-align: center;" width="50%">
-<p>Oppose</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top">1. Broader principles that, if true, would support this belief</td>
-<td valign="top">1. Broader principles that, if true, would oppose this belief</td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
-<h3>🔹 More Specific (Downstream)</h3>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #f0f0f0;">
-<th style="text-align: center;" width="50%">
-<p>Support</p>
-</th> <th style="text-align: center;" width="50%">
-<p>Oppose</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top">1. More specific claims that depend on this belief being true</td>
-<td valign="top">1. More specific claims that depend on this belief being false</td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
-<p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🔄 </span><a style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;" href="/combine%20similar%20beliefs">Similar Beliefs</a></p>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr style="background-color: #f0f0f0;">
-<th style="text-align: center;" width="50%">
-<p>More Extreme Versions</p>
-</th> <th width="50%">
-<p style="text-align: center;">More Moderate Versions</p>
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td valign="top">1.<br />2.</td>
-<td valign="top">1.<br />2.</td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<!--
-  Rule 1: Definitions and Scoring Concepts render LAST, just before Contribute.
-  Readers come for the scored argument network; definitions are a footnote,
-  not a tutorial. Do not move this section above the Argument Trees.
--->
+
+<h2>&nbsp;</h2>
+
+<!-- ===== DEFINITIONS GO AT THE END, NEVER AT THE TOP ===== -->
 <h1>📖 Definitions and Scoring Concepts</h1>
-<p><strong>Arguments vs. Evidence.</strong> <a href="/Reasons">Arguments</a> are logical claims — scored by <a href="/Logical%20Validity%20Scores">logical validity</a> and <a href="/Linkage%20Scores">linkage strength</a>. <a href="/Evidence">Evidence</a> is empirical data — scored by source tier and conclusion relevance. The scoring formula is <em>Argument Score = Evidence Quality x Logical Validity x Linkage Strength</em>. An argument with great evidence but a logical fallacy still scores low. Evidence attached to the wrong argument contributes almost nothing even if the data is impeccable. Both layers are required.</p>
-<p><strong>Evidence Tiers.</strong> T1 = peer-reviewed / official data. T2 = expert analysis / institutional reports. T3 = investigative journalism / surveys. T4 = opinion / anecdotal. Tier is set by the underlying source, not the format — a meme visualizing a T1 study is T1. A pundit asserting a claim is T4 at best, and is an argument, not evidence.</p>
-<p><strong>Scoring Concepts.</strong> <a href="/Argument%20scores%20from%20sub-argument%20scores">Argument Scores</a> are computed recursively — never manually assigned. <a href="/truth">Truth Scores</a> integrate validity, evidence, and linkage. <a href="/Importance%20Score">Importance Scores</a> weight arguments by how much they move the needle. <a href="/ReasonRank">ReasonRank</a> sorts by quality, not volume or recency.</p>
-<p>Page-specific terminology:</p>
-<table style="border-color: #cccccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead>
-<tr>
-<th style="text-align: center;" width="30%">Term</th><th style="text-align: center;" width="70%">Definition Used in This Analysis</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>&nbsp;<br /></td>
-<td>&nbsp;<br /></td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<p><span style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📬 Contribute</span></p>
-<p><a style="font-size: 13px;" href="/Contact%20Me">Contact me</a><span style="font-size: 13px;"> to contribute to the Idea Stock Exchange.</span></p>
-<p>&nbsp;</p>
-<p><a href="https://github.com/myklob/ideastockexchange">View the full codebase and technical documentation on GitHub</a> to understand the scoring algorithms, contribute to development, or adapt this system for your own use.</p>
-<p>&nbsp;</p>
-<p>Start by exploring how we:</p>
-<p>&nbsp;</p>
-<ul>
-<li>Calculate <a href="/Argument%20scores%20from%20sub-argument%20scores">argument scores from sub-arguments</a></li>
-<li>Measure <a href="/truth">truth</a> and <a href="/Evidence">evidence quality</a></li>
-<li>Apply <a href="/Linkage%20Scores">linkage scores</a> to weight relevance</li>
-<li>Implement <a href="/ReasonRank">ReasonRank</a> for quality-based sorting</li>
-</ul>
-<p>&nbsp;</p>
-<p>This template provides the structure. Your contributions provide the content. Together, we build humanity's knowledge infrastructure for better decisions.</p>
-<p>&nbsp;</p>
-<p>Score: [To be calculated based on <a href="/Argument%20scores%20from%20sub-argument%20scores">argument scores</a>]</p>
+<p>
+  <strong>Arguments vs. Evidence:</strong>
+  <a href="https://myclob.pbworks.com/Reasons">Arguments</a> are logical claims — scored by <a href="https://myclob.pbworks.com/w/page/159301147/Logical%20Validity%20Scores">logical validity</a> and <a href="https://myclob.pbworks.com/w/page/159338766/Linkage%20Scores">linkage strength</a>.
+  <a href="https://myclob.pbworks.com/w/page/159353568/Evidence">Evidence</a> is empirical data — scored by source tier and conclusion relevance.
+  The scoring formula: <em>Argument Score = Evidence Quality x Logical Validity x Linkage Strength</em>.
+  An argument with great evidence but a logical fallacy still scores low. Evidence attached to the wrong argument contributes almost nothing even if the data is impeccable. Both layers are required.
+</p>
+<p>
+  <strong>Evidence Tiers:</strong> T1 = peer-reviewed / official data. T2 = expert analysis / institutional reports. T3 = investigative journalism / surveys. T4 = opinion / anecdotal.
+  Tier is set by the underlying source, not the format — a meme visualizing a T1 study is T1. A pundit asserting a claim is T4 at best, and is an argument, not evidence.
+</p>
+<p>
+  <a href="https://myclob.pbworks.com/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">Argument Scores</a> are computed recursively — never manually assigned.
+  <a href="https://myclob.pbworks.com/w/page/21960078/truth">Truth Scores</a> integrate validity, evidence, and linkage.
+  <a href="https://myclob.pbworks.com/importance%20score">Importance Scores</a> weight arguments by how much they move the needle.
+  <a href="https://myclob.pbworks.com/w/page/159300543/ReasonRank">ReasonRank</a> sorts by quality, not volume or recency.
+</p>
+
+<h2>&nbsp;</h2>
+
+<h1>🔬 Contribute</h1>
+<p>
+  <strong><a href="https://myclob.pbworks.com/w/page/160433328/Contact%20Me">Contact me</a></strong> to add arguments, evidence, images, or video. |
+  <strong><a href="https://github.com/IdeaStockExchange/ideastockexchange">GitHub</a></strong> for scoring algorithms and technical documentation.
+</p>
+
+</div>


### PR DESCRIPTION
## Summary

This PR refactors the belief analysis page template and React components to implement the canonical section order and structured data model defined in `docs/BELIEF_PAGE_RULES.md`. The changes consolidate scattered analysis sections, introduce typed sub-tables for Values and Interests analysis, and move media evidence into the Evidence Ledger rather than a separate section.

## Key Changes

### Template Restructuring (`templates/belief-analysis-template.html`)
- **Simplified header**: Removed metadata box; belief statement now followed directly by Score + Topic line
- **Canonical section order**: Reorganized from 18 sections to 12, with Evidence Ledger, Values, and Interests sections now containing structured sub-tables
- **Values Conflict Analysis**: Split into 4 sub-tables:
  - Value Priority Rankings (with gap analysis and confidence scoring)
  - Shared Values, Different Priorities (context for each side)
  - Cross-Context Consistency Check (hypocrisy detector)
  - Advertised vs. Actual Motivation (symmetric for both sides)
- **Interests & Motivations**: Restructured into 3 sub-tables:
  - Interest Priority Rankings (parallel to Values)
  - Shared vs. Conflicting Interests (with "Why the Conflict Exists" column)
  - How Interests Drive Value Rankings
- **Evidence Ledger**: Consolidated text/data and visual evidence into single section with unified tier-based styling
- **Cost-Benefit Analysis**: Now includes Short-Term vs. Long-Term impacts as a sub-table rather than separate section
- **Removed sections**: Impact, Media Resources, Falsifiability, Testable Predictions (consolidated or moved)
- **Added CSS**: Unified table styling with visible borders, header rows, and zebra striping

### React Components

**`EvidenceSection.tsx`**:
- Added `media` prop to render visual/video evidence in the same table as text sources
- Implemented tier-based sorting (T1→T4) with supporting evidence first
- Replaced custom scoring display with simplified linkage percentage
- Unified single evidence table replacing separate supporting/weakening tables

**`ValuesSection.tsx`**:
- Introduced 4 new sub-components: `PriorityRankingsTable`, `SharedValuesTable`, `CrossContextTable`, `AdvertisedVsActualTable`
- Added helper functions: `rankCell()`, `gapCell()`, `pctCell()` for consistent cell formatting
- Implemented structured rendering of `ValuePriorityRankingItem`, `SharedValuePriorityItem`, `CrossContextConsistencyItem`
- Fallback to placeholder rows when data is empty

**`InterestsSection.tsx`**:
- Parallel restructuring to Values with 3 sub-tables
- New sub-components: `PriorityRankingsTable`, `SharedVsConflictingTable`, `InterestValueLinkTable`
- Backward compatibility: falls back to legacy free-text fields if structured rows absent

**`CostBenefitSection.tsx`**:
- Added `impact` prop for Short-Term vs. Long-Term sub-table
- Integrated impact analysis into CBA section rather than separate top-level section

**`ObjectiveCriteriaSection.tsx`**:
- Added `currentStatus` and `thresholdForAgreement` columns per canonical template
- Simplified score display to percentage format

**`page.tsx` (belief page)**:
- Removed imports for `ImpactSection`, `MediaSection`, `FalsifiabilitySection`, `TestablePredictionsSection`
- Removed `StrengthSpectrumBar` visualization
- Simplified header to statement + score/topic line (no metadata box)
- Removed sections from render order per canonical template

### Type Definitions (`types.ts`)

Added new interfaces for structured analysis:
- `ValuePriorityRankingItem`: value, ranks per side, self-reported %, confidence, source
- `SharedValuePriorityItem`: shared value with per-side priority context
- `CrossContextConsistencyItem`: value deprioritized here, where defended elsewhere, hypocrisy flag
- `InterestPriority

https://claude.ai/code/session_01KJzrx9Fprfn2bLaCHVfmEh