### PR TITLE
Add iOS app scaffold with WKWebView wrapper and native Browse tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,15 @@ Or set `CLAUDE_DEBUG_FILE` before launching. File logging cannot be enabled mid-
 - The roadmap to a Play Store listing is `docs/ANDROID.md` — TWA wrapper via Google's Bubblewrap CLI. The Android project is *not* committed; it's generated against the deployed manifest.
 - `public/.well-known/assetlinks.json` is the Digital Asset Links file Android fetches to verify the TWA. The signing-key SHA-256 placeholder must be filled in after generating the keystore. If a future host strips `.well-known/`, add a rewrite.
 
+## iOS app
+
+- `ios/` holds a SwiftUI shell with two tabs: a `WKWebView` over the deployed site, and a native **Browse** tab that calls `/api/beliefs` and `/api/beliefs/[id]` to traverse Reasons-to-Agree / Reasons-to-Disagree with each argument's impact and linkage scores.
+- The `.xcodeproj` is **not** committed; run `xcodegen` from `ios/` to materialize it from `ios/project.yml`. Same philosophy as not committing the Bubblewrap-generated Android project — pbxproj files merge-conflict constantly.
+- Roadmap: `docs/IOS.md` (mirrors `docs/ANDROID.md`). PWA → WKWebView App Store wrapper → optional full SwiftUI rebuild.
+- `public/.well-known/apple-app-site-association` is the Universal Links manifest. The placeholder `TEAMID` must be replaced with a real Apple Team ID before submission. Apple is strict: no `.json` extension, `Content-Type: application/json`, status 200 with no redirect.
+- Native tab models only the subset of the API needed for argument traversal (`ios/Sources/Native/Models.swift`). When new fields land server-side, add them here as needed — don't try to mirror the full Prisma payload.
+- iOS builds require macOS + Xcode 15.4+. The repo is editable on Linux but the build step is not. Don't try to "fix" Swift errors locally without a Mac to verify.
+
 ## Routes Worth Knowing
 
 - `/beliefs` — index of all beliefs.

--- a/docs/IOS.md
+++ b/docs/IOS.md
@@ -1,0 +1,127 @@
+# iOS: PWA → App Store
+
+The plan mirrors `docs/ANDROID.md`. Each step is reversible and shippable on its own; you don't have to commit to native rebuild to get a real App Store listing.
+
+| Step | What it gives you | Time | Status |
+|------|-------------------|------|--------|
+| 1. Installable PWA on Safari | Add to Home Screen launches full-screen, with the manifest icon. iOS users get most of the value before any App Store work. | done | ✅ Same `public/manifest.webmanifest` and `<meta>` tags in `src/app/layout.tsx` already serve iOS. |
+| 2. WKWebView wrapper for App Store | A real App Store listing. The "app" is a thin SwiftUI shell that opens your URL in `WKWebView` with no Safari chrome. The web app keeps deploying normally; the IPA only needs to change for version bumps or shell config. | 1–2 days | 🟡 Scaffold under `ios/` (this doc + `public/.well-known/apple-app-site-association`); waits on a deployed HTTPS URL and an Apple Developer account. |
+| 3. SwiftUI native rebuild | Native UI, push notifications via APNs, real native list/detail, share extension. The scaffold already includes a starter native "Browse Beliefs" tab so you can grow into this without throwing away the wrapper. | 3–6 months | ⏸ Don't start until step 2 is shipped and you have usage data. |
+
+## Step 2 in detail: WKWebView wrapper
+
+Apple's iOS equivalent of an Android Trusted Web Activity is just a `WKWebView` inside a SwiftUI app. Apple does not have a TWA-style "no chrome unless verified" mode — `WKWebView` always renders without browser chrome by default. Universal Links cover the asset-linking story (deep links from the web go straight into the app instead of Safari).
+
+### Prerequisites
+
+1. **Mac with Xcode 15.4+.** iOS builds require macOS; there is no Linux toolchain. CI builds work via macOS runners (GitHub Actions `macos-14`, etc.).
+2. **Apple Developer Program membership** ($99/year). Required for App Store distribution and for signed device builds beyond the 7-day free-tier window.
+3. **HTTPS deployment.** Universal Links and AASA fetching only work over HTTPS. Vercel, Cloudflare Pages, Fly, or Render all work. Local `next dev` does not.
+4. **Stable bundle identifier.** We default to `com.ideastockexchange.ios` (matches `apple-app-site-association`). If you change it, change it in *both* the AASA file *and* `ios/project.yml`, or Universal Links silently fall back to opening Safari.
+5. **XcodeGen** (`brew install xcodegen`) to materialize `IdeaStockExchange.xcodeproj` from `ios/project.yml`. We don't commit the `.xcodeproj` — it's a build artifact (its `pbxproj` is famous for merge conflicts). Same philosophy as not committing the Bubblewrap-generated Android project.
+
+### Generate the Xcode project
+
+```bash
+cd ios
+xcodegen                       # reads project.yml, emits IdeaStockExchange.xcodeproj
+open IdeaStockExchange.xcodeproj
+```
+
+In Xcode:
+
+1. Select the `IdeaStockExchange` target → Signing & Capabilities → set **Team** to your Apple Developer team.
+2. Build & Run on the iOS Simulator (`Cmd+R`). The shell opens the production URL.
+3. To run on a physical device, plug it in and select it as the run destination. First time will require you to trust the developer profile on the device (Settings → General → VPN & Device Management).
+
+### Configure the deployed URL
+
+The production URL is read from `Info.plist` at runtime via the `ISEWebURL` key. Edit `ios/Resources/Info.plist` (or override per-scheme in Xcode) before shipping:
+
+```xml
+<key>ISEWebURL</key>
+<string>https://YOUR_DEPLOYED_DOMAIN</string>
+```
+
+The default in the scaffold points at `https://ideastockexchange.com` — change it to your real domain before submitting.
+
+### Wire up Universal Links (the iOS analogue of assetlinks.json)
+
+iOS verifies that your app is allowed to handle `https://your-domain.com/...` URLs by fetching `https://YOUR_DEPLOYED_DOMAIN/.well-known/apple-app-site-association`. If verification fails, `https://` taps fall back to Safari instead of opening the app.
+
+This repo serves the file from `public/.well-known/apple-app-site-association`. You need to fill in **two** values:
+
+1. Your Apple **Team ID** (10 characters, found at developer.apple.com → Membership). Replace every occurrence of `TEAMID` in `apple-app-site-association`.
+2. The bundle identifier, if you changed it from the default `com.ideastockexchange.ios`.
+
+Then deploy and verify:
+
+```bash
+# Apple's CDN caches AASA for ~24h. To force a refresh on a device, reinstall the app.
+curl -i https://YOUR_DEPLOYED_DOMAIN/.well-known/apple-app-site-association
+```
+
+Critical details Apple is strict about:
+
+- **No `.json` extension.** Just `apple-app-site-association`. Next.js will serve it from `public/` verbatim, but make sure your CDN/host doesn't auto-append extensions or strip dotfile-prefixed paths.
+- **`Content-Type: application/json`** (some hosts default to `application/octet-stream`, which iOS rejects).
+- **Status 200**, no redirects. Vercel and Cloudflare Pages serve `public/` files cleanly; Netlify needs a `_headers` rule to set the content type.
+
+If your host strips `.well-known/`, add a rewrite in `next.config.ts` so the path actually serves.
+
+### Test on a real device
+
+```bash
+# Plug in iPhone, select it as run destination in Xcode, Cmd+R.
+# Or, after archiving:
+xcodebuild -project IdeaStockExchange.xcodeproj -scheme IdeaStockExchange \
+           -destination 'generic/platform=iOS' archive \
+           -archivePath build/IdeaStockExchange.xcarchive
+```
+
+Open the app. Tap an `https://your-domain.com/beliefs/...` link in Messages or Notes — if Universal Links work, the app opens directly. If Safari opens instead, the AASA file isn't being fetched correctly.
+
+### Ship to the App Store
+
+1. In Xcode: Product → Archive (must be on a real device run destination, not the Simulator).
+2. Distribute App → App Store Connect → Upload.
+3. In App Store Connect, fill in screenshots (iPhone 6.7" + iPhone 6.1" + iPad if you ship iPad), description, keywords, privacy policy URL, App Privacy disclosure ("Data Not Collected" if the wrapper makes no extra calls beyond the website), and content rating.
+4. Submit for review.
+
+First-time review takes 24–72 hours. Updates take 24–48 hours. Apple is stricter than Google about WebView-only apps — the App Store guideline 4.2 ("Minimum Functionality") sometimes flags pure web wrappers. Mitigations the scaffold already includes:
+
+- A native **Browse** tab that calls `/api/beliefs` and renders a real native list + detail. This is enough to clear 4.2 in most reviews.
+- Native pull-to-refresh and offline error states on the Browse tab.
+- Universal Links so the app handles its own domain.
+
+If Apple still rejects under 4.2, expand the native side (push notifications via APNs, share extension, native compose flow) before re-submitting; do not argue with the reviewer.
+
+## When to consider step 3 (full SwiftUI rebuild)
+
+Honest signals:
+
+- WebView cold-start > 2 seconds even after caching is tuned.
+- You need rich push notifications with action buttons (web push on iOS only landed in 16.4 and is still limited).
+- You need Apple platform features the web can't reach: Live Activities, widgets, App Intents, Shortcuts, Handoff, ShareExtension, native scroll perf at 120Hz on ProMotion.
+- You want to be on iPad with a multi-pane layout, or watchOS / visionOS.
+
+If none of those bite, stay on the wrapper. The two-codebase tax of going fully native is real; don't pay it for status reasons. The native-stub tab in the scaffold gives you a place to grow into native incrementally without committing to a rewrite.
+
+## Cost recap
+
+| | DIY | Freelance | Agency |
+|---|---|---|---|
+| Step 1 (PWA on iOS Safari) | Done | n/a | n/a |
+| Step 2 (WKWebView wrapper) | $99 Apple fee + ~1 day | $1–3k | $3–8k |
+| Step 3 (SwiftUI rebuild) | 3–6 months | $30–80k | $100–200k |
+| Cross-platform (RN / Flutter) | shared with Android | $40–100k | $120–250k |
+
+## File map
+
+- `ios/project.yml` — XcodeGen spec. Source of truth for bundle ID, deployment target, capabilities.
+- `ios/Sources/App/` — `@main` entry, root TabView. Tabs: **Web** (WKWebView) and **Browse** (native).
+- `ios/Sources/Web/WebViewScreen.swift` — `UIViewRepresentable` over `WKWebView`. Reads `ISEWebURL` from `Info.plist`.
+- `ios/Sources/Native/` — native Browse: list of beliefs, detail view that splits arguments into "Reasons to Agree" / "Reasons to Disagree" with each argument's impact score, and a recursive sub-argument view.
+- `ios/Resources/Info.plist` — bundle config, deployed URL key, App Transport Security defaults.
+- `ios/Resources/Assets.xcassets/` — app icon and accent color slots (placeholders).
+- `public/.well-known/apple-app-site-association` — Universal Links manifest. Fill in `TEAMID` before shipping.

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,17 @@
+# XcodeGen output — regenerated from project.yml on demand.
+*.xcodeproj/
+*.xcworkspace/
+
+# Xcode user / build artifacts
+xcuserdata/
+DerivedData/
+build/
+*.ipa
+*.xcarchive
+
+# Swift Package Manager (if added later)
+.build/
+.swiftpm/
+
+# macOS
+.DS_Store

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,65 @@
+# Idea Stock Exchange — iOS app
+
+A SwiftUI shell for the Idea Stock Exchange web app. Two tabs:
+
+- **Web** — `WKWebView` pointing at the deployed site. The whole product, exactly as it renders in Safari, with no browser chrome.
+- **Browse** — native list/detail that traverses *Reasons to Agree* and *Reasons to Disagree* using the `/api/beliefs` JSON API. Each argument shows its impact and linkage scores; tapping it navigates into the child belief so you can recursively walk the reason graph.
+
+The split exists because Apple's App Store guideline 4.2 ("Minimum Functionality") sometimes flags pure WebView wrappers. The native Browse tab gives reviewers something native to look at, and seeds the path toward a fully native rebuild later (`docs/IOS.md`, step 3).
+
+## Quick start (macOS)
+
+```bash
+brew install xcodegen          # one-time, if you don't already have it
+cd ios
+xcodegen                       # materializes IdeaStockExchange.xcodeproj
+open IdeaStockExchange.xcodeproj
+```
+
+In Xcode:
+
+1. Select the **IdeaStockExchange** target → *Signing & Capabilities* → set **Team** to your Apple Developer team.
+2. Pick an iOS Simulator (e.g. iPhone 15) as the run destination.
+3. `Cmd+R` to build and run.
+
+The Web tab loads the URL configured in `Resources/Info.plist` under the `ISEWebURL` key (defaults to `https://ideastockexchange.com`). Edit that value before shipping or override it per scheme. The Browse tab points at the same base URL.
+
+## Layout
+
+```
+ios/
+├── project.yml                         # XcodeGen spec (source of truth for bundle ID, deployment target, capabilities)
+├── Sources/
+│   ├── App/
+│   │   ├── IdeaStockExchangeApp.swift  # @main entry point
+│   │   └── RootView.swift              # TabView shell
+│   ├── Web/
+│   │   └── WebViewScreen.swift         # WKWebView wrapper with loading + error states
+│   └── Native/
+│       ├── Models.swift                # Codables for /api/beliefs and /api/beliefs/[id]
+│       ├── ISEAPI.swift                # URLSession-based networking
+│       ├── BeliefsListView.swift       # Searchable list of beliefs
+│       └── BeliefDetailView.swift      # Score banner + Reasons-to-Agree / Reasons-to-Disagree
+└── Resources/
+    ├── Info.plist                      # ISEWebURL, ATS, orientations
+    ├── IdeaStockExchange.entitlements  # Associated domains for Universal Links
+    └── Assets.xcassets/                # AppIcon + AccentColor placeholders
+```
+
+## Universal Links
+
+`public/.well-known/apple-app-site-association` (in the web repo, served at the deployed root) routes `/beliefs/*`, `/markets/*`, and `/` through the app once installed. Before shipping:
+
+1. Replace `TEAMID` in `apple-app-site-association` with your real Apple Team ID.
+2. Confirm the file serves with `Content-Type: application/json` and HTTP 200 (no redirect).
+3. Re-archive and reinstall the app — Apple's CDN caches AASA for ~24h.
+
+Full walkthrough in `docs/IOS.md`.
+
+## Why XcodeGen instead of a committed `.xcodeproj`?
+
+`pbxproj` files merge-conflict on every change to file membership. XcodeGen generates the project from the YAML spec on demand, so reviewable changes stay in `project.yml`. Mirror of the same philosophy in `docs/ANDROID.md`: don't commit Bubblewrap's generated Android Studio project.
+
+## Building without macOS
+
+You can't. iOS apps require Xcode, which is macOS-only. CI runs on `macos-14` GitHub runners (or equivalent). The repository scaffold is editable on Linux but the build step is not.

--- a/ios/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.039",
+          "green" : "0.039",
+          "red" : "0.039"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Resources/Assets.xcassets/Contents.json
+++ b/ios/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Resources/IdeaStockExchange.entitlements
+++ b/ios/Resources/IdeaStockExchange.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+        <string>applinks:ideastockexchange.com</string>
+        <string>webcredentials:ideastockexchange.com</string>
+    </array>
+</dict>
+</plist>

--- a/ios/Resources/Info.plist
+++ b/ios/Resources/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <false/>
+    </dict>
+</dict>
+</plist>

--- a/ios/Sources/App/IdeaStockExchangeApp.swift
+++ b/ios/Sources/App/IdeaStockExchangeApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct IdeaStockExchangeApp: App {
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .tint(Color("AccentColor"))
+        }
+    }
+}

--- a/ios/Sources/App/RootView.swift
+++ b/ios/Sources/App/RootView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Two-tab shell:
+///   - "Web" hosts a WKWebView pointing at the deployed site (the entire product).
+///   - "Browse" is a native list/detail that traverses reasons-to-agree/disagree
+///     using the JSON API. It exists primarily to clear App Store guideline 4.2
+///     ("minimum functionality") and to seed the path toward a fully native
+///     rebuild (docs/IOS.md, step 3).
+struct RootView: View {
+    var body: some View {
+        TabView {
+            WebViewScreen()
+                .tabItem {
+                    Label("Web", systemImage: "globe")
+                }
+
+            NavigationStack {
+                BeliefsListView()
+            }
+            .tabItem {
+                Label("Browse", systemImage: "list.bullet.rectangle")
+            }
+        }
+    }
+}
+
+#Preview {
+    RootView()
+}

--- a/ios/Sources/Native/BeliefDetailView.swift
+++ b/ios/Sources/Native/BeliefDetailView.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+
+/// Single-belief detail screen. Splits arguments into "Reasons to Agree" and
+/// "Reasons to Disagree", each row showing the argument's impact score. Tapping
+/// an argument navigates into that argument's child belief — the user can
+/// recursively traverse the reason graph from here.
+struct BeliefDetailView: View {
+    let beliefId: Int
+    let initialStatement: String
+
+    @State private var detail: BeliefDetailResponse?
+    @State private var loadError: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text(detail?.belief.statement ?? initialStatement)
+                    .font(.title3.weight(.semibold))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                ScoreBanner(scores: detail?.scores)
+
+                if let error = loadError {
+                    Label(error, systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+
+                if let detail {
+                    let pro = detail.belief.arguments.filter { $0.isPro }
+                    let con = detail.belief.arguments.filter { !$0.isPro }
+
+                    ArgumentList(title: "Reasons to Agree",
+                                 systemImage: "hand.thumbsup.fill",
+                                 tint: .green,
+                                 arguments: pro)
+
+                    ArgumentList(title: "Reasons to Disagree",
+                                 systemImage: "hand.thumbsdown.fill",
+                                 tint: .red,
+                                 arguments: con)
+
+                    if pro.isEmpty && con.isEmpty {
+                        Text("No reasons recorded yet.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    ProgressView().frame(maxWidth: .infinity)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Belief")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationDestination(for: ChildBelief.self) { child in
+            BeliefDetailView(beliefId: child.id, initialStatement: child.statement)
+        }
+        .task(id: beliefId) { await load() }
+    }
+
+    private func load() async {
+        do {
+            let response = try await ISEAPI.shared.fetchBelief(id: beliefId)
+            self.detail = response
+            self.loadError = nil
+        } catch {
+            self.loadError = error.localizedDescription
+        }
+    }
+}
+
+private struct ScoreBanner: View {
+    let scores: BeliefScores?
+
+    var body: some View {
+        HStack(spacing: 16) {
+            ScoreChip(label: "Pro",
+                      value: scores?.totalPro,
+                      tint: .green,
+                      sign: "+")
+            ScoreChip(label: "Con",
+                      value: scores?.totalCon,
+                      tint: .red,
+                      sign: "-")
+        }
+    }
+}
+
+private struct ScoreChip: View {
+    let label: String
+    let value: Double?
+    let tint: Color
+    let sign: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if let value {
+                Text("\(sign)\(value, specifier: "%.1f")")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(tint)
+                    .monospacedDigit()
+            } else {
+                Text("—")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct ArgumentList: View {
+    let title: String
+    let systemImage: String
+    let tint: Color
+    let arguments: [Argument]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+                .foregroundStyle(tint)
+
+            if arguments.isEmpty {
+                Text("None recorded.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(arguments) { argument in
+                        NavigationLink(value: argument.belief) {
+                            ArgumentRow(argument: argument, tint: tint)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct ArgumentRow: View {
+    let argument: Argument
+    let tint: Color
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(argument.belief.statement)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.leading)
+                Text("Impact \(argument.impactScore, specifier: "%.2f")  ·  Linkage \(argument.linkageScore, specifier: "%.2f")")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(12)
+        .background(tint.opacity(0.06), in: RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(tint.opacity(0.2), lineWidth: 1)
+        )
+    }
+}
+
+#Preview {
+    NavigationStack {
+        BeliefDetailView(beliefId: 1, initialStatement: "Sample belief statement")
+    }
+}

--- a/ios/Sources/Native/BeliefsListView.swift
+++ b/ios/Sources/Native/BeliefsListView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct BeliefsListView: View {
+    @State private var beliefs: [BeliefSummary] = []
+    @State private var loadState: LoadState = .idle
+    @State private var search: String = ""
+
+    enum LoadState { case idle, loading, loaded, failed(String) }
+
+    private var filtered: [BeliefSummary] {
+        guard !search.isEmpty else { return beliefs }
+        return beliefs.filter {
+            $0.canonicalText.localizedCaseInsensitiveContains(search)
+        }
+    }
+
+    var body: some View {
+        Group {
+            switch loadState {
+            case .idle, .loading where beliefs.isEmpty:
+                ProgressView("Loading beliefs…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            case .failed(let message):
+                ContentUnavailableView {
+                    Label("Couldn't load", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(message)
+                } actions: {
+                    Button("Try again") { Task { await load() } }
+                        .buttonStyle(.borderedProminent)
+                }
+
+            default:
+                List(filtered) { belief in
+                    NavigationLink(value: belief) {
+                        BeliefRow(belief: belief)
+                    }
+                }
+                .listStyle(.plain)
+                .refreshable { await load() }
+                .searchable(text: $search, prompt: "Search beliefs")
+            }
+        }
+        .navigationTitle("Beliefs")
+        .navigationDestination(for: BeliefSummary.self) { summary in
+            BeliefDetailView(beliefId: Int(summary.beliefId) ?? 0,
+                             initialStatement: summary.canonicalText)
+        }
+        .task { if beliefs.isEmpty { await load() } }
+    }
+
+    private func load() async {
+        loadState = .loading
+        do {
+            let result = try await ISEAPI.shared.fetchBeliefs(limit: 200)
+            self.beliefs = result
+            self.loadState = .loaded
+        } catch {
+            self.loadState = .failed(error.localizedDescription)
+        }
+    }
+}
+
+private struct BeliefRow: View {
+    let belief: BeliefSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(belief.canonicalText)
+                .font(.body)
+                .foregroundStyle(.primary)
+            HStack(spacing: 8) {
+                if let topic = belief.parentTopicId, !topic.isEmpty {
+                    Text(topic)
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.secondary.opacity(0.12), in: Capsule())
+                }
+                if let v = belief.spectrumCoordinates?.valence {
+                    Text("valence \(v >= 0 ? "+\(v)" : "\(v)")")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    NavigationStack { BeliefsListView() }
+}

--- a/ios/Sources/Native/ISEAPI.swift
+++ b/ios/Sources/Native/ISEAPI.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Thin networking layer over the deployed JSON API.
+/// Base URL is read from the same `ISEWebURL` Info.plist key the WebView uses,
+/// so the wrapper and native tab always agree on which environment they target.
+struct ISEAPI {
+    static let shared = ISEAPI()
+
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    private let baseURL: URL
+
+    init(session: URLSession = .shared) {
+        self.session = session
+        self.decoder = JSONDecoder()
+
+        let raw = (Bundle.main.object(forInfoDictionaryKey: "ISEWebURL") as? String)
+            ?? "https://ideastockexchange.com"
+        self.baseURL = URL(string: raw) ?? URL(string: "https://ideastockexchange.com")!
+    }
+
+    func fetchBeliefs(limit: Int = 100) async throws -> [BeliefSummary] {
+        var components = URLComponents(url: baseURL.appendingPathComponent("api/beliefs"),
+                                       resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        let url = components.url!
+
+        let (data, response) = try await session.data(from: url)
+        try Self.validate(response)
+        let decoded = try decoder.decode(BeliefListResponse.self, from: data)
+        return decoded.beliefs
+    }
+
+    func fetchBelief(id: Int) async throws -> BeliefDetailResponse {
+        let url = baseURL.appendingPathComponent("api/beliefs/\(id)")
+        let (data, response) = try await session.data(from: url)
+        try Self.validate(response)
+        return try decoder.decode(BeliefDetailResponse.self, from: data)
+    }
+
+    private static func validate(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse else { return }
+        guard (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+    }
+}

--- a/ios/Sources/Native/Models.swift
+++ b/ios/Sources/Native/Models.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Decoders for the subset of `/api/beliefs` and `/api/beliefs/[id]` shapes the
+/// native Browse tab consumes. Only the fields needed for traversing reasons
+/// to agree / disagree and rendering scores are modeled — not the full
+/// canonical belief payload (Values, Interests, Cost-Benefit, etc.). Add more
+/// here as native screens grow.
+
+// MARK: - List endpoint
+
+struct BeliefListResponse: Decodable {
+    let beliefs: [BeliefSummary]
+    let count: Int
+}
+
+struct BeliefSummary: Decodable, Identifiable, Hashable {
+    let beliefId: String
+    let canonicalText: String
+    let slug: String?
+    let parentTopicId: String?
+    let spectrumCoordinates: SpectrumCoordinates?
+
+    var id: String { beliefId }
+
+    enum CodingKeys: String, CodingKey {
+        case beliefId = "belief_id"
+        case canonicalText = "canonical_text"
+        case slug
+        case parentTopicId = "parent_topic_id"
+        case spectrumCoordinates = "spectrum_coordinates"
+    }
+}
+
+struct SpectrumCoordinates: Decodable, Hashable {
+    let valence: Int?
+    let specificity: Int?
+    let intensity: Int?
+}
+
+// MARK: - Detail endpoint
+
+struct BeliefDetailResponse: Decodable {
+    let belief: BeliefDetail
+    let scores: BeliefScores
+}
+
+struct BeliefDetail: Decodable, Identifiable {
+    let id: Int
+    let slug: String
+    let statement: String
+    let category: String?
+    let subcategory: String?
+    let arguments: [Argument]
+}
+
+struct BeliefScores: Decodable {
+    let totalPro: Double?
+    let totalCon: Double?
+    let totalSupportingEvidence: Double?
+    let totalWeakeningEvidence: Double?
+}
+
+/// One argument in the belief's tree. `side` is "agree" or "disagree".
+/// `belief` here is the *child* belief that this argument leans on — tapping
+/// it lets the user traverse one level deeper.
+struct Argument: Decodable, Identifiable, Hashable {
+    let id: Int
+    let side: String
+    let linkageScore: Double
+    let impactScore: Double
+    let importanceScore: Double?
+    let belief: ChildBelief
+
+    var isPro: Bool { side.lowercased() == "agree" }
+
+    static func == (lhs: Argument, rhs: Argument) -> Bool { lhs.id == rhs.id }
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+}
+
+struct ChildBelief: Decodable, Hashable {
+    let id: Int
+    let slug: String?
+    let statement: String
+    let positivity: Double?
+}

--- a/ios/Sources/Web/WebViewScreen.swift
+++ b/ios/Sources/Web/WebViewScreen.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+@preconcurrency import WebKit
+
+/// Hosts the production web app inside a WKWebView. The destination URL is
+/// configured via the `ISEWebURL` Info.plist key so CI and per-scheme overrides
+/// don't require a code change.
+struct WebViewScreen: View {
+    @State private var isLoading = true
+    @State private var loadError: String?
+
+    private var startURL: URL {
+        let raw = (Bundle.main.object(forInfoDictionaryKey: "ISEWebURL") as? String)
+            ?? "https://ideastockexchange.com"
+        return URL(string: raw) ?? URL(string: "https://ideastockexchange.com")!
+    }
+
+    var body: some View {
+        ZStack {
+            WebView(url: startURL, isLoading: $isLoading, loadError: $loadError)
+                .ignoresSafeArea(edges: .bottom)
+
+            if isLoading && loadError == nil {
+                ProgressView().controlSize(.large)
+            }
+
+            if let loadError {
+                VStack(spacing: 12) {
+                    Text("Couldn't load").font(.headline)
+                    Text(loadError)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                    Button("Try again") {
+                        self.loadError = nil
+                        self.isLoading = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+                .padding()
+            }
+        }
+    }
+}
+
+private struct WebView: UIViewRepresentable {
+    let url: URL
+    @Binding var isLoading: Bool
+    @Binding var loadError: String?
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.allowsInlineMediaPlayback = true
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.allowsBackForwardNavigationGestures = true
+        webView.scrollView.contentInsetAdjustmentBehavior = .automatic
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        if loadError == nil && webView.url == nil {
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        let parent: WebView
+        init(_ parent: WebView) { self.parent = parent }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation nav: WKNavigation!) {
+            parent.isLoading = true
+        }
+
+        func webView(_ webView: WKWebView, didFinish nav: WKNavigation!) {
+            parent.isLoading = false
+        }
+
+        func webView(_ webView: WKWebView, didFail nav: WKNavigation!, withError error: Error) {
+            parent.isLoading = false
+            parent.loadError = error.localizedDescription
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation nav: WKNavigation!, withError error: Error) {
+            parent.isLoading = false
+            parent.loadError = error.localizedDescription
+        }
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,0 +1,64 @@
+# XcodeGen spec for the Idea Stock Exchange iOS app.
+#
+# Run `xcodegen` in this directory to materialize IdeaStockExchange.xcodeproj.
+# We don't commit the generated .xcodeproj — its pbxproj merge-conflicts constantly.
+# See ../docs/IOS.md for the full setup walkthrough.
+
+name: IdeaStockExchange
+
+options:
+  bundleIdPrefix: com.ideastockexchange
+  deploymentTarget:
+    iOS: "16.0"
+  developmentLanguage: en
+  groupSortPosition: top
+  generateEmptyDirectories: true
+
+settings:
+  base:
+    SWIFT_VERSION: "5.9"
+    IPHONEOS_DEPLOYMENT_TARGET: "16.0"
+    TARGETED_DEVICE_FAMILY: "1,2"      # iPhone + iPad
+    ENABLE_PREVIEWS: YES
+    CODE_SIGN_STYLE: Automatic
+    DEVELOPMENT_TEAM: ""               # set via Xcode Signing & Capabilities
+
+targets:
+  IdeaStockExchange:
+    type: application
+    platform: iOS
+    sources:
+      - path: Sources
+    resources:
+      - path: Resources/Assets.xcassets
+    info:
+      path: Resources/Info.plist
+      properties:
+        CFBundleDisplayName: Idea Stock Exchange
+        CFBundleShortVersionString: "0.1.0"
+        CFBundleVersion: "1"
+        UILaunchScreen:
+          UIColorName: AccentColor
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        ITSAppUsesNonExemptEncryption: false
+        # Default URL the WKWebView tab opens. Override per-scheme or in CI.
+        ISEWebURL: "https://ideastockexchange.com"
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.ideastockexchange.ios
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
+    entitlements:
+      path: Resources/IdeaStockExchange.entitlements
+      properties:
+        com.apple.developer.associated-domains:
+          - "applinks:ideastockexchange.com"
+          - "webcredentials:ideastockexchange.com"

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,27 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appIDs": ["TEAMID.com.ideastockexchange.ios"],
+        "components": [
+          {
+            "/": "/beliefs/*",
+            "comment": "Open belief pages directly in the app"
+          },
+          {
+            "/": "/markets/*",
+            "comment": "Open market pages directly in the app"
+          },
+          {
+            "/": "/",
+            "comment": "Open the home page in the app"
+          }
+        ]
+      }
+    ]
+  },
+  "webcredentials": {
+    "apps": ["TEAMID.com.ideastockexchange.ios"]
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a complete iOS app scaffold for the Idea Stock Exchange, implementing a two-tab SwiftUI shell that combines a `WKWebView` wrapper for the web app with a native "Browse" tab that traverses the belief reason graph via the JSON API.

## Key Changes

- **iOS app structure**: Complete SwiftUI project scaffold under `ios/` with XcodeGen-based build configuration (`project.yml`), eliminating the need to commit merge-conflict-prone `.xcodeproj` files.

- **WKWebView wrapper** (`WebViewScreen.swift`): Hosts the production web app in a native shell with loading states, error handling, and back/forward gesture support. The target URL is configurable via `Info.plist` (`ISEWebURL` key) to support CI overrides and per-scheme configuration without code changes.

- **Native Browse tab** (`BeliefsListView.swift`, `BeliefDetailView.swift`): 
  - Searchable list of beliefs fetched from `/api/beliefs`
  - Detail view that splits arguments into "Reasons to Agree" and "Reasons to Disagree"
  - Each argument displays impact and linkage scores
  - Recursive navigation through the reason graph (tapping an argument navigates to its child belief)
  - Pull-to-refresh and error states

- **API layer** (`ISEAPI.swift`, `Models.swift`): Lightweight `URLSession`-based networking with `Codable` models for the subset of `/api/beliefs` and `/api/beliefs/[id]` shapes needed for the native tab. Models include `BeliefSummary`, `BeliefDetail`, `Argument`, and score structures.

- **Universal Links support** (`apple-app-site-association`): AASA file configured to route `/beliefs/*`, `/markets/*`, and `/` through the app once installed. Requires Team ID substitution before deployment.

- **Documentation**: 
  - `docs/IOS.md`: Comprehensive three-step roadmap from installable PWA to App Store listing, with detailed setup instructions for XcodeGen, Universal Links, and App Store submission.
  - `ios/README.md`: Quick-start guide and project layout reference.

## Notable Implementation Details

- **XcodeGen over committed `.xcodeproj`**: Mirrors Android's Bubblewrap approach—the project is generated from `project.yml` on demand, keeping merge conflicts out of version control.
- **Shared configuration**: Both Web and Browse tabs read the base URL from the same `ISEWebURL` Info.plist key, ensuring they always target the same environment.
- **App Store guideline 4.2 mitigation**: The native Browse tab provides "minimum functionality" beyond a pure WebView wrapper, addressing Apple's stricter review criteria for web-only apps.
- **Deployment target**: iOS 16.0+, supporting both iPhone and iPad with appropriate orientation settings.
- **Entitlements**: Associated domains configured for Universal Links and web credentials.

https://claude.ai/code/session_01VCQ2usZJ3gcekWkJvEXUJf