### PR TITLE
Add interactive play-money prediction markets (/markets)

### DIFF
--- a/src/app/markets/[contractId]/MarketTrade.tsx
+++ b/src/app/markets/[contractId]/MarketTrade.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import { useState, useSyncExternalStore } from 'react';
+import {
+  type LmsrState,
+  type Side,
+  applyTrade,
+  avgPricePerShare,
+  costToBuy,
+  priceFor,
+  priceYes,
+} from '@/lib/markets/lmsr';
+
+interface PortfolioEntry {
+  /** Total YES shares held on this contract. */
+  yes: number;
+  /** Total NO shares held. */
+  no: number;
+  /** Cost-basis dollars for the YES position. */
+  yesCostBasis: number;
+  /** Cost-basis dollars for the NO position. */
+  noCostBasis: number;
+  /** AMM state shifted by this user's local trades. */
+  state: LmsrState;
+}
+
+interface SavedPortfolio {
+  cash: number;
+  positions: Record<string, PortfolioEntry>;
+}
+
+const STORAGE_KEY = 'ise:markets:portfolio:v1';
+const STARTING_CASH = 1000;
+const EMPTY_PORTFOLIO: SavedPortfolio = { cash: STARTING_CASH, positions: {} };
+
+let cachedSnapshot: SavedPortfolio = EMPTY_PORTFOLIO;
+const subscribers = new Set<() => void>();
+
+function readFromStorage(): SavedPortfolio {
+  if (typeof window === 'undefined') return EMPTY_PORTFOLIO;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY_PORTFOLIO;
+    const parsed = JSON.parse(raw) as SavedPortfolio;
+    if (typeof parsed.cash !== 'number' || !parsed.positions) {
+      return EMPTY_PORTFOLIO;
+    }
+    return parsed;
+  } catch {
+    return EMPTY_PORTFOLIO;
+  }
+}
+
+function subscribe(cb: () => void): () => void {
+  if (subscribers.size === 0 && typeof window !== 'undefined') {
+    cachedSnapshot = readFromStorage();
+  }
+  subscribers.add(cb);
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) {
+      cachedSnapshot = readFromStorage();
+      subscribers.forEach((s) => s());
+    }
+  };
+  if (typeof window !== 'undefined') {
+    window.addEventListener('storage', onStorage);
+  }
+  return () => {
+    subscribers.delete(cb);
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('storage', onStorage);
+    }
+  };
+}
+
+function getSnapshot(): SavedPortfolio {
+  return cachedSnapshot;
+}
+
+function getServerSnapshot(): SavedPortfolio {
+  return EMPTY_PORTFOLIO;
+}
+
+function savePortfolio(p: SavedPortfolio) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(p));
+  cachedSnapshot = p;
+  subscribers.forEach((s) => s());
+}
+
+function formatMoney(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+function formatCents(p: number): string {
+  return `${(p * 100).toFixed(1)}¢`;
+}
+
+interface Props {
+  contractId: string;
+  initialState: LmsrState;
+  threshold: number;
+  direction: 'ABOVE' | 'BELOW';
+  currentScore: number;
+}
+
+export default function MarketTrade({
+  contractId,
+  initialState,
+  threshold,
+  direction,
+  currentScore,
+}: Props) {
+  const portfolio = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const [side, setSide] = useState<Side>('YES');
+  const [shareInput, setShareInput] = useState('10');
+  const [flash, setFlash] = useState<string | null>(null);
+
+  const entry: PortfolioEntry = portfolio.positions[contractId] ?? {
+    yes: 0,
+    no: 0,
+    yesCostBasis: 0,
+    noCostBasis: 0,
+    state: initialState,
+  };
+
+  const state = entry.state;
+  const shares = Math.max(0, Number(shareInput) || 0);
+
+  const marginalYes = priceYes(state);
+  const marginalSide = priceFor(state, side);
+  const quoteCost = costToBuy(state, side, shares);
+  const quoteAvg = shares > 0 ? avgPricePerShare(state, side, shares) : marginalSide;
+
+  const insufficientCash = quoteCost > portfolio.cash + 1e-9;
+  const canBuy = shares > 0 && !insufficientCash;
+
+  function handleBuy() {
+    if (!canBuy) return;
+    const newState = applyTrade(state, side, shares);
+    const next: SavedPortfolio = {
+      cash: portfolio.cash - quoteCost,
+      positions: {
+        ...portfolio.positions,
+        [contractId]: {
+          yes: side === 'YES' ? entry.yes + shares : entry.yes,
+          no: side === 'NO' ? entry.no + shares : entry.no,
+          yesCostBasis:
+            side === 'YES' ? entry.yesCostBasis + quoteCost : entry.yesCostBasis,
+          noCostBasis:
+            side === 'NO' ? entry.noCostBasis + quoteCost : entry.noCostBasis,
+          state: newState,
+        },
+      },
+    };
+    savePortfolio(next);
+    setFlash(`Bought ${shares} ${side} for ${formatMoney(quoteCost)}`);
+    setTimeout(() => setFlash(null), 2500);
+  }
+
+  function handleResetAccount() {
+    if (
+      typeof window !== 'undefined' &&
+      !window.confirm('Reset cash to $1,000 and clear all positions?')
+    ) {
+      return;
+    }
+    savePortfolio({ cash: STARTING_CASH, positions: {} });
+    setFlash('Account reset.');
+    setTimeout(() => setFlash(null), 2000);
+  }
+
+  // Settlement-value preview: if the live score were to settle YES today,
+  // what would this user pocket?
+  const liveResolvesYes =
+    direction === 'ABOVE' ? currentScore > threshold : currentScore < threshold;
+  const settlementValueIfNow = liveResolvesYes ? entry.yes : entry.no;
+  const totalCostBasis = entry.yesCostBasis + entry.noCostBasis;
+  const unrealizedPnL = entry.yes * marginalYes + entry.no * (1 - marginalYes) - totalCostBasis;
+
+  return (
+    <div className="space-y-6">
+      <PriceHeader state={state} />
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="md:col-span-2 border border-gray-200 rounded-lg p-5">
+          <div className="flex gap-2 mb-4">
+            <button
+              type="button"
+              onClick={() => setSide('YES')}
+              className={`flex-1 py-2 px-4 rounded font-medium transition-colors ${
+                side === 'YES'
+                  ? 'bg-green-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              }`}
+            >
+              Buy YES @ {formatCents(marginalYes)}
+            </button>
+            <button
+              type="button"
+              onClick={() => setSide('NO')}
+              className={`flex-1 py-2 px-4 rounded font-medium transition-colors ${
+                side === 'NO'
+                  ? 'bg-red-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              }`}
+            >
+              Buy NO @ {formatCents(1 - marginalYes)}
+            </button>
+          </div>
+
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700">Shares</span>
+            <div className="flex gap-2 mt-1">
+              <input
+                type="number"
+                min={0}
+                step={1}
+                value={shareInput}
+                onChange={(e) => setShareInput(e.target.value)}
+                className="flex-1 border border-gray-300 rounded px-3 py-2 font-mono text-right"
+              />
+              {[10, 25, 100].map((n) => (
+                <button
+                  type="button"
+                  key={n}
+                  onClick={() => setShareInput(String(n))}
+                  className="px-3 py-2 text-sm border border-gray-300 rounded hover:bg-gray-50"
+                >
+                  {n}
+                </button>
+              ))}
+            </div>
+          </label>
+
+          <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+            <Stat label="Avg price / share" value={formatCents(quoteAvg)} />
+            <Stat label="Total cost" value={formatMoney(quoteCost)} />
+            <Stat
+              label="Max payout if won"
+              value={formatMoney(shares * 1)}
+              hint="$1.00 per winning share"
+            />
+            <Stat
+              label="Profit if won"
+              value={formatMoney(shares * 1 - quoteCost)}
+              hint={
+                shares > 0
+                  ? `${(((shares * 1 - quoteCost) / quoteCost) * 100).toFixed(0)}% return`
+                  : '—'
+              }
+            />
+          </div>
+
+          {insufficientCash && (
+            <p className="mt-3 text-sm text-red-600">
+              Not enough play money. You have {formatMoney(portfolio.cash)};
+              this trade costs {formatMoney(quoteCost)}.
+            </p>
+          )}
+
+          <button
+            type="button"
+            onClick={handleBuy}
+            disabled={!canBuy}
+            className={`mt-4 w-full py-3 rounded font-semibold text-white transition-colors ${
+              canBuy
+                ? side === 'YES'
+                  ? 'bg-green-600 hover:bg-green-700'
+                  : 'bg-red-600 hover:bg-red-700'
+                : 'bg-gray-400 cursor-not-allowed'
+            }`}
+          >
+            {`Buy ${shares} ${side} for ${formatMoney(quoteCost)}`}
+          </button>
+
+          {flash && (
+            <p className="mt-3 text-sm text-green-700 font-medium">{flash}</p>
+          )}
+        </div>
+
+        <div className="border border-gray-200 rounded-lg p-5 bg-gray-50">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="font-semibold">Your account</h3>
+            <button
+              type="button"
+              onClick={handleResetAccount}
+              className="text-xs text-gray-500 hover:text-red-600 hover:underline"
+            >
+              Reset
+            </button>
+          </div>
+          <Stat
+            label="Play-money cash"
+            value={formatMoney(portfolio.cash)}
+          />
+          <div className="mt-4 space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span className="text-gray-600">YES shares on this market</span>
+              <span className="font-mono">{entry.yes.toFixed(0)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-600">NO shares on this market</span>
+              <span className="font-mono">{entry.no.toFixed(0)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-600">Cost basis</span>
+              <span className="font-mono">{formatMoney(totalCostBasis)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-600">Unrealized P/L</span>
+              <span
+                className={`font-mono ${unrealizedPnL >= 0 ? 'text-green-700' : 'text-red-700'}`}
+              >
+                {unrealizedPnL >= 0 ? '+' : ''}
+                {formatMoney(unrealizedPnL)}
+              </span>
+            </div>
+          </div>
+          <div className="mt-4 pt-3 border-t border-gray-200 text-xs text-gray-500">
+            <p className="mb-1">
+              If the contract settled <strong>now</strong> (live score{' '}
+              {(currentScore * 100).toFixed(0)}%), you&apos;d receive{' '}
+              <strong>{formatMoney(settlementValueIfNow)}</strong>.
+            </p>
+            <p>Positions saved to this browser only.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PriceHeader({ state }: { state: LmsrState }) {
+  const py = priceYes(state);
+  return (
+    <div className="border border-gray-200 rounded-lg p-5 bg-gradient-to-r from-green-50 via-white to-red-50">
+      <div className="flex items-end justify-between gap-4">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">
+            Implied YES probability
+          </div>
+          <div className="text-4xl font-bold text-gray-900 leading-none">
+            {(py * 100).toFixed(1)}%
+          </div>
+          <div className="text-sm text-gray-600 mt-1">
+            YES <span className="font-mono">{formatCents(py)}</span>
+            {' · '}
+            NO <span className="font-mono">{formatCents(1 - py)}</span>
+          </div>
+        </div>
+        <div className="text-right text-xs text-gray-500">
+          <div>
+            Inventory{' '}
+            <span className="font-mono text-gray-700">
+              q_yes={state.qYes.toFixed(0)} · q_no={state.qNo.toFixed(0)}
+            </span>
+          </div>
+          <div>
+            Liquidity{' '}
+            <span className="font-mono text-gray-700">b={state.b}</span>
+          </div>
+        </div>
+      </div>
+      <div className="flex h-2 w-full overflow-hidden rounded-full bg-gray-200 mt-4">
+        <div className="bg-green-500" style={{ width: `${py * 100}%` }} />
+        <div className="bg-red-400" style={{ width: `${(1 - py) * 100}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div>
+      <div className="text-xs uppercase tracking-wide text-gray-500">
+        {label}
+      </div>
+      <div className="text-lg font-semibold text-gray-900">{value}</div>
+      {hint && <div className="text-xs text-gray-500">{hint}</div>}
+    </div>
+  );
+}

--- a/src/app/markets/[contractId]/page.tsx
+++ b/src/app/markets/[contractId]/page.tsx
@@ -1,0 +1,123 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import {
+  getContract,
+  formatResolutionLabel,
+  formatThresholdLabel,
+} from '@/lib/markets/contracts';
+import MarketTrade from './MarketTrade';
+
+interface PageProps {
+  params: Promise<{ contractId: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { contractId } = await params;
+  const c = getContract(contractId);
+  if (!c) return { title: 'Market not found' };
+  return {
+    title: `${c.beliefStatement} — Market — Idea Stock Exchange`,
+    description: `Buy YES/NO on whether the belief score is ${formatThresholdLabel(c)} at ${formatResolutionLabel(c)}.`,
+  };
+}
+
+export default async function MarketDetailPage({ params }: PageProps) {
+  const { contractId } = await params;
+  const contract = getContract(contractId);
+  if (!contract) notFound();
+
+  return (
+    <main className="max-w-[960px] mx-auto px-4 py-8 text-[#222]">
+      <p className="text-right text-sm italic text-gray-600 mb-6">
+        <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+        {' > '}
+        <Link href="/markets" className="text-blue-700 hover:underline">Markets</Link>
+        {' > '}
+        <strong className="truncate">{contract.beliefStatement.slice(0, 60)}…</strong>
+      </p>
+
+      <div className="text-xs text-gray-500 mb-2">
+        <span className="font-medium">{contract.category}</span>
+        {' • '}
+        <span>Resolves {formatResolutionLabel(contract)}</span>
+        {' • '}
+        <span className="font-mono">{contract.id}</span>
+      </div>
+
+      <h1 className="text-2xl font-bold mb-2 leading-tight">
+        {contract.beliefStatement}
+      </h1>
+      <p className="text-lg text-gray-700 mb-6">
+        Will <strong>{formatThresholdLabel(contract)}</strong> at epoch end
+        ({formatResolutionLabel(contract)})?
+      </p>
+
+      <MarketTrade
+        contractId={contract.id}
+        initialState={contract.state}
+        threshold={contract.threshold}
+        direction={contract.direction}
+        currentScore={contract.currentScore}
+      />
+
+      <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="border border-gray-200 rounded-lg p-4">
+          <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">
+            Live belief score
+          </div>
+          <div className="text-3xl font-bold text-gray-900">
+            {(contract.currentScore * 100).toFixed(0)}%
+          </div>
+          <p className="text-sm text-gray-600 mt-2">
+            Computed by the ReasonRank engine from the current argument
+            graph. The market is betting on what this number will be at{' '}
+            {formatResolutionLabel(contract)}.
+          </p>
+          <Link
+            href={`/beliefs/${contract.beliefSlug}`}
+            className="inline-block mt-3 text-sm text-blue-700 hover:underline"
+          >
+            Open the belief page →
+          </Link>
+        </div>
+
+        <div className="border border-gray-200 rounded-lg p-4">
+          <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">
+            Settlement rule
+          </div>
+          <p className="text-sm text-gray-800">
+            <strong>YES</strong> wins if the live score is{' '}
+            <strong>{contract.direction === 'ABOVE' ? 'above' : 'below'}</strong>{' '}
+            <strong>{(contract.threshold * 100).toFixed(0)}%</strong> at{' '}
+            {formatResolutionLabel(contract)}. Strict inequality — ties
+            resolve NO.
+          </p>
+          <p className="text-xs text-gray-500 mt-2 italic">
+            The graph freezes for 20 minutes around each epoch boundary so
+            no last-minute edits flip outcomes.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 bg-gray-50 border border-gray-200 rounded-lg p-4 text-sm text-gray-700">
+        <p className="mb-1">
+          <strong>Want to move the price?</strong> Don&apos;t out-bid the AMM —
+          go improve the underlying argument graph. Better arguments,
+          better evidence, tighter linkages all show up in the next
+          snapshot.
+        </p>
+        <p>
+          Read{' '}
+          <Link
+            href="/prediction-markets-comparison"
+            className="text-blue-700 hover:underline"
+          >
+            the engineering spec
+          </Link>{' '}
+          for the full settlement mechanics.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -1,0 +1,129 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import {
+  FEATURED_CONTRACTS,
+  formatResolutionLabel,
+  formatThresholdLabel,
+} from '@/lib/markets/contracts';
+import { priceYes } from '@/lib/markets/lmsr';
+
+export const metadata: Metadata = {
+  title: 'Prediction Markets — Idea Stock Exchange',
+  description:
+    'Buy YES/NO shares on the future ReasonRank score of belief pages. Play money. Settles against the live argument graph at the end of each month.',
+};
+
+function PriceBar({ priceYes }: { priceYes: number }) {
+  const pctYes = Math.round(priceYes * 100);
+  return (
+    <div className="flex h-2 w-full overflow-hidden rounded-full bg-gray-200">
+      <div className="bg-green-500" style={{ width: `${pctYes}%` }} />
+      <div className="bg-red-400" style={{ width: `${100 - pctYes}%` }} />
+    </div>
+  );
+}
+
+export default function MarketsIndexPage() {
+  const rows = FEATURED_CONTRACTS.map((c) => {
+    const py = priceYes(c.state);
+    return { contract: c, py };
+  });
+
+  return (
+    <main className="max-w-[960px] mx-auto px-4 py-8 text-[#222]">
+      <p className="text-right text-sm italic text-gray-600 mb-6">
+        <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+        {' > '}
+        <strong>Markets</strong>
+      </p>
+
+      <h1 className="text-3xl font-bold mb-2">Prediction Markets</h1>
+      <p className="text-lg text-gray-600 mb-4">
+        Buy YES or NO on the future ReasonRank score of a belief.
+      </p>
+
+      <div className="bg-amber-50 border-l-4 border-amber-500 p-4 mb-6 rounded text-sm">
+        <p className="mb-1">
+          <strong>Play money.</strong> Every account starts with{' '}
+          <span className="font-mono">$1,000</span>. Positions are stored
+          locally in your browser, and prices are quoted by an LMSR market
+          maker (<InlineLink href="/prediction-markets-comparison" />).
+        </p>
+        <p>
+          Markets settle against{' '}
+          <code className="font-mono text-xs bg-amber-100 px-1 rounded">
+            EpochSnapshot.truth_score
+          </code>{' '}
+          on the resolution date. Move the score by posting better arguments
+          on the belief page — not by trading.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {rows.map(({ contract: c, py }) => {
+          const yesPct = (py * 100).toFixed(0);
+          const noPct = ((1 - py) * 100).toFixed(0);
+          return (
+            <Link
+              key={c.id}
+              href={`/markets/${c.id}`}
+              className="block border border-gray-200 rounded-lg p-5 hover:border-blue-400 hover:bg-gray-50 transition-colors"
+            >
+              <div className="flex items-start justify-between gap-4 mb-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 text-xs text-gray-500 mb-1">
+                    <span className="font-medium">{c.category}</span>
+                    <span>•</span>
+                    <span>Resolves {formatResolutionLabel(c)}</span>
+                  </div>
+                  <h2 className="font-semibold text-lg leading-snug mb-1">
+                    {c.beliefStatement}
+                  </h2>
+                  <p className="text-sm text-gray-600 mb-1">
+                    Will <strong>{formatThresholdLabel(c)}</strong> at epoch
+                    end? Current live score:{' '}
+                    <span className="font-mono">
+                      {(c.currentScore * 100).toFixed(0)}%
+                    </span>
+                  </p>
+                  <p className="text-sm text-gray-500 italic">{c.blurb}</p>
+                </div>
+
+                <div className="flex-shrink-0 text-right min-w-[120px]">
+                  <div className="text-2xl font-bold text-green-700 leading-none">
+                    {yesPct}¢
+                  </div>
+                  <div className="text-xs text-gray-500 mb-2">YES price</div>
+                  <div className="text-sm text-red-600">{noPct}¢ NO</div>
+                </div>
+              </div>
+
+              <PriceBar priceYes={py} />
+            </Link>
+          );
+        })}
+      </div>
+
+      <div className="mt-10 pt-6 border-t border-gray-200 text-sm text-gray-600">
+        <p>
+          See the full mechanics in the{' '}
+          <Link
+            href="/prediction-markets-comparison"
+            className="text-blue-700 hover:underline"
+          >
+            Prediction Market Layer engineering spec
+          </Link>
+          .
+        </p>
+      </div>
+    </main>
+  );
+}
+
+function InlineLink({ href }: { href: string }) {
+  return (
+    <Link href={href} className="text-blue-700 hover:underline">
+      see the spec
+    </Link>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -510,6 +510,60 @@ export default function Home() {
           </div>
         </section>
 
+        {/* Prediction Markets */}
+        <section className="mb-16">
+          <h2 className="text-3xl font-bold mb-6">
+            Prediction Markets on Belief Scores
+          </h2>
+          <p className="text-lg text-[var(--muted-foreground)] mb-8">
+            Buy YES or NO shares on what the ReasonRank score of a belief
+            will be at the end of the month. The only way to move the price
+            is to post better arguments &mdash; this is a prediction market
+            and a reasoning platform at the same time. Play money for now;
+            real money once the mechanics are proven.
+          </p>
+
+          <div className="grid gap-6 md:grid-cols-3 mb-8">
+            <div className="p-4 border border-[var(--border)] rounded-lg">
+              <h3 className="font-semibold mb-2">Settles On the Score</h3>
+              <p className="text-sm text-[var(--muted-foreground)]">
+                Each contract pays $1 if the live belief score crosses its
+                threshold at the snapshot epoch. No external oracle.
+              </p>
+            </div>
+            <div className="p-4 border border-[var(--border)] rounded-lg">
+              <h3 className="font-semibold mb-2">LMSR Pricing</h3>
+              <p className="text-sm text-[var(--muted-foreground)]">
+                Continuous liquidity from day one. The market quotes a price
+                even when only a handful of traders have shown up.
+              </p>
+            </div>
+            <div className="p-4 border border-[var(--border)] rounded-lg">
+              <h3 className="font-semibold mb-2">Skin In the Argument</h3>
+              <p className="text-sm text-[var(--muted-foreground)]">
+                Want to win? Improve the underlying argument graph. Brigading
+                with low-quality reasons gets compressed and down-weighted
+                automatically.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex gap-4 flex-wrap">
+            <Link
+              href="/markets"
+              className="inline-block bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white px-6 py-3 rounded-lg font-medium transition-colors"
+            >
+              Browse Markets
+            </Link>
+            <Link
+              href="/prediction-markets-comparison"
+              className="inline-block border border-[var(--border)] hover:border-[var(--accent)] px-6 py-3 rounded-lg font-medium transition-colors"
+            >
+              How It Compares to Polymarket
+            </Link>
+          </div>
+        </section>
+
         {/* Get Started */}
         <section className="bg-gradient-to-r from-[var(--accent)]/10 to-[var(--accent)]/5 p-12 rounded-lg text-center">
           <h2 className="text-3xl font-bold mb-4">
@@ -564,6 +618,7 @@ export default function Home() {
                 <li><Link href="/product-reviews" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Product Reviews</Link></li>
                 <li><Link href="/cba" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Cost-Benefit Analysis</Link></li>
                 <li><Link href="/laws" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Browse Laws</Link></li>
+                <li><Link href="/markets" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Prediction Markets</Link></li>
                 <li><Link href="/prediction-markets-comparison" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Idea Stock Exchange vs Polymarket</Link></li>
                 <li><Link href="/faq" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">FAQ &amp; Criticisms</Link></li>
                 <li><a href="https://github.com/myklob/ideastockexchange/wiki" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]" target="_blank" rel="noopener noreferrer">Framework Wiki</a></li>

--- a/src/app/prediction-markets-comparison/page.tsx
+++ b/src/app/prediction-markets-comparison/page.tsx
@@ -49,8 +49,16 @@ export default function PredictionMarketsComparisonPage() {
       <h1 className="text-3xl font-bold mb-3 leading-tight">
         Idea Stock Exchange vs Other Prediction Markets Like Polymarket
       </h1>
-      <p className="text-lg text-gray-600 mb-6">
+      <p className="text-lg text-gray-600 mb-4">
         Prediction Market Layer: Engineering Specification
+      </p>
+      <p className="mb-6">
+        <Link
+          href="/markets"
+          className="inline-block bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded font-medium text-sm"
+        >
+          → Browse the live play-money markets
+        </Link>
       </p>
 
       <Callout>

--- a/src/lib/markets/contracts.ts
+++ b/src/lib/markets/contracts.ts
@@ -1,0 +1,162 @@
+import type { LmsrState } from './lmsr';
+
+/**
+ * Featured prediction-market contracts. Each contract is a binary
+ * claim about a belief's future ReasonRank score at a snapshot epoch.
+ *
+ * `currentScore` is the live belief score (0-1) at the time we wrote
+ * this list — used as a reference value next to the threshold so users
+ * can see how far the market is betting from "right now."
+ *
+ * `state` is the initial LMSR inventory. We seed slightly off 50/50
+ * for some markets so the prices reflect the consensus we'd expect.
+ */
+export interface FeaturedContract {
+  id: string;
+  beliefSlug: string;
+  beliefStatement: string;
+  category: string;
+  threshold: number;
+  direction: 'ABOVE' | 'BELOW';
+  resolutionEpoch: string;
+  currentScore: number;
+  state: LmsrState;
+  /** Why this market exists / what makes it interesting. */
+  blurb: string;
+}
+
+const NEXT_EPOCH = '2026-05-31';
+const NEXT_QUARTER_EPOCH = '2026-07-31';
+const YEAR_END_EPOCH = '2026-12-31';
+
+export const FEATURED_CONTRACTS: FeaturedContract[] = [
+  {
+    id: 'ubi-above-50-2026-05',
+    beliefSlug: 'universal-basic-income-should-be-implemented',
+    beliefStatement:
+      'Universal Basic Income should be implemented in developed nations',
+    category: 'Economics',
+    threshold: 0.5,
+    direction: 'ABOVE',
+    resolutionEpoch: NEXT_EPOCH,
+    currentScore: 0.42,
+    state: { qYes: 60, qNo: 100, b: 100 },
+    blurb:
+      'The flagship UBI debate. Will the argument graph cross majority support by month-end?',
+  },
+  {
+    id: 'automation-above-70-2026-07',
+    beliefSlug: 'automation-will-displace-workers',
+    beliefStatement:
+      'Automation and AI will displace a significant portion of the workforce',
+    category: 'Technology',
+    threshold: 0.7,
+    direction: 'ABOVE',
+    resolutionEpoch: NEXT_QUARTER_EPOCH,
+    currentScore: 0.66,
+    state: { qYes: 140, qNo: 80, b: 100 },
+    blurb:
+      'Already trending up — the market thinks the score will keep climbing through Q3.',
+  },
+  {
+    id: 'inflation-below-40-2026-05',
+    beliefSlug: 'ubi-causes-inflation',
+    beliefStatement:
+      'UBI would cause significant inflation, negating its benefits',
+    category: 'Economics',
+    threshold: 0.4,
+    direction: 'BELOW',
+    resolutionEpoch: NEXT_EPOCH,
+    currentScore: 0.36,
+    state: { qYes: 110, qNo: 70, b: 100 },
+    blurb:
+      'The classic UBI counterargument. YES wins if the inflation belief stays under 40% next epoch.',
+  },
+  {
+    id: 'work-incentive-above-55-2026-07',
+    beliefSlug: 'ubi-reduces-work-incentive',
+    beliefStatement:
+      'Guaranteed income would significantly reduce the incentive to work',
+    category: 'Economics',
+    threshold: 0.55,
+    direction: 'ABOVE',
+    resolutionEpoch: NEXT_QUARTER_EPOCH,
+    currentScore: 0.31,
+    state: { qYes: 45, qNo: 130, b: 100 },
+    blurb:
+      'Long-shot YES bet — needs new evidence to land in the next two months.',
+  },
+  {
+    id: 'poverty-above-85-2026-12',
+    beliefSlug: 'poverty-reduction-improves-society',
+    beliefStatement:
+      'Reducing poverty improves societal outcomes across all dimensions',
+    category: 'Social Science',
+    threshold: 0.85,
+    direction: 'ABOVE',
+    resolutionEpoch: YEAR_END_EPOCH,
+    currentScore: 0.83,
+    state: { qYes: 130, qNo: 60, b: 120 },
+    blurb:
+      'Already near-consensus. Will it nudge over 85% by year end?',
+  },
+  {
+    id: 'free-markets-above-50-2026-07',
+    beliefSlug: 'free-markets-allocate-best',
+    beliefStatement:
+      'Free markets allocate resources more efficiently than government programs',
+    category: 'Economics',
+    threshold: 0.5,
+    direction: 'ABOVE',
+    resolutionEpoch: NEXT_QUARTER_EPOCH,
+    currentScore: 0.49,
+    state: { qYes: 100, qNo: 100, b: 100 },
+    blurb:
+      'Pure coin-flip. The market starts at 50/50 — pick your side and find evidence.',
+  },
+  {
+    id: 'falc-below-25-2026-12',
+    beliefSlug: 'fully-automated-luxury-communism',
+    beliefStatement:
+      'Society should transition to fully automated luxury communism',
+    category: 'Political Economy',
+    threshold: 0.25,
+    direction: 'BELOW',
+    resolutionEpoch: YEAR_END_EPOCH,
+    currentScore: 0.18,
+    state: { qYes: 150, qNo: 50, b: 100 },
+    blurb: 'Entertainment market. The crowd thinks FALC stays niche.',
+  },
+  {
+    id: 'nit-above-40-2026-07',
+    beliefSlug: 'negative-income-tax',
+    beliefStatement:
+      'A negative income tax would be a better approach than UBI',
+    category: 'Economics',
+    threshold: 0.4,
+    direction: 'ABOVE',
+    resolutionEpoch: NEXT_QUARTER_EPOCH,
+    currentScore: 0.38,
+    state: { qYes: 95, qNo: 110, b: 100 },
+    blurb:
+      'NIT vs UBI — sleeper market. A few good Friedman citations could move it.',
+  },
+];
+
+export function getContract(id: string): FeaturedContract | undefined {
+  return FEATURED_CONTRACTS.find((c) => c.id === id);
+}
+
+export function formatThresholdLabel(c: FeaturedContract): string {
+  const op = c.direction === 'ABOVE' ? '>' : '<';
+  return `score ${op} ${(c.threshold * 100).toFixed(0)}%`;
+}
+
+export function formatResolutionLabel(c: FeaturedContract): string {
+  const d = new Date(c.resolutionEpoch);
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/src/lib/markets/lmsr.ts
+++ b/src/lib/markets/lmsr.ts
@@ -1,0 +1,77 @@
+/**
+ * Logarithmic Market Scoring Rule helpers.
+ *
+ * See /prediction-markets-comparison for the spec these match.
+ *
+ *   C(q_yes, q_no) = b * ln( exp(q_yes / b) + exp(q_no / b) )
+ *   P_yes          = exp(q_yes / b) / ( exp(q_yes / b) + exp(q_no / b) )
+ *   cost(buy n YES at state q) = C(q_yes + n, q_no) - C(q_yes, q_no)
+ *
+ * The naive form overflows once q/b grows past ~700. We use the
+ * log-sum-exp trick so the math stays numerically stable for any
+ * realistic inventory.
+ */
+
+export interface LmsrState {
+  qYes: number;
+  qNo: number;
+  /** Liquidity parameter — larger = flatter prices, more subsidy cost. */
+  b: number;
+}
+
+export type Side = 'YES' | 'NO';
+
+function logSumExp(a: number, b: number): number {
+  const m = Math.max(a, b);
+  return m + Math.log(Math.exp(a - m) + Math.exp(b - m));
+}
+
+export function cost({ qYes, qNo, b }: LmsrState): number {
+  return b * logSumExp(qYes / b, qNo / b);
+}
+
+export function priceYes({ qYes, qNo, b }: LmsrState): number {
+  const a = qYes / b;
+  const c = qNo / b;
+  const m = Math.max(a, c);
+  const expA = Math.exp(a - m);
+  const expC = Math.exp(c - m);
+  return expA / (expA + expC);
+}
+
+export function priceNo(state: LmsrState): number {
+  return 1 - priceYes(state);
+}
+
+export function priceFor(state: LmsrState, side: Side): number {
+  return side === 'YES' ? priceYes(state) : priceNo(state);
+}
+
+/**
+ * Cost in play-money dollars to buy `shares` of the given side at the
+ * current state. Returns a positive number (what you pay).
+ */
+export function costToBuy(state: LmsrState, side: Side, shares: number): number {
+  if (shares <= 0) return 0;
+  const before = cost(state);
+  const after = cost(applyTrade(state, side, shares));
+  return after - before;
+}
+
+/** Returns a NEW state after buying `shares` of the given side. */
+export function applyTrade(state: LmsrState, side: Side, shares: number): LmsrState {
+  if (side === 'YES') {
+    return { ...state, qYes: state.qYes + shares };
+  }
+  return { ...state, qNo: state.qNo + shares };
+}
+
+/**
+ * Average effective price per share for a buy of `shares`. Always >=
+ * the marginal price, because LMSR slippage moves the price against
+ * the buyer.
+ */
+export function avgPricePerShare(state: LmsrState, side: Side, shares: number): number {
+  if (shares <= 0) return priceFor(state, side);
+  return costToBuy(state, side, shares) / shares;
+}


### PR DESCRIPTION
## Summary

Builds on PR #107 (the spec page) and makes it playable. Users can now actually buy YES/NO shares on the future ReasonRank score of featured beliefs.

- `/markets` — index of 8 featured contracts on real seeded beliefs (UBI, automation, free markets, FALC, NIT, etc.) with live LMSR-quoted YES/NO prices and visual price bars.
- `/markets/[contractId]` — full trade UI: implied YES probability header, Buy YES / Buy NO toggle with shortcut buttons (10 / 25 / 100), live cost + average-price quote (LMSR slippage included), per-market position tracking, cost basis, unrealized P/L, and an "if it settled now" payout preview against the live belief score.
- $1,000 starting cash per browser, persisted in `localStorage` via `useSyncExternalStore` (compatible with React 19's compiler — no `useEffect` / setState cascade warning).
- LMSR math in `src/lib/markets/lmsr.ts` uses the log-sum-exp trick so prices stay numerically stable for any realistic inventory.
- Linked from the home page (new section + footer) and from the top of the `/prediction-markets-comparison` spec page.

## Implementation notes

- **No DB writes yet.** Positions are browser-local; the AMM state is per-browser. When this goes multi-user, swap the `useSyncExternalStore` store for `POST /api/markets/[id]/trade` backed by the `Contract` and `Position` tables described in the spec.
- **Settlement isn't wired up** — the UI shows the rule and a hypothetical "if it settled now" payout, but no `EpochSnapshot` cron exists. That's the next chunk.
- Featured contracts are defined statically in `src/lib/markets/contracts.ts` referencing belief slugs from `prisma/seed-beliefs.ts`.

## Files

- `src/lib/markets/lmsr.ts`, `src/lib/markets/contracts.ts`
- `src/app/markets/page.tsx`, `src/app/markets/[contractId]/page.tsx`, `src/app/markets/[contractId]/MarketTrade.tsx`
- `src/app/page.tsx` (new prediction-markets section + footer link)
- `src/app/prediction-markets-comparison/page.tsx` (added "Browse the live play-money markets" CTA)

## Test plan

- [ ] Visit `/markets` — 8 contracts render with green/red price bars and YES prices in cents
- [ ] Click into a market (e.g. `/markets/free-markets-above-50-2026-07`, the 50/50 coin-flip)
- [ ] Toggle YES ↔ NO; the implied probability and cost both flip symmetrically
- [ ] Buy 10 YES — cash decreases, YES share count increases, cost basis updates
- [ ] Buy 100 more YES on the same market — verify the implied probability shifts visibly (slippage works)
- [ ] Refresh the page — cash and positions persist
- [ ] Try to buy more shares than you can afford — button disables and a "Not enough play money" warning appears
- [ ] Click "Reset" in the account panel — confirms, then resets to $1,000 with no positions
- [ ] Home page → footer Resources lists "Prediction Markets"
- [ ] Home page → new "Prediction Markets on Belief Scores" section above the Get Started CTA
- [ ] `/prediction-markets-comparison` shows the new "Browse the live play-money markets" button at the top
- [ ] `npx tsc --noEmit` clean for files in this PR (the ~50 pre-existing implicit-any errors elsewhere are unrelated — see CLAUDE.md)
- [ ] `npx eslint <touched files>` clean
- [ ] `npm run build` compiles successfully (the prerender errors on `/debate-topics/new` and `/beliefs` are pre-existing — `/beliefs` needs `npm run db:seed`, `/debate-topics/new` needs a Suspense boundary)

https://claude.ai/code/session_01KKWPJoQgoEDajCkV9QdkTU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKWPJoQgoEDajCkV9QdkTU)_