### PR TITLE
Add trading game with portfolio and leaderboard screens

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,17 +1,42 @@
 # Idea Stock Exchange — Android app
 
-Native Android shell that mirrors `ios/`: a Jetpack Compose two-tab app over
-the deployed Idea Stock Exchange API.
+Native Android shell that mirrors `ios/`: a Jetpack Compose four-tab app over
+the deployed Idea Stock Exchange API, with a built-in fake-money trading game
+on top.
 
 - **Browse** — native list/detail that traverses *Reasons to Agree* and
   *Reasons to Disagree* via `/api/beliefs` and `/api/beliefs/[id]`. Each
   argument shows its impact, linkage, and importance scores; tapping it
   navigates into the child belief so the user can recursively walk the reason
   graph. The detail screen also surfaces the Cost-Benefit Analysis (benefits,
-  costs, and their likelihoods) and any Impact / Risks fields.
+  costs, and their likelihoods) and any Impact / Risks fields. From any
+  loaded belief the user can **Buy (Long)** or **Short** at the current
+  market price (derived from the strength-adjusted or overall score).
+- **Portfolio** — every player starts with **$10,000** of fake cash. This
+  tab shows current equity, realized + unrealized P&L, cash on hand, every
+  open position marked-to-market against the latest API score, and a close
+  button per position. There's a "Reset" affordance to wipe state and start
+  fresh. Persisted on-device as JSON in `filesDir/portfolio.json`.
+- **Top 10** — leaderboard ranked by net worth (cash + open-position
+  mark-to-market). The current player's row is computed live; the other nine
+  slots come from a static seed of fictional traders so a fresh install has
+  someone to play against. When a real backend leaderboard endpoint exists
+  we'll swap the seed list for an HTTP fetch.
 - **Web** — `WebView` over the deployed site for everything the native tab
   doesn't yet cover (Values & Interests Analysis, Evidence Ledger, Definitions,
   etc.).
+
+### Trading model
+
+- **Price** = `max(0.01, score × 100)` where `score` is the belief's
+  `strengthAdjustedScore` (preferred) or `overallScore`, both 0–1 from the
+  API. Beliefs without a score are not tradeable.
+- **Long**: buy `n` shares at price `p`. Cash decreases by `n × p`. P&L =
+  `n × (mark − p)`.
+- **Short**: collateral `n × p` is held. P&L = `n × (p − mark)`. Closing a
+  short returns `n × (2p − mark)` — collateral plus the price decline.
+- The portfolio file is rewritten atomically (temp + rename) on every trade,
+  so a crash mid-write can't corrupt state.
 
 The split exists for the same reason as iOS: Google's Play Store reviewers
 sometimes flag pure WebView wrappers under "Repetitive Content" / Minimum
@@ -74,13 +99,21 @@ android/
     └── src/main/
         ├── AndroidManifest.xml
         ├── java/com/ideastockexchange/app/
-        │   ├── MainActivity.kt    # Tab shell + Compose nav graph
+        │   ├── MainActivity.kt    # 4-tab shell + Compose nav graph
         │   ├── api/IseApi.kt      # HttpURLConnection-based JSON client
-        │   ├── model/Belief.kt    # @Serializable mirrors of the API shapes
+        │   ├── data/
+        │   │   ├── PortfolioStore.kt  # Atomic-write JSON store, $10k seed
+        │   │   └── Leaderboard.kt     # Top-10 builder + 9 mock seed traders
+        │   ├── model/
+        │   │   ├── Belief.kt      # @Serializable mirrors of the API shapes
+        │   │   └── Trading.kt     # Portfolio, Position, Side, pricing helpers
         │   └── ui/
         │       ├── theme/Theme.kt
         │       ├── list/          # Browseable list of beliefs
-        │       ├── detail/        # Pro/con + scores + CBA + impact + nav
+        │       ├── detail/        # Pro/con + scores + CBA + impact + Trade bar
+        │       ├── trade/         # Buy / Short confirmation dialog
+        │       ├── portfolio/     # Equity, positions, P&L, close
+        │       ├── leaderboard/   # Top 10 with rank badges
         │       └── web/WebScreen.kt
         └── res/
             ├── values/{strings,colors,themes}.xml

--- a/android/app/src/main/java/com/ideastockexchange/app/MainActivity.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/MainActivity.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Leaderboard
 import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -28,7 +30,9 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.ideastockexchange.app.ui.detail.BeliefDetailScreen
+import com.ideastockexchange.app.ui.leaderboard.LeaderboardScreen
 import com.ideastockexchange.app.ui.list.BeliefsListScreen
+import com.ideastockexchange.app.ui.portfolio.PortfolioScreen
 import com.ideastockexchange.app.ui.theme.IseTheme
 import com.ideastockexchange.app.ui.web.WebScreen
 
@@ -41,7 +45,12 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-private enum class RootTab(val title: String) { Browse("Browse"), Web("Web") }
+private enum class RootTab(val title: String) {
+    Browse("Browse"),
+    Portfolio("Portfolio"),
+    Leaderboard("Leaderboard"),
+    Web("Web"),
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,6 +74,18 @@ private fun RootScaffold() {
                     label = { Text("Browse") },
                 )
                 NavigationBarItem(
+                    selected = tab == RootTab.Portfolio,
+                    onClick = { tab = RootTab.Portfolio },
+                    icon = { Icon(Icons.Filled.ShowChart, contentDescription = null) },
+                    label = { Text("Portfolio") },
+                )
+                NavigationBarItem(
+                    selected = tab == RootTab.Leaderboard,
+                    onClick = { tab = RootTab.Leaderboard },
+                    icon = { Icon(Icons.Filled.Leaderboard, contentDescription = null) },
+                    label = { Text("Top 10") },
+                )
+                NavigationBarItem(
                     selected = tab == RootTab.Web,
                     onClick = { tab = RootTab.Web },
                     icon = { Icon(Icons.Filled.Public, contentDescription = null) },
@@ -75,6 +96,12 @@ private fun RootScaffold() {
     ) { padding ->
         when (tab) {
             RootTab.Browse -> BrowseTab(navController, padding)
+            RootTab.Portfolio -> androidx.compose.foundation.layout.Box(
+                modifier = Modifier.fillMaxSize().padding(padding)
+            ) { PortfolioScreen() }
+            RootTab.Leaderboard -> androidx.compose.foundation.layout.Box(
+                modifier = Modifier.fillMaxSize().padding(padding)
+            ) { LeaderboardScreen() }
             RootTab.Web -> WebScreen(modifier = Modifier.fillMaxSize().padding(padding))
         }
     }
@@ -132,6 +159,8 @@ private fun AppTopBar(navController: NavHostController, tab: RootTab) {
             Text(
                 when (tab) {
                     RootTab.Browse -> if (showBack) "Belief" else "Beliefs"
+                    RootTab.Portfolio -> "Portfolio"
+                    RootTab.Leaderboard -> "Top 10"
                     RootTab.Web -> "Idea Stock Exchange"
                 }
             )

--- a/android/app/src/main/java/com/ideastockexchange/app/data/Leaderboard.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/data/Leaderboard.kt
@@ -1,0 +1,49 @@
+package com.ideastockexchange.app.data
+
+import com.ideastockexchange.app.model.Portfolio
+
+// Top-10 leaderboard. The current user's row is computed live from the
+// PortfolioStore (cash + mark-to-market open positions). The other nine slots
+// come from a small static seed of fictional traders so the screen has
+// something to compare against on a fresh install. When/if a real backend
+// leaderboard endpoint exists we can swap this out for an HTTP fetch.
+
+data class LeaderboardEntry(
+    val rank: Int,
+    val displayName: String,
+    val netWorth: Double,
+    val isCurrentUser: Boolean,
+)
+
+object Leaderboard {
+
+    private data class Seed(val name: String, val netWorth: Double)
+
+    private val seedTraders = listOf(
+        Seed("MarketMaven", 18_420.50),
+        Seed("ContrarianCarl", 16_775.00),
+        Seed("ShortSqueezeSara", 15_910.25),
+        Seed("AlphaAlchemist", 14_050.75),
+        Seed("BeliefBaron", 13_220.10),
+        Seed("ReasonRanger", 12_405.60),
+        Seed("ProConPro", 11_780.00),
+        Seed("SteelmanSteve", 11_120.40),
+        Seed("EdgeOfReason", 10_555.85),
+    )
+
+    fun build(currentUserNetWorth: Double, currentUserName: String = "You"): List<LeaderboardEntry> {
+        val all = seedTraders.map { it.name to it.netWorth } +
+            (currentUserName to currentUserNetWorth)
+        return all
+            .sortedByDescending { it.second }
+            .take(10)
+            .mapIndexed { idx, (name, net) ->
+                LeaderboardEntry(
+                    rank = idx + 1,
+                    displayName = name,
+                    netWorth = net,
+                    isCurrentUser = name == currentUserName,
+                )
+            }
+    }
+}

--- a/android/app/src/main/java/com/ideastockexchange/app/data/PortfolioStore.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/data/PortfolioStore.kt
@@ -1,0 +1,159 @@
+package com.ideastockexchange.app.data
+
+import android.content.Context
+import com.ideastockexchange.app.model.Action
+import com.ideastockexchange.app.model.Portfolio
+import com.ideastockexchange.app.model.Position
+import com.ideastockexchange.app.model.Side
+import com.ideastockexchange.app.model.TradeEvent
+import com.ideastockexchange.app.model.unrealizedPnL
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.util.UUID
+
+// Persists the user's $10k trading game state to a single JSON file. Single
+// instance per process — call PortfolioStore.get(context) to share across
+// ViewModels. Reads/writes are guarded by a coroutine mutex; the JSON file is
+// rewritten atomically (temp file + rename) so a crash mid-write can't leave
+// a half-serialized blob.
+class PortfolioStore private constructor(
+    private val file: File,
+) {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = false
+        encodeDefaults = true
+    }
+    private val mutex = Mutex()
+    private val _state = MutableStateFlow(loadFromDisk())
+    val state: StateFlow<Portfolio> = _state.asStateFlow()
+
+    private fun loadFromDisk(): Portfolio = try {
+        if (file.exists()) json.decodeFromString(Portfolio.serializer(), file.readText())
+        else Portfolio()
+    } catch (_: Throwable) {
+        Portfolio()
+    }
+
+    private fun persist(portfolio: Portfolio) {
+        val tmp = File(file.parentFile, file.name + ".tmp")
+        tmp.writeText(json.encodeToString(Portfolio.serializer(), portfolio))
+        if (!tmp.renameTo(file)) {
+            file.writeText(json.encodeToString(Portfolio.serializer(), portfolio))
+            tmp.delete()
+        }
+    }
+
+    suspend fun reset() = mutex.withLock {
+        val fresh = Portfolio()
+        persist(fresh)
+        _state.value = fresh
+    }
+
+    suspend fun openPosition(
+        beliefId: Int,
+        statement: String,
+        side: Side,
+        shares: Int,
+        price: Double,
+        nowMillis: Long = System.currentTimeMillis(),
+    ): TradeResult = mutex.withLock {
+        if (shares <= 0) return@withLock TradeResult.Error("Enter at least 1 share.")
+        if (price <= 0.0) return@withLock TradeResult.Error("This belief doesn't have a tradeable price yet.")
+        val cost = shares * price
+        val current = _state.value
+        if (cost > current.cash) {
+            return@withLock TradeResult.Error(
+                "Not enough cash. Need $${"%.2f".format(cost)}, have $${"%.2f".format(current.cash)}."
+            )
+        }
+        val newPosition = Position(
+            id = UUID.randomUUID().toString(),
+            beliefId = beliefId,
+            statement = statement,
+            side = side,
+            shares = shares,
+            openPrice = price,
+            openedAtMillis = nowMillis,
+        )
+        val event = TradeEvent(
+            timestampMillis = nowMillis,
+            beliefId = beliefId,
+            statement = statement,
+            side = side,
+            action = Action.OPEN,
+            shares = shares,
+            price = price,
+        )
+        val next = current.copy(
+            cash = current.cash - cost,
+            positions = current.positions + newPosition,
+            history = (current.history + event).takeLast(MAX_HISTORY),
+        )
+        persist(next)
+        _state.value = next
+        TradeResult.Ok(newPosition)
+    }
+
+    suspend fun closePosition(
+        positionId: String,
+        markPrice: Double,
+        nowMillis: Long = System.currentTimeMillis(),
+    ): TradeResult = mutex.withLock {
+        val current = _state.value
+        val position = current.positions.firstOrNull { it.id == positionId }
+            ?: return@withLock TradeResult.Error("That position is no longer open.")
+        if (markPrice <= 0.0) return@withLock TradeResult.Error("No live price to close at.")
+
+        val proceeds = when (position.side) {
+            Side.LONG -> position.shares * markPrice
+            // Shorts: return the collateral + the price decline.
+            Side.SHORT -> position.shares * (2 * position.openPrice - markPrice)
+        }
+        val realized = position.unrealizedPnL(markPrice)
+        val event = TradeEvent(
+            timestampMillis = nowMillis,
+            beliefId = position.beliefId,
+            statement = position.statement,
+            side = position.side,
+            action = Action.CLOSE,
+            shares = position.shares,
+            price = markPrice,
+            realizedPnL = realized,
+        )
+        val next = current.copy(
+            cash = current.cash + proceeds,
+            positions = current.positions.filterNot { it.id == positionId },
+            realizedPnL = current.realizedPnL + realized,
+            history = (current.history + event).takeLast(MAX_HISTORY),
+        )
+        persist(next)
+        _state.value = next
+        TradeResult.Closed(realized)
+    }
+
+    sealed interface TradeResult {
+        data class Ok(val position: Position) : TradeResult
+        data class Closed(val realizedPnL: Double) : TradeResult
+        data class Error(val message: String) : TradeResult
+    }
+
+    companion object {
+        private const val MAX_HISTORY = 200
+        @Volatile private var instance: PortfolioStore? = null
+
+        fun get(context: Context): PortfolioStore {
+            instance?.let { return it }
+            return synchronized(this) {
+                instance ?: PortfolioStore(
+                    File(context.applicationContext.filesDir, "portfolio.json")
+                ).also { instance = it }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/ideastockexchange/app/model/Trading.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/model/Trading.kt
@@ -1,0 +1,77 @@
+package com.ideastockexchange.app.model
+
+import kotlinx.serialization.Serializable
+
+// On-device trading game state. The user opens with $10,000 of fake cash and
+// can buy long ("underrated") or short ("overrated") any belief whose
+// /api/beliefs/[id] response carries a usable score. Persisted as JSON in
+// `filesDir/portfolio.json` — see data/PortfolioStore.kt.
+
+@Serializable
+data class Portfolio(
+    val cash: Double = STARTING_CASH,
+    val positions: List<Position> = emptyList(),
+    val realizedPnL: Double = 0.0,
+    val history: List<TradeEvent> = emptyList(),
+) {
+    companion object {
+        const val STARTING_CASH: Double = 10_000.0
+    }
+}
+
+@Serializable
+data class Position(
+    val id: String,
+    val beliefId: Int,
+    val statement: String,
+    val side: Side,
+    val shares: Int,
+    val openPrice: Double,
+    val openedAtMillis: Long,
+)
+
+@Serializable
+enum class Side { LONG, SHORT }
+
+@Serializable
+data class TradeEvent(
+    val timestampMillis: Long,
+    val beliefId: Int,
+    val statement: String,
+    val side: Side,
+    val action: Action,
+    val shares: Int,
+    val price: Double,
+    val realizedPnL: Double = 0.0,
+)
+
+@Serializable
+enum class Action { OPEN, CLOSE }
+
+// Shared price formula. We treat the strength-adjusted (or overall) score as a
+// 0-1 quality signal and scale to dollars. A flat 1c floor keeps the math
+// from blowing up on beliefs whose API record is missing a score.
+fun priceFromScore(strengthAdjusted: Double?, overall: Double?): Double? {
+    val raw = strengthAdjusted ?: overall ?: return null
+    return (raw * 100.0).coerceAtLeast(0.01)
+}
+
+// Mark-to-market value if we closed every open position at `currentPrice` (a
+// map from beliefId -> latest price). Positions whose price isn't known yet
+// fall back to their open price (zero P&L).
+fun Portfolio.equity(currentPrice: Map<Int, Double>): Double {
+    val open = positions.sumOf { p ->
+        val mark = currentPrice[p.beliefId] ?: p.openPrice
+        when (p.side) {
+            Side.LONG -> p.shares * mark
+            // For shorts we hold the original sale proceeds plus any decline.
+            Side.SHORT -> p.shares * (2 * p.openPrice - mark)
+        }
+    }
+    return cash + open
+}
+
+fun Position.unrealizedPnL(mark: Double): Double = when (side) {
+    Side.LONG -> shares * (mark - openPrice)
+    Side.SHORT -> shares * (openPrice - mark)
+}

--- a/android/app/src/main/java/com/ideastockexchange/app/ui/detail/BeliefDetailScreen.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/ui/detail/BeliefDetailScreen.kt
@@ -20,12 +20,20 @@ import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.ThumbDown
 import androidx.compose.material.icons.filled.ThumbUp
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,8 +45,10 @@ import com.ideastockexchange.app.model.Argument
 import com.ideastockexchange.app.model.BeliefScores
 import com.ideastockexchange.app.model.CostBenefitAnalysis
 import com.ideastockexchange.app.model.ImpactAnalysis
+import com.ideastockexchange.app.model.Side
 import com.ideastockexchange.app.ui.theme.ConRed
 import com.ideastockexchange.app.ui.theme.ProGreen
+import com.ideastockexchange.app.ui.trade.TradeDialog
 
 @Composable
 fun BeliefDetailScreen(
@@ -49,7 +59,17 @@ fun BeliefDetailScreen(
 ) {
     LaunchedEffect(beliefId) { viewModel.loadIfNeeded(beliefId) }
     val state = viewModel.state
+    val snackbarHostState = remember { SnackbarHostState() }
+    var pendingSide: Side? by remember { mutableStateOf(null) }
 
+    LaunchedEffect(viewModel.tradeFeedback) {
+        viewModel.tradeFeedback?.let {
+            snackbarHostState.showSnackbar(it, duration = SnackbarDuration.Short)
+            viewModel.clearFeedback()
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -79,6 +99,13 @@ fun BeliefDetailScreen(
 
                 ScoreBanner(scores)
 
+                TradeBar(
+                    price = viewModel.currentPrice(),
+                    cash = viewModel.cash,
+                    onBuy = { pendingSide = Side.LONG },
+                    onShort = { pendingSide = Side.SHORT },
+                )
+
                 belief.costBenefitAnalysis?.let { CostBenefitCard(it, scores.cbaLikelihoodScore) }
                 belief.impactAnalysis?.let { ImpactCard(it) }
 
@@ -107,7 +134,88 @@ fun BeliefDetailScreen(
                         color = MaterialTheme.colorScheme.secondary,
                     )
                 }
+
+                pendingSide?.let { side ->
+                    val price = viewModel.currentPrice()
+                    if (price != null) {
+                        TradeDialog(
+                            statement = belief.statement,
+                            side = side,
+                            pricePerShare = price,
+                            cashAvailable = viewModel.cash,
+                            onDismiss = { pendingSide = null },
+                            onConfirm = { shares ->
+                                viewModel.openPosition(side, shares)
+                                pendingSide = null
+                            },
+                        )
+                    } else {
+                        pendingSide = null
+                    }
+                }
             }
+        }
+    }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter).padding(12.dp),
+        )
+    }
+}
+
+@Composable
+private fun TradeBar(
+    price: Double?,
+    cash: Double,
+    onBuy: () -> Unit,
+    onShort: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Market price", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.secondary)
+                Text(
+                    if (price != null) "$${"%.2f".format(price)} / share" else "—",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Cash on hand", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.secondary)
+                Text("$${"%.2f".format(cash)}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+                onClick = onBuy,
+                enabled = price != null,
+                colors = ButtonDefaults.buttonColors(containerColor = ProGreen),
+                modifier = Modifier.weight(1f),
+            ) { Text("Buy (Long)") }
+            Button(
+                onClick = onShort,
+                enabled = price != null,
+                colors = ButtonDefaults.buttonColors(containerColor = ConRed),
+                modifier = Modifier.weight(1f),
+            ) { Text("Short") }
+        }
+        if (price == null) {
+            Text(
+                "No score on file yet — this idea isn't tradeable until it has an overall or strength-adjusted score.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.secondary,
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/ideastockexchange/app/ui/detail/BeliefDetailViewModel.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/ui/detail/BeliefDetailViewModel.kt
@@ -1,12 +1,16 @@
 package com.ideastockexchange.app.ui.detail
 
+import android.app.Application
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.ideastockexchange.app.api.IseApi
+import com.ideastockexchange.app.data.PortfolioStore
 import com.ideastockexchange.app.model.BeliefDetailResponse
+import com.ideastockexchange.app.model.Side
+import com.ideastockexchange.app.model.priceFromScore
 import kotlinx.coroutines.launch
 
 sealed interface BeliefDetailState {
@@ -16,13 +20,26 @@ sealed interface BeliefDetailState {
 }
 
 class BeliefDetailViewModel(
-    private val api: IseApi = IseApi(),
-) : ViewModel() {
+    application: Application,
+) : AndroidViewModel(application) {
+
+    private val api: IseApi = IseApi()
+    private val portfolioStore = PortfolioStore.get(application)
 
     var state: BeliefDetailState by mutableStateOf(BeliefDetailState.Loading)
         private set
+    var tradeFeedback: String? by mutableStateOf(null)
+        private set
+    var cash: Double by mutableStateOf(portfolioStore.state.value.cash)
+        private set
 
     private var loadedId: Int = -1
+
+    init {
+        viewModelScope.launch {
+            portfolioStore.state.collect { cash = it.cash }
+        }
+    }
 
     fun loadIfNeeded(id: Int) {
         if (loadedId == id && state is BeliefDetailState.Loaded) return
@@ -36,4 +53,37 @@ class BeliefDetailViewModel(
             }
         }
     }
+
+    fun currentPrice(): Double? {
+        val loaded = state as? BeliefDetailState.Loaded ?: return null
+        val s = loaded.response.scores
+        return priceFromScore(s.strengthAdjustedScore, s.overallScore)
+    }
+
+    fun openPosition(side: Side, shares: Int) {
+        val loaded = state as? BeliefDetailState.Loaded ?: return
+        val price = currentPrice() ?: run {
+            tradeFeedback = "No live price for this belief yet."
+            return
+        }
+        val belief = loaded.response.belief
+        viewModelScope.launch {
+            tradeFeedback = when (val r = portfolioStore.openPosition(
+                beliefId = belief.id,
+                statement = belief.statement,
+                side = side,
+                shares = shares,
+                price = price,
+            )) {
+                is PortfolioStore.TradeResult.Ok -> {
+                    val verb = if (side == Side.LONG) "Bought" else "Shorted"
+                    "$verb $shares @ $${"%.2f".format(price)}."
+                }
+                is PortfolioStore.TradeResult.Error -> r.message
+                is PortfolioStore.TradeResult.Closed -> null
+            }
+        }
+    }
+
+    fun clearFeedback() { tradeFeedback = null }
 }

--- a/android/app/src/main/java/com/ideastockexchange/app/ui/leaderboard/LeaderboardScreen.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/ui/leaderboard/LeaderboardScreen.kt
@@ -1,0 +1,121 @@
+package com.ideastockexchange.app.ui.leaderboard
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ideastockexchange.app.data.LeaderboardEntry
+import com.ideastockexchange.app.model.Portfolio
+import com.ideastockexchange.app.ui.theme.ConRed
+import com.ideastockexchange.app.ui.theme.ProGreen
+
+@Composable
+fun LeaderboardScreen(viewModel: LeaderboardViewModel = viewModel()) {
+    val entries = viewModel.entries
+    val refreshing = viewModel.refreshing
+
+    Column(modifier = Modifier.fillMaxSize().padding(horizontal = 12.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Top 10 Traders", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "Ranked by net worth (cash + open positions, marked to market).",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.secondary,
+                )
+            }
+            OutlinedButton(onClick = { viewModel.refresh() }, enabled = !refreshing) {
+                Text(if (refreshing) "…" else "Refresh")
+            }
+        }
+        LazyColumn(
+            contentPadding = PaddingValues(vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            items(entries, key = { it.rank.toString() + it.displayName }) { entry ->
+                LeaderboardRow(entry)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LeaderboardRow(entry: LeaderboardEntry) {
+    val rowBg = if (entry.isCurrentUser) MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)
+    else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+    val pnl = entry.netWorth - Portfolio.STARTING_CASH
+    val pnlTint = if (pnl >= 0) ProGreen else ConRed
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(rowBg)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        RankBadge(entry.rank)
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                entry.displayName + if (entry.isCurrentUser) " (you)" else "",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (entry.isCurrentUser) FontWeight.SemiBold else FontWeight.Normal,
+            )
+            Text(
+                "${if (pnl >= 0) "+" else "-"}$${"%.2f".format(kotlin.math.abs(pnl))} P&L",
+                style = MaterialTheme.typography.labelSmall,
+                color = pnlTint,
+            )
+        }
+        Text(
+            "$${"%.2f".format(entry.netWorth)}",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun RankBadge(rank: Int) {
+    val tint = when (rank) {
+        1 -> Color(0xFFFFD700)
+        2 -> Color(0xFFC0C0C0)
+        3 -> Color(0xFFCD7F32)
+        else -> MaterialTheme.colorScheme.surfaceVariant
+    }
+    val textColor = if (rank <= 3) Color.Black else MaterialTheme.colorScheme.onSurface
+    androidx.compose.foundation.layout.Box(
+        modifier = Modifier
+            .size(32.dp)
+            .clip(CircleShape)
+            .background(tint),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("$rank", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold, color = textColor)
+    }
+}

--- a/android/app/src/main/java/com/ideastockexchange/app/ui/leaderboard/LeaderboardViewModel.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/ui/leaderboard/LeaderboardViewModel.kt
@@ -1,0 +1,62 @@
+package com.ideastockexchange.app.ui.leaderboard
+
+import android.app.Application
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.ideastockexchange.app.api.IseApi
+import com.ideastockexchange.app.data.Leaderboard
+import com.ideastockexchange.app.data.LeaderboardEntry
+import com.ideastockexchange.app.data.PortfolioStore
+import com.ideastockexchange.app.model.equity
+import com.ideastockexchange.app.model.priceFromScore
+import kotlinx.coroutines.launch
+
+class LeaderboardViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+
+    private val api: IseApi = IseApi()
+    private val store = PortfolioStore.get(application)
+    private val marks = mutableStateMapOf<Int, Double>()
+
+    var refreshing by mutableStateOf(false)
+        private set
+    var entries: List<LeaderboardEntry> by mutableStateOf(buildEntries())
+        private set
+
+    init {
+        refresh()
+        viewModelScope.launch {
+            store.state.collect { entries = buildEntries() }
+        }
+    }
+
+    fun refresh() {
+        if (refreshing) return
+        refreshing = true
+        viewModelScope.launch {
+            val ids = store.state.value.positions.map { it.beliefId }.toSet()
+            ids.forEach { id ->
+                try {
+                    val r = api.fetchBelief(id)
+                    val price = priceFromScore(r.scores.strengthAdjustedScore, r.scores.overallScore)
+                    if (price != null) marks[id] = price
+                } catch (_: Throwable) {
+                    // keep prior mark; one failed fetch shouldn't blank the leaderboard.
+                }
+            }
+            entries = buildEntries()
+            refreshing = false
+        }
+    }
+
+    private fun buildEntries(): List<LeaderboardEntry> {
+        val portfolio = store.state.value
+        val net = portfolio.equity(marks.toMap())
+        return Leaderboard.build(currentUserNetWorth = net)
+    }
+}

--- a/android/app/src/main/java/com/ideastockexchange/app/ui/list/BeliefsListViewModel.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/ui/list/BeliefsListViewModel.kt
@@ -15,9 +15,9 @@ sealed interface BeliefsListState {
     data class Error(val message: String) : BeliefsListState
 }
 
-class BeliefsListViewModel(
-    private val api: IseApi = IseApi(),
-) : ViewModel() {
+class BeliefsListViewModel : ViewModel() {
+
+    private val api: IseApi = IseApi()
 
     var state: BeliefsListState by mutableStateOf(BeliefsListState.Loading)
         private set

--- a/android/app/src/main/java/com/ideastockexchange/app/ui/portfolio/PortfolioScreen.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/ui/portfolio/PortfolioScreen.kt
@@ -1,0 +1,238 @@
+package com.ideastockexchange.app.ui.portfolio
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ideastockexchange.app.model.Portfolio
+import com.ideastockexchange.app.model.Side
+import com.ideastockexchange.app.ui.theme.ConRed
+import com.ideastockexchange.app.ui.theme.ProGreen
+
+@Composable
+fun PortfolioScreen(viewModel: PortfolioViewModel = viewModel()) {
+    val portfolio by viewModel.portfolioFlow.collectAsState()
+    LaunchedEffect(portfolio.positions.size) { viewModel.refresh() }
+    val ui = viewModel.uiState()
+    var showResetDialog by remember { mutableStateOf(false) }
+
+    if (showResetDialog) {
+        AlertDialog(
+            onDismissRequest = { showResetDialog = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.resetPortfolio()
+                    showResetDialog = false
+                }) { Text("Reset", color = ConRed) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showResetDialog = false }) { Text("Cancel") }
+            },
+            title = { Text("Reset portfolio?") },
+            text = { Text("All open positions are closed at zero P&L and your cash returns to $${"%.0f".format(Portfolio.STARTING_CASH)}.") },
+        )
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(horizontal = 12.dp)) {
+        SummaryCard(
+            cash = portfolio.cash,
+            equity = ui.equity,
+            totalPnL = ui.totalPnL,
+            realizedPnL = portfolio.realizedPnL,
+            refreshing = ui.refreshing,
+            onRefresh = { viewModel.refresh() },
+            onReset = { showResetDialog = true },
+        )
+
+        ui.refreshing.let {
+            // no-op; SummaryCard shows the spinner state.
+        }
+
+        viewModel.lastError?.let {
+            Text(
+                "Couldn't refresh: $it",
+                color = ConRed,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(vertical = 6.dp),
+            )
+        }
+
+        if (ui.rows.isEmpty()) {
+            EmptyState()
+        } else {
+            LazyColumn(
+                contentPadding = PaddingValues(vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                items(ui.rows, key = { it.position.id }) { row ->
+                    PositionRow(
+                        row = row,
+                        onClose = {
+                            row.markPrice?.let { mark ->
+                                viewModel.closePosition(row.position.id, mark)
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SummaryCard(
+    cash: Double,
+    equity: Double,
+    totalPnL: Double,
+    realizedPnL: Double,
+    refreshing: Boolean,
+    onRefresh: () -> Unit,
+    onReset: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f))
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text("Portfolio", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Stat("Equity", "$${"%.2f".format(equity)}", modifier = Modifier.weight(1f))
+            Stat(
+                label = "P&L",
+                value = "${if (totalPnL >= 0) "+" else "-"}$${"%.2f".format(kotlin.math.abs(totalPnL))}",
+                tint = if (totalPnL >= 0) ProGreen else ConRed,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Stat("Cash", "$${"%.2f".format(cash)}", modifier = Modifier.weight(1f))
+            Stat("Realized", "$${"%.2f".format(realizedPnL)}", modifier = Modifier.weight(1f))
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedButton(onClick = onRefresh, enabled = !refreshing, modifier = Modifier.weight(1f)) {
+                Text(if (refreshing) "Refreshing…" else "Refresh prices")
+            }
+            OutlinedButton(onClick = onReset, modifier = Modifier.weight(1f)) {
+                Text("Reset")
+            }
+        }
+    }
+}
+
+@Composable
+private fun Stat(label: String, value: String, modifier: Modifier = Modifier, tint: Color? = null) {
+    Column(modifier = modifier) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.secondary)
+        Text(
+            value,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = tint ?: MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun PositionRow(row: PortfolioRow, onClose: () -> Unit) {
+    val tint = if (row.position.side == Side.LONG) ProGreen else ConRed
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .border(1.dp, tint.copy(alpha = 0.30f), RoundedCornerShape(12.dp))
+            .background(tint.copy(alpha = 0.06f))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                if (row.position.side == Side.LONG) "LONG" else "SHORT",
+                style = MaterialTheme.typography.labelSmall,
+                color = tint,
+                fontWeight = FontWeight.Bold,
+            )
+            Text("${row.position.shares} sh", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.secondary)
+        }
+        Text(row.position.statement, style = MaterialTheme.typography.bodyMedium)
+        HorizontalDivider(color = Color(0x14000000))
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Stat("Open", "$${"%.2f".format(row.position.openPrice)}", modifier = Modifier.weight(1f))
+            Stat(
+                label = "Mark",
+                value = row.markPrice?.let { "$${"%.2f".format(it)}" } ?: "—",
+                modifier = Modifier.weight(1f),
+            )
+            Stat(
+                label = "P&L",
+                value = if (row.markPrice != null)
+                    "${if (row.unrealizedPnL >= 0) "+" else "-"}$${"%.2f".format(kotlin.math.abs(row.unrealizedPnL))}"
+                else "—",
+                tint = if (row.markPrice == null) null
+                else if (row.unrealizedPnL >= 0) ProGreen else ConRed,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Button(
+            onClick = onClose,
+            enabled = row.markPrice != null,
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(if (row.markPrice == null) "Close (waiting for price…)" else "Close at $${"%.2f".format(row.markPrice)}")
+        }
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Box(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text("No open positions yet.", style = MaterialTheme.typography.titleSmall)
+            Text(
+                "Browse the ideas and tap Buy on ones you think are underrated, or Short on overrated ones.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/ideastockexchange/app/ui/portfolio/PortfolioViewModel.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/ui/portfolio/PortfolioViewModel.kt
@@ -1,0 +1,111 @@
+package com.ideastockexchange.app.ui.portfolio
+
+import android.app.Application
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.ideastockexchange.app.api.IseApi
+import com.ideastockexchange.app.data.PortfolioStore
+import com.ideastockexchange.app.model.Portfolio
+import com.ideastockexchange.app.model.Position
+import com.ideastockexchange.app.model.equity
+import com.ideastockexchange.app.model.priceFromScore
+import com.ideastockexchange.app.model.unrealizedPnL
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class PortfolioRow(
+    val position: Position,
+    val markPrice: Double?,
+    val unrealizedPnL: Double,
+)
+
+data class PortfolioUiState(
+    val portfolio: Portfolio,
+    val marks: Map<Int, Double>,
+    val rows: List<PortfolioRow>,
+    val equity: Double,
+    val totalPnL: Double,
+    val refreshing: Boolean,
+)
+
+class PortfolioViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+
+    private val api: IseApi = IseApi()
+    private val store = PortfolioStore.get(application)
+
+    // Live mark-to-market cache. Refreshed on screen entry and on manual pull.
+    private val marks = mutableStateMapOf<Int, Double>()
+    var refreshing by mutableStateOf(false)
+        private set
+    var lastError: String? by mutableStateOf(null)
+        private set
+
+    val portfolioFlow: StateFlow<Portfolio> = store.state.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = store.state.value,
+    )
+
+    fun uiState(): PortfolioUiState {
+        val portfolio = portfolioFlow.value
+        val rows = portfolio.positions.map { p ->
+            val mark = marks[p.beliefId]
+            PortfolioRow(
+                position = p,
+                markPrice = mark,
+                unrealizedPnL = if (mark != null) p.unrealizedPnL(mark) else 0.0,
+            )
+        }
+        val equity = portfolio.equity(marks.toMap())
+        val totalPnL = equity - Portfolio.STARTING_CASH
+        return PortfolioUiState(
+            portfolio = portfolio,
+            marks = marks.toMap(),
+            rows = rows,
+            equity = equity,
+            totalPnL = totalPnL,
+            refreshing = refreshing,
+        )
+    }
+
+    fun refresh() {
+        if (refreshing) return
+        refreshing = true
+        lastError = null
+        viewModelScope.launch {
+            val ids = portfolioFlow.value.positions.map { it.beliefId }.toSet()
+            ids.forEach { id ->
+                try {
+                    val response = api.fetchBelief(id)
+                    val price = priceFromScore(
+                        response.scores.strengthAdjustedScore,
+                        response.scores.overallScore,
+                    )
+                    if (price != null) marks[id] = price
+                } catch (t: Throwable) {
+                    lastError = t.message ?: "Network error"
+                }
+            }
+            refreshing = false
+        }
+    }
+
+    fun closePosition(positionId: String, mark: Double) {
+        viewModelScope.launch { store.closePosition(positionId, mark) }
+    }
+
+    fun resetPortfolio() {
+        viewModelScope.launch {
+            store.reset()
+            marks.clear()
+        }
+    }
+}

--- a/android/app/src/main/java/com/ideastockexchange/app/ui/trade/TradeDialog.kt
+++ b/android/app/src/main/java/com/ideastockexchange/app/ui/trade/TradeDialog.kt
@@ -1,0 +1,105 @@
+package com.ideastockexchange.app.ui.trade
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.ideastockexchange.app.model.Side
+import com.ideastockexchange.app.ui.theme.ConRed
+import com.ideastockexchange.app.ui.theme.ProGreen
+
+@Composable
+fun TradeDialog(
+    statement: String,
+    side: Side,
+    pricePerShare: Double,
+    cashAvailable: Double,
+    onDismiss: () -> Unit,
+    onConfirm: (shares: Int) -> Unit,
+) {
+    var sharesText by remember { mutableStateOf("1") }
+    val shares = sharesText.toIntOrNull()?.coerceAtLeast(0) ?: 0
+    val cost = shares * pricePerShare
+    val tint = if (side == Side.LONG) ProGreen else ConRed
+    val verb = if (side == Side.LONG) "Buy" else "Short"
+    val rationale = if (side == Side.LONG)
+        "You think this idea is underrated and its score will rise."
+    else
+        "You think this idea is overrated and its score will fall."
+    val canConfirm = shares > 0 && cost <= cashAvailable && pricePerShare > 0.0
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = { if (canConfirm) onConfirm(shares) }, enabled = canConfirm) {
+                Text("$verb $shares share${if (shares == 1) "" else "s"}", color = tint, fontWeight = FontWeight.SemiBold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+        title = { Text("$verb position") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text(
+                    text = statement,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(rationale, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.secondary)
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(tint.copy(alpha = 0.10f))
+                        .padding(10.dp),
+                ) {
+                    KeyValue(label = "Price / share", value = "$${"%.2f".format(pricePerShare)}", modifier = Modifier.weight(1f))
+                    KeyValue(label = "Cash", value = "$${"%.2f".format(cashAvailable)}", modifier = Modifier.weight(1f))
+                }
+                OutlinedTextField(
+                    value = sharesText,
+                    onValueChange = { sharesText = it.filter { ch -> ch.isDigit() }.take(6) },
+                    label = { Text("Shares") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                val capacity = if (pricePerShare > 0) (cashAvailable / pricePerShare).toInt() else 0
+                Text(
+                    "Cost: $${"%.2f".format(cost)} • Max affordable: $capacity",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (cost > cashAvailable) ConRed else MaterialTheme.colorScheme.secondary,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun KeyValue(label: String, value: String, modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.secondary)
+        Text(value, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a complete fake-money trading game on top of the Idea Stock Exchange API, allowing users to buy long or short any belief at market prices derived from API scores. Includes persistent portfolio state, mark-to-market position tracking, and a leaderboard ranked by net worth.

## Key Changes

**Trading Game Core**
- New `Trading.kt` model classes: `Portfolio`, `Position`, `Side` (LONG/SHORT), `TradeEvent`, and `Action` (OPEN/CLOSE)
- `priceFromScore()` function converts belief scores to tradeable prices (1¢ floor)
- `Portfolio.equity()` and `Position.unrealizedPnL()` helpers for mark-to-market calculations
- Users start with $10,000 fake cash

**Data Persistence**
- `PortfolioStore` persists portfolio state to `filesDir/portfolio.json` with atomic writes (temp file + rename)
- Thread-safe mutations guarded by coroutine mutex
- Maintains trade history (last 200 events) and tracks realized P&L

**Portfolio Screen**
- `PortfolioScreen` displays summary card (equity, P&L, cash, realized P&L)
- Lists all open positions with mark-to-market values and unrealized P&L
- Close button per position (enabled when price is available)
- Reset affordance to wipe state and return to $10k
- Manual refresh button to fetch latest prices from API

**Leaderboard Screen**
- `LeaderboardScreen` shows top 10 traders ranked by net worth
- Current user's row computed live from portfolio state
- Other nine slots from static seed of fictional traders (enables comparison on fresh install)
- Highlights current user's row and displays P&L relative to starting capital

**Trade Entry Points**
- `BeliefDetailScreen` now shows a "Trade Bar" with current market price
- Buy/Short buttons open `TradeDialog` for share quantity input
- Validates cash availability and shows max affordable shares
- Integrates with `PortfolioStore` to persist trades
- Shows snackbar feedback on success/error

**ViewModels**
- `PortfolioViewModel` manages portfolio UI state, price caching, and refresh logic
- `LeaderboardViewModel` builds leaderboard entries and syncs with portfolio changes
- `BeliefDetailViewModel` extended to support trading (openPosition, currentPrice, tradeFeedback)

**Navigation**
- `MainActivity` expanded from 2 tabs to 4: Browse, Portfolio, Top 10, Web
- Added ShowChart and Leaderboard icons to bottom navigation

## Implementation Details
- Mark-to-market prices cached in-memory and refreshed on demand; positions fall back to open price if current price unavailable
- Short positions use formula: `shares * (2 * openPrice - markPrice)` to account for collateral
- Trade dialog validates inputs and prevents over-leveraging
- Portfolio state flows through Compose StateFlow for reactive UI updates
- Leaderboard seed traders ensure meaningful comparison even on fresh install

https://claude.ai/code/session_01KchBAk1Qf4oP7ts9vXk5pM