### PR TITLE
Spectrum query API and navigation surface per One-Page-Per-Belief tech spec

### DIFF
--- a/prisma/seed-beliefs.ts
+++ b/prisma/seed-beliefs.ts
@@ -148,6 +148,39 @@ async function main() {
     },
   })
 
+  // Downstream conclusions: more specific beliefs that follow if the main belief is true.
+  // These exist so the propagation cascade in src/lib/propagate-belief-scores.ts has
+  // something to traverse on the seeded UBI page.
+  const ubiFundingBelief = await prisma.belief.upsert({
+    where: { slug: 'ubi-should-be-funded-by-vat' },
+    update: {},
+    create: {
+      slug: 'ubi-should-be-funded-by-vat',
+      statement: 'UBI should be funded primarily through a value-added tax',
+      category: 'Economics',
+      subcategory: 'Tax Policy',
+      deweyNumber: '336.27',
+      positivity: 30,
+      specificity: 0.85,
+      claimStrength: 0.6,
+    },
+  })
+
+  const ubiAmountBelief = await prisma.belief.upsert({
+    where: { slug: 'ubi-should-equal-poverty-line' },
+    update: {},
+    create: {
+      slug: 'ubi-should-equal-poverty-line',
+      statement: 'UBI payments should be set at the federal poverty line, not below',
+      category: 'Economics',
+      subcategory: 'Social Policy',
+      deweyNumber: '362.58',
+      positivity: 40,
+      specificity: 0.8,
+      claimStrength: 0.7,
+    },
+  })
+
   // Similar beliefs (more extreme / more moderate)
   const extremeBelief = await prisma.belief.upsert({
     where: { slug: 'fully-automated-luxury-communism' },
@@ -447,11 +480,17 @@ async function main() {
     ],
   })
 
-  // Create belief mappings (upstream = more general, downstream = more specific)
+  // Create belief mappings (upstream = more general, downstream = more specific).
+  // Upstream: foundational principles you must accept to hold mainBelief.
+  // Downstream: implementation choices that follow if mainBelief is true.
   await prisma.beliefMapping.createMany({
     data: [
+      // Upstream
       { parentBeliefId: humanDignityBelief.id, childBeliefId: mainBelief.id, direction: 'upstream', side: 'support' },
       { parentBeliefId: marketFreedomBelief.id, childBeliefId: mainBelief.id, direction: 'upstream', side: 'oppose' },
+      // Downstream
+      { parentBeliefId: mainBelief.id, childBeliefId: ubiFundingBelief.id, direction: 'downstream', side: 'support' },
+      { parentBeliefId: mainBelief.id, childBeliefId: ubiAmountBelief.id, direction: 'downstream', side: 'support' },
     ],
   })
 
@@ -465,7 +504,7 @@ async function main() {
 
   console.log('Belief analysis seed completed!')
   console.log(`Main belief: /beliefs/${mainBelief.slug}`)
-  console.log(`Total beliefs created: 11`)
+  console.log(`Total beliefs created: 13`)
 }
 
 main()

--- a/src/app/api/beliefs/[id]/route.ts
+++ b/src/app/api/beliefs/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { fetchBeliefById, computeBeliefScores } from '@/features/belief-analysis/data/fetch-belief'
+import { toSpectrumCoordinates } from '@/features/belief-analysis/spectrum-coordinates'
 
 export async function GET(
   _request: Request,
@@ -20,8 +21,33 @@ export async function GET(
 
   const scores = computeBeliefScores(belief)
 
+  // Spec shape per /One Page Per Belief: Technical Specification §1.
+  // Returned alongside the existing `belief` payload so existing consumers don't break.
+  const upstreamBeliefs = belief.upstreamMappings.map(m => String(m.parentBelief.id))
+  const downstreamBeliefs = belief.downstreamMappings.map(m => String(m.childBelief.id))
+  const linkedEvidence = belief.evidence.map(ev => ({
+    evidence_id: String(ev.id),
+    metadata: {
+      url: ev.sourceUrl ?? null,
+      tier: ev.evidenceType,
+    },
+  }))
+
   return NextResponse.json({
     belief,
     scores,
+    spec: {
+      belief_id: String(belief.id),
+      canonical_text: belief.statement,
+      spectrum_coordinates: toSpectrumCoordinates({
+        positivity: belief.positivity,
+        specificity: belief.specificity,
+        claimStrength: belief.claimStrength,
+      }),
+      parent_topic_id: belief.category ?? null,
+      linked_evidence: linkedEvidence,
+      upstream_beliefs: upstreamBeliefs,
+      downstream_beliefs: downstreamBeliefs,
+    },
   })
 }

--- a/src/app/api/beliefs/route.ts
+++ b/src/app/api/beliefs/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from 'next/server'
+import {
+  fetchFilteredBeliefs,
+  type BeliefFilterParams,
+} from '@/features/belief-analysis/data/fetch-belief'
+import {
+  toSpectrumCoordinates,
+  fromValenceCoord,
+  fromSpecificityCoord,
+  fromIntensityCoord,
+} from '@/features/belief-analysis/spectrum-coordinates'
+
+/**
+ * GET /api/beliefs
+ *
+ * The spectrum-query surface from /One Page Per Belief: Technical Specification (&sect;5).
+ *
+ * Query params (all optional; missing means "no bound on this axis"):
+ *   valenceMin, valenceMax           — integers in -5..+5
+ *   specificityMin, specificityMax   — integers in 1..10
+ *   intensityMin, intensityMax       — integers in 1..5
+ *   category                         — exact-match category string
+ *   sortBy                           — 'valence' | 'specificity' | 'intensity' | 'statement' | 'updated' (default 'valence')
+ *   sortDir                          — 'asc' | 'desc' (default 'asc' so the default sort goes negative → positive)
+ *   limit                            — max rows to return
+ *
+ * Response: { beliefs: [&lt;spec shape&gt;] } where each entry follows &sect;1 of the spec
+ * (belief_id, canonical_text, spectrum_coordinates, parent_topic_id).
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const sp = url.searchParams
+
+  const parseInt10 = (key: string): number | undefined => {
+    const raw = sp.get(key)
+    if (raw === null || raw === '') return undefined
+    const n = parseInt(raw, 10)
+    return Number.isFinite(n) ? n : undefined
+  }
+
+  const valenceMin = parseInt10('valenceMin')
+  const valenceMax = parseInt10('valenceMax')
+  const specificityMin = parseInt10('specificityMin')
+  const specificityMax = parseInt10('specificityMax')
+  const intensityMin = parseInt10('intensityMin')
+  const intensityMax = parseInt10('intensityMax')
+
+  const filters: BeliefFilterParams = {
+    ...(valenceMin !== undefined ? { positivityMin: fromValenceCoord(valenceMin) } : {}),
+    ...(valenceMax !== undefined ? { positivityMax: fromValenceCoord(valenceMax) } : {}),
+    ...(specificityMin !== undefined ? { specificityMin: fromSpecificityCoord(specificityMin) } : {}),
+    ...(specificityMax !== undefined ? { specificityMax: fromSpecificityCoord(specificityMax) } : {}),
+    ...(intensityMin !== undefined ? { claimStrengthMin: fromIntensityCoord(intensityMin) } : {}),
+    ...(intensityMax !== undefined ? { claimStrengthMax: fromIntensityCoord(intensityMax) } : {}),
+  }
+
+  const category = sp.get('category')
+  if (category) filters.category = category
+
+  const sortByMap: Record<string, BeliefFilterParams['sortBy']> = {
+    valence: 'positivity',
+    specificity: 'specificity',
+    intensity: 'claimStrength',
+    statement: 'statement',
+    updated: 'updatedAt',
+  }
+  const sortByKey = sp.get('sortBy') ?? 'valence'
+  filters.sortBy = sortByMap[sortByKey] ?? 'positivity'
+  filters.sortDir = sp.get('sortDir') === 'desc' ? 'desc' : 'asc'
+
+  const limitRaw = parseInt10('limit')
+  if (limitRaw !== undefined && limitRaw > 0) {
+    filters.limit = Math.min(limitRaw, 500)
+  }
+
+  const beliefs = await fetchFilteredBeliefs(filters)
+
+  return NextResponse.json({
+    beliefs: beliefs.map(b => ({
+      belief_id: String(b.id),
+      canonical_text: b.statement,
+      spectrum_coordinates: toSpectrumCoordinates({
+        positivity: b.positivity,
+        specificity: b.specificity,
+        claimStrength: b.claimStrength,
+      }),
+      parent_topic_id: b.category ?? null,
+      slug: b.slug,
+    })),
+    count: beliefs.length,
+  })
+}

--- a/src/app/beliefs/page.tsx
+++ b/src/app/beliefs/page.tsx
@@ -1,8 +1,114 @@
 import Link from 'next/link'
-import { fetchAllBeliefs } from '@/features/belief-analysis/data/fetch-belief'
+import {
+  fetchFilteredBeliefs,
+  fetchBeliefCategories,
+  type BeliefFilterParams,
+} from '@/features/belief-analysis/data/fetch-belief'
+import { getStrengthBand, formatStrength } from '@/core/scoring/claim-strength'
 
-export default async function BeliefsIndexPage() {
-  const beliefs = await fetchAllBeliefs()
+interface BeliefsPageSearchParams {
+  valence?: string       // 'all' | 'extreme-neg' | 'mild-neg' | 'neutral' | 'mild-pos' | 'extreme-pos'
+  specificity?: string   // 'all' | 'general' | 'case-level' | 'specific'
+  intensity?: string     // 'all' | 'weak' | 'moderate' | 'strong' | 'extreme'
+  category?: string      // 'all' | <category name>
+  sort?: string          // 'valence' | 'specificity' | 'intensity' | 'statement'
+  dir?: string           // 'asc' | 'desc'
+}
+
+interface BeliefsIndexProps {
+  searchParams: Promise<BeliefsPageSearchParams>
+}
+
+const VALENCE_BUCKETS: Record<string, { min: number; max: number; label: string }> = {
+  'extreme-neg': { min: -100, max: -60, label: 'Extremely Negative' },
+  'mild-neg':    { min: -60,  max: -20, label: 'Mildly Negative' },
+  'neutral':     { min: -20,  max:  20, label: 'Neutral' },
+  'mild-pos':    { min:  20,  max:  60, label: 'Mildly Positive' },
+  'extreme-pos': { min:  60,  max: 100, label: 'Extremely Positive' },
+}
+
+const SPECIFICITY_BUCKETS: Record<string, { min: number; max: number; label: string }> = {
+  general:      { min: 0,    max: 0.33, label: 'General Principle' },
+  'case-level': { min: 0.33, max: 0.66, label: 'Case-Level' },
+  specific:     { min: 0.66, max: 1.0,  label: 'Specific Instance' },
+}
+
+const INTENSITY_BUCKETS: Record<string, { min: number; max: number; label: string }> = {
+  weak:     { min: 0,    max: 0.35, label: 'Weak' },
+  moderate: { min: 0.35, max: 0.65, label: 'Moderate' },
+  strong:   { min: 0.65, max: 0.9,  label: 'Strong' },
+  extreme:  { min: 0.9,  max: 1.0,  label: 'Extreme' },
+}
+
+function paramsToFilters(p: BeliefsPageSearchParams): BeliefFilterParams {
+  const filters: BeliefFilterParams = {}
+
+  if (p.valence && p.valence !== 'all') {
+    const bucket = VALENCE_BUCKETS[p.valence]
+    if (bucket) {
+      filters.positivityMin = bucket.min
+      filters.positivityMax = bucket.max
+    }
+  }
+  if (p.specificity && p.specificity !== 'all') {
+    const bucket = SPECIFICITY_BUCKETS[p.specificity]
+    if (bucket) {
+      filters.specificityMin = bucket.min
+      filters.specificityMax = bucket.max
+    }
+  }
+  if (p.intensity && p.intensity !== 'all') {
+    const bucket = INTENSITY_BUCKETS[p.intensity]
+    if (bucket) {
+      filters.claimStrengthMin = bucket.min
+      filters.claimStrengthMax = bucket.max
+    }
+  }
+  if (p.category && p.category !== 'all') {
+    filters.category = p.category
+  }
+
+  const sortMap: Record<string, BeliefFilterParams['sortBy']> = {
+    valence: 'positivity',
+    specificity: 'specificity',
+    intensity: 'claimStrength',
+    statement: 'statement',
+    updated: 'updatedAt',
+  }
+  filters.sortBy = sortMap[p.sort ?? ''] ?? 'positivity'
+  filters.sortDir = p.dir === 'desc' ? 'desc' : 'asc'
+
+  return filters
+}
+
+function valenceLabel(positivity: number): string {
+  if (positivity >= 60) return 'Extremely Positive'
+  if (positivity >= 20) return 'Mildly Positive'
+  if (positivity > -20) return 'Neutral'
+  if (positivity > -60) return 'Mildly Negative'
+  return 'Extremely Negative'
+}
+
+function specificityLabel(specificity: number): string {
+  if (specificity < 0.33) return 'General'
+  if (specificity < 0.66) return 'Case-Level'
+  return 'Specific'
+}
+
+export default async function BeliefsIndexPage({ searchParams }: BeliefsIndexProps) {
+  const params = await searchParams
+  const filters = paramsToFilters(params)
+  const [beliefs, categories] = await Promise.all([
+    fetchFilteredBeliefs(filters),
+    fetchBeliefCategories(),
+  ])
+
+  const activeValence = params.valence ?? 'all'
+  const activeSpecificity = params.specificity ?? 'all'
+  const activeIntensity = params.intensity ?? 'all'
+  const activeCategory = params.category ?? 'all'
+  const activeSort = params.sort ?? 'valence'
+  const activeDir = params.dir === 'desc' ? 'desc' : 'asc'
 
   return (
     <div className="min-h-screen bg-white">
@@ -16,41 +122,142 @@ export default async function BeliefsIndexPage() {
 
       <main className="max-w-[960px] mx-auto px-4 py-8">
         <h1 className="text-2xl font-bold text-[var(--foreground)] mb-2">Belief Analysis Pages</h1>
-        <p className="text-sm text-[var(--muted-foreground)] mb-8">
-          Every belief gets its own comprehensive analysis page with argument trees, evidence, values analysis,
-          cost-benefit analysis, and more. Click a belief to view its full analysis.
+        <p className="text-sm text-[var(--muted-foreground)] mb-6">
+          Every belief is a coordinate on three spectrums:{' '}
+          <strong>Valence</strong> (negative ↔ positive),{' '}
+          <strong>Specificity</strong> (general ↔ specific), and{' '}
+          <strong>Intensity</strong> (weak ↔ extreme). Filter or re-sort below to navigate the space.
         </p>
+
+        <form
+          method="get"
+          className="border border-[var(--border)] rounded p-3 mb-6 bg-gray-50 grid grid-cols-1 md:grid-cols-3 gap-3 text-sm"
+        >
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">Valence</span>
+            <select name="valence" defaultValue={activeValence} className="border border-gray-300 rounded px-2 py-1 bg-white">
+              <option value="all">All</option>
+              {Object.entries(VALENCE_BUCKETS).map(([key, b]) => (
+                <option key={key} value={key}>{b.label}</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">Specificity</span>
+            <select name="specificity" defaultValue={activeSpecificity} className="border border-gray-300 rounded px-2 py-1 bg-white">
+              <option value="all">All</option>
+              {Object.entries(SPECIFICITY_BUCKETS).map(([key, b]) => (
+                <option key={key} value={key}>{b.label}</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">Intensity</span>
+            <select name="intensity" defaultValue={activeIntensity} className="border border-gray-300 rounded px-2 py-1 bg-white">
+              <option value="all">All</option>
+              {Object.entries(INTENSITY_BUCKETS).map(([key, b]) => (
+                <option key={key} value={key}>{b.label}</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">Category</span>
+            <select name="category" defaultValue={activeCategory} className="border border-gray-300 rounded px-2 py-1 bg-white">
+              <option value="all">All</option>
+              {categories.map(c => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">Sort by</span>
+            <select name="sort" defaultValue={activeSort} className="border border-gray-300 rounded px-2 py-1 bg-white">
+              <option value="valence">Valence</option>
+              <option value="specificity">Specificity</option>
+              <option value="intensity">Intensity</option>
+              <option value="statement">Statement</option>
+              <option value="updated">Recently updated</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">Direction</span>
+            <select name="dir" defaultValue={activeDir} className="border border-gray-300 rounded px-2 py-1 bg-white">
+              <option value="asc">Ascending</option>
+              <option value="desc">Descending</option>
+            </select>
+          </label>
+          <div className="md:col-span-3 flex items-center justify-between gap-3">
+            <span className="text-xs text-[var(--muted-foreground)]">
+              {beliefs.length} {beliefs.length === 1 ? 'belief' : 'beliefs'} match
+            </span>
+            <div className="flex gap-2">
+              <Link
+                href="/beliefs"
+                className="text-xs text-[var(--accent)] hover:underline"
+              >
+                Reset
+              </Link>
+              <button
+                type="submit"
+                className="bg-[var(--accent)] text-white text-sm font-medium px-3 py-1 rounded hover:opacity-90"
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        </form>
 
         {beliefs.length === 0 ? (
           <div className="text-center py-16 text-[var(--muted-foreground)]">
-            <p className="text-lg mb-2">No beliefs yet.</p>
-            <p className="text-sm">Seed the database to get started with sample beliefs.</p>
+            <p className="text-lg mb-2">No beliefs match these filters.</p>
+            <p className="text-sm">Try widening one of the spectrums above.</p>
           </div>
         ) : (
           <div className="space-y-3">
-            {beliefs.map(belief => (
-              <Link
-                key={belief.id}
-                href={`/beliefs/${belief.slug}`}
-                className="block bg-gray-50 border border-gray-200 rounded-lg p-4 hover:bg-gray-100 hover:border-gray-300 transition-colors"
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1">
-                    <h2 className="font-semibold text-[var(--foreground)] mb-1">{belief.statement}</h2>
-                    <div className="flex gap-3 text-xs text-[var(--muted-foreground)]">
-                      {belief.category && <span>{belief.category}</span>}
-                      {belief.subcategory && <span>&gt; {belief.subcategory}</span>}
+            {beliefs.map(belief => {
+              const band = getStrengthBand(belief.claimStrength)
+              return (
+                <Link
+                  key={belief.id}
+                  href={`/beliefs/${belief.slug}`}
+                  className="block bg-gray-50 border border-gray-200 rounded-lg p-4 hover:bg-gray-100 hover:border-gray-300 transition-colors"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <h2 className="font-semibold text-[var(--foreground)] mb-1">{belief.statement}</h2>
+                      <div className="flex flex-wrap gap-3 text-xs text-[var(--muted-foreground)]">
+                        {belief.category && <span>{belief.category}</span>}
+                        {belief.subcategory && <span>&gt; {belief.subcategory}</span>}
+                      </div>
+                      <div className="flex flex-wrap gap-2 mt-2 text-[10px]">
+                        <span className="px-1.5 py-0.5 rounded border border-gray-300 bg-white font-mono">
+                          Valence:{' '}
+                          <strong>
+                            {belief.positivity >= 0 ? '+' : ''}{belief.positivity.toFixed(0)}
+                          </strong>{' '}
+                          ({valenceLabel(belief.positivity)})
+                        </span>
+                        <span className="px-1.5 py-0.5 rounded border border-gray-300 bg-white font-mono">
+                          Specificity: <strong>{specificityLabel(belief.specificity)}</strong>
+                        </span>
+                        <span
+                          className="px-1.5 py-0.5 rounded border border-gray-300 font-mono"
+                          style={{ backgroundColor: band.hexColor }}
+                        >
+                          Intensity: <strong>{band.label}</strong> ({formatStrength(belief.claimStrength)})
+                        </span>
+                      </div>
+                    </div>
+                    <div className="flex-shrink-0 text-right">
+                      <span className={`text-sm font-bold ${belief.positivity >= 0 ? 'text-green-700' : 'text-red-700'}`}>
+                        {belief.positivity >= 0 ? '+' : ''}{belief.positivity.toFixed(0)}%
+                      </span>
+                      <div className="text-xs text-[var(--muted-foreground)]">positivity</div>
                     </div>
                   </div>
-                  <div className="flex-shrink-0 text-right">
-                    <span className={`text-sm font-bold ${belief.positivity >= 0 ? 'text-green-700' : 'text-red-700'}`}>
-                      {belief.positivity >= 0 ? '+' : ''}{belief.positivity.toFixed(0)}%
-                    </span>
-                    <div className="text-xs text-[var(--muted-foreground)]">positivity</div>
-                  </div>
-                </div>
-              </Link>
-            ))}
+                </Link>
+              )
+            })}
           </div>
         )}
       </main>

--- a/src/features/belief-analysis/data/fetch-belief.ts
+++ b/src/features/belief-analysis/data/fetch-belief.ts
@@ -97,9 +97,92 @@ export async function fetchAllBeliefs() {
       category: true,
       subcategory: true,
       positivity: true,
+      specificity: true,
+      claimStrength: true,
     },
     orderBy: { updatedAt: 'desc' },
   })
+}
+
+/**
+ * Filters for spectrum-driven belief navigation, mirroring &sect;5 of
+ * /One Page Per Belief: Technical Specification. All bounds are inclusive
+ * and use internal storage scales (positivity -100..+100, specificity 0..1,
+ * claimStrength 0..1). Use the spectrum-coordinates helpers to translate
+ * from the spec's coarse 1..10 / -5..+5 / 1..5 scales.
+ */
+export interface BeliefFilterParams {
+  positivityMin?: number
+  positivityMax?: number
+  specificityMin?: number
+  specificityMax?: number
+  claimStrengthMin?: number
+  claimStrengthMax?: number
+  category?: string
+  /** Field to sort on. Defaults to positivity (the "valence spectrum" surface). */
+  sortBy?: 'positivity' | 'specificity' | 'claimStrength' | 'statement' | 'updatedAt'
+  /** Sort direction. Defaults to 'asc' so the page reads negative → positive. */
+  sortDir?: 'asc' | 'desc'
+  limit?: number
+}
+
+export async function fetchFilteredBeliefs(params: BeliefFilterParams = {}) {
+  const where: Record<string, unknown> = {}
+
+  if (params.positivityMin !== undefined || params.positivityMax !== undefined) {
+    where.positivity = {
+      ...(params.positivityMin !== undefined ? { gte: params.positivityMin } : {}),
+      ...(params.positivityMax !== undefined ? { lte: params.positivityMax } : {}),
+    }
+  }
+
+  if (params.specificityMin !== undefined || params.specificityMax !== undefined) {
+    where.specificity = {
+      ...(params.specificityMin !== undefined ? { gte: params.specificityMin } : {}),
+      ...(params.specificityMax !== undefined ? { lte: params.specificityMax } : {}),
+    }
+  }
+
+  if (params.claimStrengthMin !== undefined || params.claimStrengthMax !== undefined) {
+    where.claimStrength = {
+      ...(params.claimStrengthMin !== undefined ? { gte: params.claimStrengthMin } : {}),
+      ...(params.claimStrengthMax !== undefined ? { lte: params.claimStrengthMax } : {}),
+    }
+  }
+
+  if (params.category) {
+    where.category = params.category
+  }
+
+  const sortBy = params.sortBy ?? 'positivity'
+  const sortDir = params.sortDir ?? 'asc'
+
+  return prisma.belief.findMany({
+    where,
+    select: {
+      id: true,
+      slug: true,
+      statement: true,
+      category: true,
+      subcategory: true,
+      positivity: true,
+      specificity: true,
+      claimStrength: true,
+    },
+    orderBy: { [sortBy]: sortDir },
+    ...(params.limit !== undefined ? { take: params.limit } : {}),
+  })
+}
+
+/** All distinct category values currently used on Belief rows, for filter dropdowns. */
+export async function fetchBeliefCategories(): Promise<string[]> {
+  const rows = await prisma.belief.findMany({
+    where: { category: { not: null } },
+    select: { category: true },
+    distinct: ['category'],
+    orderBy: { category: 'asc' },
+  })
+  return rows.map(r => r.category).filter((c): c is string => c !== null)
 }
 
 /** Compute all 12 ReasonRank scores for a belief */

--- a/src/features/belief-analysis/spectrum-coordinates.ts
+++ b/src/features/belief-analysis/spectrum-coordinates.ts
@@ -1,0 +1,70 @@
+/**
+ * Conversion helpers between internal storage scales and the public
+ * &ldquo;spectrum_coordinates&rdquo; shape from the One-Page-Per-Belief technical spec.
+ *
+ * Internal (Prisma):
+ *   positivity      Float (-100..+100)
+ *   specificity     Float (0..1)
+ *   claimStrength   Float (0..1)
+ *
+ * Public (spec &sect;1):
+ *   valence         Integer (-5..+5)
+ *   specificity     Integer (1..10)
+ *   intensity       Integer (1..5)
+ *
+ * The internal scales are kept as floats so propagation math stays continuous;
+ * the public scales are coarse buckets meant for navigation and URL filters.
+ */
+
+export interface InternalSpectrum {
+  positivity: number
+  specificity: number
+  claimStrength: number
+}
+
+export interface SpectrumCoordinates {
+  valence: number
+  specificity: number
+  intensity: number
+}
+
+const clampInt = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, Math.round(value)))
+
+/** -100..+100 → -5..+5 (rounded). */
+export function toValenceCoord(positivity: number): number {
+  return clampInt(positivity / 20, -5, 5)
+}
+
+/** 0..1 → 1..10 (rounded; 0 maps to 1, 1 maps to 10). */
+export function toSpecificityCoord(specificity: number): number {
+  return clampInt(specificity * 9 + 1, 1, 10)
+}
+
+/** 0..1 → 1..5 (rounded; 0 maps to 1, 1 maps to 5). */
+export function toIntensityCoord(claimStrength: number): number {
+  return clampInt(claimStrength * 4 + 1, 1, 5)
+}
+
+export function toSpectrumCoordinates(belief: InternalSpectrum): SpectrumCoordinates {
+  return {
+    valence: toValenceCoord(belief.positivity),
+    specificity: toSpecificityCoord(belief.specificity),
+    intensity: toIntensityCoord(belief.claimStrength),
+  }
+}
+
+/** Inverse of {@link toValenceCoord}: spec valence (-5..+5) back to positivity (-100..+100). */
+export function fromValenceCoord(valence: number): number {
+  return clampInt(valence, -5, 5) * 20
+}
+
+/** Inverse of {@link toSpecificityCoord}: spec spec (1..10) back to internal 0..1. */
+export function fromSpecificityCoord(spec: number): number {
+  return (clampInt(spec, 1, 10) - 1) / 9
+}
+
+/** Inverse of {@link toIntensityCoord}: spec intensity (1..5) back to claimStrength 0..1. */
+export function fromIntensityCoord(intensity: number): number {
+  return (clampInt(intensity, 1, 5) - 1) / 4
+}


### PR DESCRIPTION
## Summary

Implements §1 (canonical JSON shape) and §5 (spectrum-query navigation surface) from `/One Page Per Belief: Technical Specification`. Builds on the spectrum data model that landed in #109.

## Changes

- **`/beliefs` index rewritten as the spectrum-query navigation surface.** URL-driven filters for valence (5 bands), specificity (3 bands), intensity (4 bands), and category. Default sort is valence ascending, so the listing reads negative → positive per §5. Each row shows the three spectrum coordinates inline.
- **New `GET /api/beliefs`.** Accepts the spec's coarse `valenceMin/Max` (-5..+5), `specificityMin/Max` (1..10), `intensityMin/Max` (1..5), plus `category`, `sortBy`, `sortDir`, `limit`. Returns `{beliefs: [{belief_id, canonical_text, spectrum_coordinates, parent_topic_id, slug}], count}`.
- **`GET /api/beliefs/[id]` additively returns the spec shape.** New `spec` block with `linked_evidence`, `upstream_beliefs`, `downstream_beliefs`. Existing `belief` and `scores` payload unchanged — non-breaking.
- **New `spectrum-coordinates.ts` helper.** Bidirectional translation between internal floats (positivity -100..+100, specificity 0..1, claimStrength 0..1) and the spec's coarse buckets, so storage stays continuous for propagation math while the public API matches the spec.
- **`fetchFilteredBeliefs(BeliefFilterParams)` and `fetchBeliefCategories()`** in `data/fetch-belief.ts`.
- **Seed data:** two downstream beliefs (`ubi-should-be-funded-by-vat`, `ubi-should-equal-poverty-line`) plus four `BeliefMapping` rows so the propagation cascade in `src/lib/propagate-belief-scores.ts` has something to traverse.

## Test plan

- [x] `npx tsc --noEmit` clean on touched files
- [x] `npx eslint` clean on touched files
- [x] `GET /api/beliefs?limit=2&sortBy=valence` returns sorted spec-shape beliefs
- [x] `GET /api/beliefs?valenceMin=2` returns 6 mildly+ positive beliefs
- [x] `GET /api/beliefs/1` includes `spec.upstream_beliefs` and `spec.downstream_beliefs`
- [ ] Manually click through `/beliefs` filter UI in browser

## Out of scope (still untouched from the tech spec)

These need real ML / new infra and weren't bounded enough for this PR:

- §2 logic-extraction classifier (REASON / EVIDENCE / ASSUMPTION)
- §3 actual vector embeddings + cosine ≥ 0.85 (current `/api/beliefs/equivalency` uses mechanical similarity, not embeddings)
- A new-belief submission UI that triggers §3's consolidation prompt

https://claude.ai/code/session_011ix9SYiTP886WuXSegKusq

---
_Generated by [Claude Code](https://claude.ai/code/session_011ix9SYiTP886WuXSegKusq)_