### PR TITLE
Add on-device trading game with portfolio and leaderboard tabs

### DIFF
--- a/docs/IOS.md
+++ b/docs/IOS.md
@@ -119,9 +119,16 @@ If none of those bite, stay on the wrapper. The two-codebase tax of going fully 
 ## File map
 
 - `ios/project.yml` — XcodeGen spec. Source of truth for bundle ID, deployment target, capabilities.
-- `ios/Sources/App/` — `@main` entry, root TabView. Tabs: **Web** (WKWebView) and **Browse** (native).
+- `ios/Sources/App/` — `@main` entry, root TabView with four tabs: **Browse** (native), **Portfolio**, **Top 10**, **Web** (WKWebView).
 - `ios/Sources/Web/WebViewScreen.swift` — `UIViewRepresentable` over `WKWebView`. Reads `ISEWebURL` from `Info.plist`.
-- `ios/Sources/Native/` — native Browse: list of beliefs, detail view that splits arguments into "Reasons to Agree" / "Reasons to Disagree" with each argument's impact score, and a recursive sub-argument view.
+- `ios/Sources/Native/` — native Browse: list of beliefs, detail view that splits arguments into "Reasons to Agree" / "Reasons to Disagree" with each argument's impact / linkage / importance scores, plus cost-benefit and impact cards and Buy / Short trade buttons.
+- `ios/Sources/Game/` — on-device trading game: `Portfolio` model, `PortfolioStore` (UserDefaults-backed), seed-trader leaderboard, `TradeSheet` modal, and the Portfolio + Top 10 tab views. Mirrors `android/.../ui/portfolio` and `android/.../ui/leaderboard`.
 - `ios/Resources/Info.plist` — bundle config, deployed URL key, App Transport Security defaults.
 - `ios/Resources/Assets.xcassets/` — app icon and accent color slots (placeholders).
 - `public/.well-known/apple-app-site-association` — Universal Links manifest. Fill in `TEAMID` before shipping.
+
+## Trading game (Step 2.5)
+
+The native tabs preload the user with $10,000 of fake money and let them buy long ("underrated") or short ("overrated") any belief that has an `overallScore` or `strengthAdjustedScore` on file. Per-share price is `max(score × 100, $0.01)` — the same formula as the Android client (`android/.../model/Trading.kt`), so a player on either platform sees the same prices.
+
+State lives in `UserDefaults` under `ISEPortfolio.v1` and survives reinstall only if the user backs the device up. There is **no server-side persistence** yet — the leaderboard's nine non-user rows are static seed data, ranked alongside the user's live net worth. Swap `Game/Leaderboard.swift` out for an HTTP fetch when a real `/api/leaderboard` endpoint exists.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,11 +1,13 @@
 # Idea Stock Exchange — iOS app
 
-A SwiftUI shell for the Idea Stock Exchange web app. Two tabs:
+A SwiftUI shell for the Idea Stock Exchange web app. Four tabs:
 
+- **Browse** — native list/detail that traverses *Reasons to Agree* and *Reasons to Disagree* using the `/api/beliefs` JSON API. Each argument shows its impact, linkage, and importance scores; tapping it navigates into the child belief so you can recursively walk the reason graph. The detail screen also surfaces costs, benefits, risks, and likelihoods, plus **Buy / Short** buttons that open positions in the on-device trading game.
+- **Portfolio** — the user's $10,000 fake-money account. Shows cash, equity, realized + unrealized P&L, and every open position with a Close button that closes at the latest fetched mark price. Pull-to-refresh re-fetches each open belief's score.
+- **Top 10** — the leaderboard. Net worth = cash + open positions marked to market. The user's row is computed live from the local store; the other nine are seed traders so the screen has comparators on a fresh install.
 - **Web** — `WKWebView` pointing at the deployed site. The whole product, exactly as it renders in Safari, with no browser chrome.
-- **Browse** — native list/detail that traverses *Reasons to Agree* and *Reasons to Disagree* using the `/api/beliefs` JSON API. Each argument shows its impact and linkage scores; tapping it navigates into the child belief so you can recursively walk the reason graph.
 
-The split exists because Apple's App Store guideline 4.2 ("Minimum Functionality") sometimes flags pure WebView wrappers. The native Browse tab gives reviewers something native to look at, and seeds the path toward a fully native rebuild later (`docs/IOS.md`, step 3).
+The native tabs exist because Apple's App Store guideline 4.2 ("Minimum Functionality") sometimes flags pure WebView wrappers. They give reviewers something native to look at, give users a real reason to install, and seed the path toward a fully native rebuild later (`docs/IOS.md`, step 3).
 
 ## Quick start (macOS)
 
@@ -32,14 +34,21 @@ ios/
 ├── Sources/
 │   ├── App/
 │   │   ├── IdeaStockExchangeApp.swift  # @main entry point
-│   │   └── RootView.swift              # TabView shell
+│   │   └── RootView.swift              # 4-tab shell (Browse / Portfolio / Top 10 / Web)
 │   ├── Web/
 │   │   └── WebViewScreen.swift         # WKWebView wrapper with loading + error states
-│   └── Native/
-│       ├── Models.swift                # Codables for /api/beliefs and /api/beliefs/[id]
-│       ├── ISEAPI.swift                # URLSession-based networking
-│       ├── BeliefsListView.swift       # Searchable list of beliefs
-│       └── BeliefDetailView.swift      # Score banner + Reasons-to-Agree / Reasons-to-Disagree
+│   ├── Native/
+│   │   ├── Models.swift                # Codables for /api/beliefs and /api/beliefs/[id]
+│   │   ├── ISEAPI.swift                # URLSession-based networking
+│   │   ├── BeliefsListView.swift       # Searchable list of beliefs
+│   │   └── BeliefDetailView.swift      # Score banner + CBA / Impact / arguments + trade bar
+│   └── Game/
+│       ├── Trading.swift               # Portfolio / Position / Side / pricing
+│       ├── PortfolioStore.swift        # UserDefaults-backed ObservableObject store
+│       ├── Leaderboard.swift           # Seed traders + Top 10 builder
+│       ├── TradeSheet.swift            # Buy / Short modal sheet
+│       ├── PortfolioView.swift         # Portfolio tab
+│       └── LeaderboardView.swift       # Top 10 tab
 └── Resources/
     ├── Info.plist                      # ISEWebURL, ATS, orientations
     ├── IdeaStockExchange.entitlements  # Associated domains for Universal Links

--- a/ios/Sources/App/RootView.swift
+++ b/ios/Sources/App/RootView.swift
@@ -1,25 +1,45 @@
 import SwiftUI
 
-/// Two-tab shell:
-///   - "Web" hosts a WKWebView pointing at the deployed site (the entire product).
-///   - "Browse" is a native list/detail that traverses reasons-to-agree/disagree
-///     using the JSON API. It exists primarily to clear App Store guideline 4.2
-///     ("minimum functionality") and to seed the path toward a fully native
-///     rebuild (docs/IOS.md, step 3).
+/// Four-tab shell:
+///   - "Browse" is a native list/detail that traverses reasons-to-agree /
+///     disagree using the JSON API. Each belief surfaces its costs, benefits,
+///     risks, and likelihoods, plus Buy/Short buttons that open positions in
+///     the on-device trading game.
+///   - "Portfolio" shows the user's $10,000 fake-money account: cash, equity,
+///     and every open position with mark-to-market P&L.
+///   - "Top 10" is the leaderboard of the highest-net-worth traders.
+///   - "Web" hosts a `WKWebView` over the deployed site for the full product.
+///
+/// The native tabs also clear App Store guideline 4.2 ("minimum
+/// functionality") — see ../README.md and docs/IOS.md.
 struct RootView: View {
     var body: some View {
         TabView {
-            WebViewScreen()
-                .tabItem {
-                    Label("Web", systemImage: "globe")
-                }
-
             NavigationStack {
                 BeliefsListView()
             }
             .tabItem {
                 Label("Browse", systemImage: "list.bullet.rectangle")
             }
+
+            NavigationStack {
+                PortfolioView()
+            }
+            .tabItem {
+                Label("Portfolio", systemImage: "chart.line.uptrend.xyaxis")
+            }
+
+            NavigationStack {
+                LeaderboardView()
+            }
+            .tabItem {
+                Label("Top 10", systemImage: "trophy.fill")
+            }
+
+            WebViewScreen()
+                .tabItem {
+                    Label("Web", systemImage: "globe")
+                }
         }
     }
 }

--- a/ios/Sources/Game/Leaderboard.swift
+++ b/ios/Sources/Game/Leaderboard.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Top-10 leaderboard. The current user's row is computed live from the
+/// PortfolioStore (cash + mark-to-market open positions). The other nine slots
+/// come from a small static seed of fictional traders so the screen has
+/// something to compare against on a fresh install. When/if a real backend
+/// leaderboard endpoint exists we can swap this out for an HTTP fetch.
+///
+/// Mirrors `android/.../data/Leaderboard.kt` so the two platforms feel
+/// identical at the leaderboard tab.
+
+struct LeaderboardEntry: Identifiable, Hashable {
+    let rank: Int
+    let displayName: String
+    let netWorth: Double
+    let isCurrentUser: Bool
+
+    var id: String { "\(rank)-\(displayName)" }
+}
+
+enum Leaderboard {
+    private struct Seed { let name: String; let netWorth: Double }
+
+    private static let seedTraders: [Seed] = [
+        Seed(name: "MarketMaven",      netWorth: 18_420.50),
+        Seed(name: "ContrarianCarl",   netWorth: 16_775.00),
+        Seed(name: "ShortSqueezeSara", netWorth: 15_910.25),
+        Seed(name: "AlphaAlchemist",   netWorth: 14_050.75),
+        Seed(name: "BeliefBaron",      netWorth: 13_220.10),
+        Seed(name: "ReasonRanger",     netWorth: 12_405.60),
+        Seed(name: "ProConPro",        netWorth: 11_780.00),
+        Seed(name: "SteelmanSteve",    netWorth: 11_120.40),
+        Seed(name: "EdgeOfReason",     netWorth: 10_555.85),
+    ]
+
+    static func build(currentUserNetWorth: Double, currentUserName: String = "You") -> [LeaderboardEntry] {
+        let combined: [(String, Double)] =
+            seedTraders.map { ($0.name, $0.netWorth) }
+            + [(currentUserName, currentUserNetWorth)]
+
+        return combined
+            .sorted { $0.1 > $1.1 }
+            .prefix(10)
+            .enumerated()
+            .map { idx, pair in
+                LeaderboardEntry(
+                    rank: idx + 1,
+                    displayName: pair.0,
+                    netWorth: pair.1,
+                    isCurrentUser: pair.0 == currentUserName
+                )
+            }
+    }
+}

--- a/ios/Sources/Game/LeaderboardView.swift
+++ b/ios/Sources/Game/LeaderboardView.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+/// Leaderboard tab: ranks the top 10 traders by net worth (cash + positions
+/// marked to the latest fetched score). Nine slots are seed traders so the
+/// screen has comparators on a fresh install; the tenth is the user.
+struct LeaderboardView: View {
+    @ObservedObject private var store = PortfolioStore.shared
+
+    @State private var marks: [Int: Double] = [:]
+    @State private var refreshing = false
+
+    private var entries: [LeaderboardEntry] {
+        let net = store.portfolio.equity(marks: marks)
+        return Leaderboard.build(currentUserNetWorth: net)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                header
+                ForEach(entries) { entry in
+                    LeaderboardRow(entry: entry)
+                }
+            }
+            .padding(16)
+        }
+        .navigationTitle("Top 10")
+        .refreshable { await refresh() }
+        .task { await refresh() }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Top 10 Traders")
+                    .font(.headline)
+                Text("Ranked by net worth (cash + open positions, marked to market).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button {
+                Task { await refresh() }
+            } label: {
+                if refreshing {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+            .buttonStyle(.bordered)
+            .disabled(refreshing)
+        }
+    }
+
+    private func refresh() async {
+        guard !refreshing else { return }
+        refreshing = true
+        defer { refreshing = false }
+
+        let ids = Set(store.portfolio.positions.map(\.beliefId))
+        for id in ids {
+            do {
+                let response = try await ISEAPI.shared.fetchBelief(id: id)
+                if let price = priceFromScore(
+                    strengthAdjusted: response.scores.strengthAdjustedScore,
+                    overall: response.scores.overallScore
+                ) {
+                    marks[id] = price
+                }
+            } catch {
+                // One failed fetch shouldn't blank the leaderboard — keep prior mark.
+            }
+        }
+    }
+}
+
+private struct LeaderboardRow: View {
+    let entry: LeaderboardEntry
+
+    private var pnl: Double { entry.netWorth - Portfolio.startingCash }
+    private var pnlTint: Color { pnl >= 0 ? .green : .red }
+    private var rowBackground: Color {
+        entry.isCurrentUser
+            ? Color.accentColor.opacity(0.12)
+            : Color.secondary.opacity(0.08)
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            RankBadge(rank: entry.rank)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.displayName + (entry.isCurrentUser ? " (you)" : ""))
+                    .font(.body)
+                    .fontWeight(entry.isCurrentUser ? .semibold : .regular)
+                Text(String(format: "%@$%.2f P&L",
+                            pnl >= 0 ? "+" : "-",
+                            abs(pnl)))
+                    .font(.caption)
+                    .foregroundStyle(pnlTint)
+                    .monospacedDigit()
+            }
+
+            Spacer()
+
+            Text(String(format: "$%.2f", entry.netWorth))
+                .font(.subheadline.weight(.semibold))
+                .monospacedDigit()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(rowBackground, in: RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+private struct RankBadge: View {
+    let rank: Int
+
+    private var tint: Color {
+        switch rank {
+        case 1: return Color(red: 1.0,  green: 0.84, blue: 0.0)   // gold
+        case 2: return Color(red: 0.75, green: 0.75, blue: 0.75)  // silver
+        case 3: return Color(red: 0.80, green: 0.50, blue: 0.20)  // bronze
+        default: return Color.secondary.opacity(0.25)
+        }
+    }
+    private var textColor: Color { rank <= 3 ? .black : .primary }
+
+    var body: some View {
+        Text("\(rank)")
+            .font(.caption.weight(.bold))
+            .foregroundStyle(textColor)
+            .frame(width: 32, height: 32)
+            .background(tint, in: Circle())
+    }
+}
+
+#Preview {
+    NavigationStack { LeaderboardView() }
+}

--- a/ios/Sources/Game/PortfolioStore.swift
+++ b/ios/Sources/Game/PortfolioStore.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Combine
+
+/// Persists the user's $10k trading game state to a single JSON blob in
+/// `UserDefaults`. Single shared instance per process — `PortfolioStore.shared`
+/// — so every screen sees the same snapshot.
+///
+/// `@Published` `portfolio` makes SwiftUI views reactive: any view holding an
+/// `@ObservedObject` reference re-renders when cash or positions change.
+///
+/// Mirrors `android/.../data/PortfolioStore.kt` (which uses a JSON file +
+/// coroutine mutex). On iOS, UserDefaults writes are atomic enough for the
+/// volume we're dealing with — a few KB at most.
+final class PortfolioStore: ObservableObject {
+    static let shared = PortfolioStore()
+
+    private static let storageKey = "ISEPortfolio.v1"
+    private static let maxHistory = 200
+
+    @Published private(set) var portfolio: Portfolio
+
+    private let defaults: UserDefaults
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        self.encoder = encoder
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+
+        if let data = defaults.data(forKey: Self.storageKey),
+           let loaded = try? decoder.decode(Portfolio.self, from: data) {
+            self.portfolio = loaded
+        } else {
+            self.portfolio = Portfolio()
+        }
+    }
+
+    // MARK: - Mutations
+
+    enum TradeResult {
+        case opened(Position)
+        case closed(realizedPnL: Double)
+        case error(String)
+    }
+
+    @discardableResult
+    func openPosition(
+        beliefId: Int,
+        statement: String,
+        side: Side,
+        shares: Int,
+        price: Double,
+        now: Date = Date()
+    ) -> TradeResult {
+        guard shares > 0 else {
+            return .error("Enter at least 1 share.")
+        }
+        guard price > 0 else {
+            return .error("This belief doesn't have a tradeable price yet.")
+        }
+        let cost = Double(shares) * price
+        if cost > portfolio.cash {
+            return .error(String(
+                format: "Not enough cash. Need $%.2f, have $%.2f.",
+                cost, portfolio.cash
+            ))
+        }
+
+        var next = portfolio
+        let position = Position(
+            id: UUID().uuidString,
+            beliefId: beliefId,
+            statement: statement,
+            side: side,
+            shares: shares,
+            openPrice: price,
+            openedAt: now
+        )
+        next.cash -= cost
+        next.positions.append(position)
+        next.history = trimmed(next.history + [TradeEvent(
+            timestamp: now,
+            beliefId: beliefId,
+            statement: statement,
+            side: side,
+            action: .open,
+            shares: shares,
+            price: price
+        )])
+
+        commit(next)
+        return .opened(position)
+    }
+
+    @discardableResult
+    func closePosition(
+        positionId: String,
+        markPrice: Double,
+        now: Date = Date()
+    ) -> TradeResult {
+        guard let position = portfolio.positions.first(where: { $0.id == positionId }) else {
+            return .error("That position is no longer open.")
+        }
+        guard markPrice > 0 else {
+            return .error("No live price to close at.")
+        }
+
+        let proceeds: Double = {
+            switch position.side {
+            case .long:
+                return Double(position.shares) * markPrice
+            case .short:
+                return Double(position.shares) * (2 * position.openPrice - markPrice)
+            }
+        }()
+        let realized = position.unrealizedPnL(mark: markPrice)
+
+        var next = portfolio
+        next.cash += proceeds
+        next.realizedPnL += realized
+        next.positions.removeAll { $0.id == positionId }
+        next.history = trimmed(next.history + [TradeEvent(
+            timestamp: now,
+            beliefId: position.beliefId,
+            statement: position.statement,
+            side: position.side,
+            action: .close,
+            shares: position.shares,
+            price: markPrice,
+            realizedPnL: realized
+        )])
+
+        commit(next)
+        return .closed(realizedPnL: realized)
+    }
+
+    func reset() {
+        commit(Portfolio())
+    }
+
+    // MARK: - Persistence
+
+    private func commit(_ next: Portfolio) {
+        portfolio = next
+        if let data = try? encoder.encode(next) {
+            defaults.set(data, forKey: Self.storageKey)
+        }
+    }
+
+    private func trimmed(_ events: [TradeEvent]) -> [TradeEvent] {
+        guard events.count > Self.maxHistory else { return events }
+        return Array(events.suffix(Self.maxHistory))
+    }
+}

--- a/ios/Sources/Game/PortfolioView.swift
+++ b/ios/Sources/Game/PortfolioView.swift
@@ -1,0 +1,250 @@
+import SwiftUI
+
+/// Portfolio tab: shows cash, equity, total P&L, and a list of every open
+/// position with its mark-to-market P&L. Each position has a Close button
+/// that closes at the latest fetched mark price.
+///
+/// On screen entry and on pull-to-refresh, we re-fetch each open belief's
+/// score so marks stay current.
+struct PortfolioView: View {
+    @ObservedObject private var store = PortfolioStore.shared
+
+    @State private var marks: [Int: Double] = [:]
+    @State private var refreshing = false
+    @State private var lastError: String?
+    @State private var showResetConfirm = false
+
+    private var equity: Double { store.portfolio.equity(marks: marks) }
+    private var totalPnL: Double { equity - Portfolio.startingCash }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                summaryCard
+
+                if let lastError {
+                    Label(lastError, systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+
+                if store.portfolio.positions.isEmpty {
+                    emptyState
+                } else {
+                    LazyVStack(alignment: .leading, spacing: 10) {
+                        ForEach(store.portfolio.positions) { position in
+                            PositionCard(
+                                position: position,
+                                markPrice: marks[position.beliefId],
+                                onClose: { close(position) }
+                            )
+                        }
+                    }
+                }
+            }
+            .padding(16)
+        }
+        .navigationTitle("Portfolio")
+        .refreshable { await refresh() }
+        .task { await refresh() }
+        .onChange(of: store.portfolio.positions) { _, _ in
+            Task { await refresh() }
+        }
+        .alert("Reset portfolio?", isPresented: $showResetConfirm) {
+            Button("Reset", role: .destructive) {
+                store.reset()
+                marks = [:]
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("All open positions are closed at zero P&L and your cash returns to $\(Int(Portfolio.startingCash)).")
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Portfolio")
+                .font(.headline)
+
+            HStack(spacing: 12) {
+                StatTile(label: "Equity",
+                         value: String(format: "$%.2f", equity))
+                StatTile(label: "P&L",
+                         value: signed(totalPnL),
+                         tint: totalPnL >= 0 ? .green : .red)
+            }
+            HStack(spacing: 12) {
+                StatTile(label: "Cash",
+                         value: String(format: "$%.2f", store.portfolio.cash))
+                StatTile(label: "Realized",
+                         value: signed(store.portfolio.realizedPnL),
+                         tint: store.portfolio.realizedPnL >= 0 ? .green : .red)
+            }
+            HStack(spacing: 8) {
+                Button {
+                    Task { await refresh() }
+                } label: {
+                    if refreshing {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Label("Refresh prices", systemImage: "arrow.clockwise")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(refreshing)
+                .frame(maxWidth: .infinity)
+
+                Button(role: .destructive) {
+                    showResetConfirm = true
+                } label: {
+                    Label("Reset", systemImage: "arrow.counterclockwise")
+                }
+                .buttonStyle(.bordered)
+                .frame(maxWidth: .infinity)
+            }
+            .font(.footnote.weight(.semibold))
+        }
+        .padding(14)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Text("No open positions yet.")
+                .font(.subheadline.weight(.semibold))
+            Text("Browse the ideas and tap Buy on ones you think are underrated, or Short on overrated ones.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+    }
+
+    // MARK: - Actions
+
+    private func refresh() async {
+        guard !refreshing else { return }
+        refreshing = true
+        lastError = nil
+        defer { refreshing = false }
+
+        let ids = Set(store.portfolio.positions.map(\.beliefId))
+        for id in ids {
+            do {
+                let response = try await ISEAPI.shared.fetchBelief(id: id)
+                if let price = priceFromScore(
+                    strengthAdjusted: response.scores.strengthAdjustedScore,
+                    overall: response.scores.overallScore
+                ) {
+                    marks[id] = price
+                }
+            } catch {
+                lastError = "Couldn't refresh: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func close(_ position: Position) {
+        guard let mark = marks[position.beliefId] else { return }
+        store.closePosition(positionId: position.id, markPrice: mark)
+    }
+
+    private func signed(_ value: Double) -> String {
+        let sign = value >= 0 ? "+" : "-"
+        return String(format: "%@$%.2f", sign, abs(value))
+    }
+}
+
+// MARK: - Position card
+
+private struct PositionCard: View {
+    let position: Position
+    let markPrice: Double?
+    let onClose: () -> Void
+
+    private var tint: Color { position.side == .long ? .green : .red }
+    private var pnl: Double {
+        guard let markPrice else { return 0 }
+        return position.unrealizedPnL(mark: markPrice)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text(position.side == .long ? "LONG" : "SHORT")
+                    .font(.caption.weight(.heavy))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(tint.opacity(0.18), in: Capsule())
+                    .foregroundStyle(tint)
+                Text("\(position.shares) sh")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(position.statement)
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 12) {
+                StatTile(label: "Open",
+                         value: String(format: "$%.2f", position.openPrice))
+                StatTile(label: "Mark",
+                         value: markPrice.map { String(format: "$%.2f", $0) } ?? "—")
+                StatTile(
+                    label: "P&L",
+                    value: markPrice == nil
+                        ? "—"
+                        : String(format: "%@$%.2f",
+                                 pnl >= 0 ? "+" : "-",
+                                 abs(pnl)),
+                    tint: markPrice == nil ? nil : (pnl >= 0 ? .green : .red)
+                )
+            }
+
+            Button(action: onClose) {
+                Text(markPrice == nil
+                     ? "Close (waiting for price…)"
+                     : String(format: "Close at $%.2f", markPrice ?? 0))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(tint)
+            .disabled(markPrice == nil)
+        }
+        .padding(12)
+        .background(tint.opacity(0.06), in: RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(tint.opacity(0.3), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Shared stat tile
+
+struct StatTile: View {
+    let label: String
+    let value: String
+    var tint: Color? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(tint ?? .primary)
+                .monospacedDigit()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+#Preview {
+    NavigationStack { PortfolioView() }
+}

--- a/ios/Sources/Game/TradeSheet.swift
+++ b/ios/Sources/Game/TradeSheet.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// Buy/Short modal. Opened from the belief detail screen when the user taps
+/// the Buy or Short button on the trade bar. Mirrors the Android `TradeDialog`
+/// so the two platforms feel identical at this critical step.
+struct TradeSheet: View {
+    let statement: String
+    let side: Side
+    let pricePerShare: Double
+    let cashAvailable: Double
+    let onConfirm: (Int) -> Void
+    let onCancel: () -> Void
+
+    @State private var sharesText: String = "1"
+
+    private var shares: Int {
+        max(0, Int(sharesText) ?? 0)
+    }
+
+    private var cost: Double { Double(shares) * pricePerShare }
+
+    private var canConfirm: Bool {
+        shares > 0 && cost <= cashAvailable && pricePerShare > 0
+    }
+
+    private var maxAffordable: Int {
+        guard pricePerShare > 0 else { return 0 }
+        return Int(cashAvailable / pricePerShare)
+    }
+
+    private var tint: Color { side == .long ? .green : .red }
+    private var verb: String { side == .long ? "Buy" : "Short" }
+    private var rationale: String {
+        side == .long
+            ? "You think this idea is underrated and its score will rise."
+            : "You think this idea is overrated and its score will fall."
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text(statement)
+                        .font(.body.weight(.semibold))
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(rationale)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Price / share")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text("$\(pricePerShare, specifier: "%.2f")")
+                                .font(.headline)
+                                .monospacedDigit()
+                        }
+                        Spacer()
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text("Cash")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text("$\(cashAvailable, specifier: "%.2f")")
+                                .font(.headline)
+                                .monospacedDigit()
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .listRowBackground(tint.opacity(0.08))
+
+                Section {
+                    HStack {
+                        Text("Shares")
+                        Spacer()
+                        TextField("0", text: $sharesText)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                            .monospacedDigit()
+                            .onChange(of: sharesText) { _, newValue in
+                                let digits = newValue.filter(\.isNumber)
+                                if digits != newValue {
+                                    sharesText = String(digits.prefix(6))
+                                } else if digits.count > 6 {
+                                    sharesText = String(digits.prefix(6))
+                                }
+                            }
+                    }
+                    HStack {
+                        Text("Cost")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("$\(cost, specifier: "%.2f")")
+                            .monospacedDigit()
+                            .foregroundStyle(cost > cashAvailable ? .red : .primary)
+                    }
+                    .font(.footnote)
+                    HStack {
+                        Text("Max affordable")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Use max") {
+                            sharesText = String(maxAffordable)
+                        }
+                        .font(.footnote.weight(.semibold))
+                        .disabled(maxAffordable < 1)
+                        Text("\(maxAffordable)")
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                    .font(.footnote)
+                }
+            }
+            .navigationTitle("\(verb) position")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", action: onCancel)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        if canConfirm { onConfirm(shares) }
+                    } label: {
+                        Text("\(verb) \(shares)")
+                            .fontWeight(.semibold)
+                    }
+                    .disabled(!canConfirm)
+                    .tint(tint)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}
+
+#Preview {
+    TradeSheet(
+        statement: "Adopting algorithm X reduces error rates by 30%.",
+        side: .long,
+        pricePerShare: 42.50,
+        cashAvailable: 9_500,
+        onConfirm: { _ in },
+        onCancel: {}
+    )
+}

--- a/ios/Sources/Game/Trading.swift
+++ b/ios/Sources/Game/Trading.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// On-device trading game state. The user opens with $10,000 of fake cash and
+/// can buy long ("underrated") or short ("overrated") any belief whose
+/// `/api/beliefs/[id]` response carries a usable score. Persisted as JSON in
+/// `UserDefaults` under `ISEPortfolio` — see `PortfolioStore.swift`.
+///
+/// Mirrors `android/.../model/Trading.kt` so the two platforms stay in sync.
+
+enum Side: String, Codable, Hashable {
+    case long = "LONG"
+    case short = "SHORT"
+}
+
+enum TradeAction: String, Codable, Hashable {
+    case open = "OPEN"
+    case close = "CLOSE"
+}
+
+struct Position: Codable, Identifiable, Hashable {
+    let id: String
+    let beliefId: Int
+    let statement: String
+    let side: Side
+    let shares: Int
+    let openPrice: Double
+    let openedAt: Date
+
+    func unrealizedPnL(mark: Double) -> Double {
+        switch side {
+        case .long:  return Double(shares) * (mark - openPrice)
+        case .short: return Double(shares) * (openPrice - mark)
+        }
+    }
+}
+
+struct TradeEvent: Codable, Identifiable, Hashable {
+    let id: String
+    let timestamp: Date
+    let beliefId: Int
+    let statement: String
+    let side: Side
+    let action: TradeAction
+    let shares: Int
+    let price: Double
+    let realizedPnL: Double
+
+    init(
+        id: String = UUID().uuidString,
+        timestamp: Date,
+        beliefId: Int,
+        statement: String,
+        side: Side,
+        action: TradeAction,
+        shares: Int,
+        price: Double,
+        realizedPnL: Double = 0
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.beliefId = beliefId
+        self.statement = statement
+        self.side = side
+        self.action = action
+        self.shares = shares
+        self.price = price
+        self.realizedPnL = realizedPnL
+    }
+}
+
+struct Portfolio: Codable, Hashable {
+    static let startingCash: Double = 10_000.0
+
+    var cash: Double = Portfolio.startingCash
+    var positions: [Position] = []
+    var realizedPnL: Double = 0
+    var history: [TradeEvent] = []
+
+    /// Mark-to-market value if every open position closed at `marks[beliefId]`.
+    /// Positions whose price isn't known yet fall back to their open price
+    /// (i.e. zero P&L), so the equity reading degrades gracefully on a network
+    /// failure rather than blanking out.
+    func equity(marks: [Int: Double]) -> Double {
+        let open = positions.reduce(0.0) { sum, p in
+            let mark = marks[p.beliefId] ?? p.openPrice
+            switch p.side {
+            case .long:
+                return sum + Double(p.shares) * mark
+            case .short:
+                // Shorts: we hold the original sale proceeds plus any decline.
+                return sum + Double(p.shares) * (2 * p.openPrice - mark)
+            }
+        }
+        return cash + open
+    }
+}
+
+/// Treat the strength-adjusted score (preferred, 0–1) or the overall score
+/// (-100..100 fallback) as a signal and convert to a per-share dollar price.
+/// A 1¢ floor keeps math sane when a belief's score is missing or negative.
+/// Returns nil if neither score is present so the UI can disable trading.
+func priceFromScore(strengthAdjusted: Double?, overall: Double?) -> Double? {
+    guard let raw = strengthAdjusted ?? overall else { return nil }
+    return max(raw * 100.0, 0.01)
+}

--- a/ios/Sources/Native/BeliefDetailView.swift
+++ b/ios/Sources/Native/BeliefDetailView.swift
@@ -1,15 +1,29 @@
 import SwiftUI
 
 /// Single-belief detail screen. Splits arguments into "Reasons to Agree" and
-/// "Reasons to Disagree", each row showing the argument's impact score. Tapping
-/// an argument navigates into that argument's child belief — the user can
-/// recursively traverse the reason graph from here.
+/// "Reasons to Disagree", surfaces the belief's costs/benefits/risks and
+/// likelihoods, and exposes Buy/Short trade buttons that open positions in
+/// the on-device trading game. Tapping an argument navigates into that
+/// argument's child belief — the user can recursively traverse the reason
+/// graph from here.
 struct BeliefDetailView: View {
     let beliefId: Int
     let initialStatement: String
 
+    @ObservedObject private var store = PortfolioStore.shared
+
     @State private var detail: BeliefDetailResponse?
     @State private var loadError: String?
+    @State private var pendingSide: Side?
+    @State private var feedbackMessage: String?
+
+    private var price: Double? {
+        guard let scores = detail?.scores else { return nil }
+        return priceFromScore(
+            strengthAdjusted: scores.strengthAdjustedScore,
+            overall: scores.overallScore
+        )
+    }
 
     var body: some View {
         ScrollView {
@@ -27,6 +41,22 @@ struct BeliefDetailView: View {
                 }
 
                 if let detail {
+                    TradeBar(
+                        price: price,
+                        cash: store.portfolio.cash,
+                        onBuy: { pendingSide = .long },
+                        onShort: { pendingSide = .short }
+                    )
+
+                    if let cba = detail.belief.costBenefitAnalysis {
+                        CostBenefitCard(cba: cba,
+                                        cbaLikelihoodScore: detail.scores.cbaLikelihoodScore)
+                    }
+
+                    if let impact = detail.belief.impactAnalysis {
+                        ImpactCard(impact: impact)
+                    }
+
                     let pro = detail.belief.arguments.filter { $0.isPro }
                     let con = detail.belief.arguments.filter { !$0.isPro }
 
@@ -57,32 +87,116 @@ struct BeliefDetailView: View {
             BeliefDetailView(beliefId: child.id, initialStatement: child.statement)
         }
         .task(id: beliefId) { await load() }
+        .sheet(item: $pendingSide) { side in
+            if let detail, let price {
+                TradeSheet(
+                    statement: detail.belief.statement,
+                    side: side,
+                    pricePerShare: price,
+                    cashAvailable: store.portfolio.cash,
+                    onConfirm: { shares in
+                        confirmTrade(side: side, shares: shares, price: price)
+                    },
+                    onCancel: { pendingSide = nil }
+                )
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if let feedbackMessage {
+                Text(feedbackMessage)
+                    .font(.footnote.weight(.medium))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(.ultraThinMaterial, in: Capsule())
+                    .padding(.bottom, 16)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+        }
+        .animation(.easeInOut, value: feedbackMessage)
     }
+
+    // MARK: - Actions
 
     private func load() async {
         do {
-            let response = try await ISEAPI.shared.fetchBelief(id: beliefId)
-            self.detail = response
+            self.detail = try await ISEAPI.shared.fetchBelief(id: beliefId)
             self.loadError = nil
         } catch {
             self.loadError = error.localizedDescription
         }
     }
+
+    private func confirmTrade(side: Side, shares: Int, price: Double) {
+        guard let belief = detail?.belief else { return }
+        let result = store.openPosition(
+            beliefId: belief.id,
+            statement: belief.statement,
+            side: side,
+            shares: shares,
+            price: price
+        )
+        switch result {
+        case .opened:
+            let verb = side == .long ? "Bought" : "Shorted"
+            showFeedback("\(verb) \(shares) @ $\(String(format: "%.2f", price))")
+        case .error(let message):
+            showFeedback(message)
+        case .closed:
+            break
+        }
+        pendingSide = nil
+    }
+
+    private func showFeedback(_ message: String) {
+        feedbackMessage = message
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            if feedbackMessage == message { feedbackMessage = nil }
+        }
+    }
 }
+
+// MARK: - Side conformance for .sheet(item:)
+
+extension Side: Identifiable {
+    var id: String { rawValue }
+}
+
+// MARK: - Score banner
 
 private struct ScoreBanner: View {
     let scores: BeliefScores?
 
     var body: some View {
-        HStack(spacing: 16) {
-            ScoreChip(label: "Pro",
-                      value: scores?.totalPro,
-                      tint: .green,
-                      sign: "+")
-            ScoreChip(label: "Con",
-                      value: scores?.totalCon,
-                      tint: .red,
-                      sign: "-")
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
+                ScoreChip(label: "Pro",
+                          value: scores?.totalPro,
+                          tint: .green,
+                          sign: "+")
+                ScoreChip(label: "Con",
+                          value: scores?.totalCon,
+                          tint: .red,
+                          sign: "-")
+            }
+            if scores?.overallScore != nil || scores?.strengthAdjustedScore != nil {
+                HStack(spacing: 12) {
+                    if let overall = scores?.overallScore {
+                        ScoreChip(label: "Overall",
+                                  value: overall * 100,
+                                  tint: .accentColor,
+                                  sign: "",
+                                  suffix: "%")
+                    }
+                    if let strength = scores?.strengthAdjustedScore {
+                        ScoreChip(label: "Strength-adj.",
+                                  value: strength * 100,
+                                  tint: .accentColor,
+                                  sign: "",
+                                  suffix: "%")
+                    }
+                }
+            }
         }
     }
 }
@@ -92,6 +206,7 @@ private struct ScoreChip: View {
     let value: Double?
     let tint: Color
     let sign: String
+    var suffix: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -99,7 +214,7 @@ private struct ScoreChip: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             if let value {
-                Text("\(sign)\(value, specifier: "%.1f")")
+                Text("\(sign)\(value, specifier: "%.1f")\(suffix)")
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(tint)
                     .monospacedDigit()
@@ -115,6 +230,150 @@ private struct ScoreChip: View {
     }
 }
 
+// MARK: - Trade bar
+
+private struct TradeBar: View {
+    let price: Double?
+    let cash: Double
+    let onBuy: () -> Void
+    let onShort: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                StatTile(label: "Market price",
+                         value: price.map { String(format: "$%.2f / share", $0) } ?? "—")
+                StatTile(label: "Cash on hand",
+                         value: String(format: "$%.2f", cash))
+            }
+            HStack(spacing: 8) {
+                Button(action: onBuy) {
+                    Label("Buy (Long)", systemImage: "arrow.up.right")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.green)
+                .disabled(price == nil)
+
+                Button(action: onShort) {
+                    Label("Short", systemImage: "arrow.down.right")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+                .disabled(price == nil)
+            }
+            .controlSize(.large)
+
+            if price == nil {
+                Text("No score on file yet — this idea isn't tradeable until it has an overall or strength-adjusted score.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// MARK: - Cost-benefit / impact
+
+private struct CostBenefitCard: View {
+    let cba: CostBenefitAnalysis
+    let cbaLikelihoodScore: Double?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Cost-Benefit Analysis")
+                .font(.subheadline.weight(.semibold))
+
+            if let benefits = cba.benefits, !benefits.isEmpty {
+                LabeledBlock(label: "Benefits",
+                             text: benefits,
+                             tint: .green,
+                             likelihood: cba.benefitLikelihood)
+            }
+            if let costs = cba.costs, !costs.isEmpty {
+                LabeledBlock(label: "Costs",
+                             text: costs,
+                             tint: .red,
+                             likelihood: cba.costLikelihood)
+            }
+            if let cbaLikelihoodScore {
+                Text("Net CBA likelihood: \(Int(cbaLikelihoodScore * 100))%")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct LabeledBlock: View {
+    let label: String
+    let text: String
+    let tint: Color
+    let likelihood: Double?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(tint)
+                if let likelihood {
+                    Text("likelihood \(Int(likelihood * 100))%")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Text(text)
+                .font(.footnote)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct ImpactCard: View {
+    let impact: ImpactAnalysis
+
+    private var rows: [(String, String)] {
+        var out: [(String, String)] = []
+        if let value = impact.shortTermEffects, !value.isEmpty { out.append(("Short-term effects", value)) }
+        if let value = impact.shortTermCosts,   !value.isEmpty { out.append(("Short-term costs",   value)) }
+        if let value = impact.longTermEffects,  !value.isEmpty { out.append(("Long-term effects",  value)) }
+        if let value = impact.longTermChanges,  !value.isEmpty { out.append(("Long-term changes",  value)) }
+        return out
+    }
+
+    var body: some View {
+        if rows.isEmpty {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Impact & Risks")
+                    .font(.subheadline.weight(.semibold))
+                ForEach(rows, id: \.0) { row in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(row.0)
+                            .font(.caption.weight(.semibold))
+                        Text(row.1)
+                            .font(.footnote)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(14)
+            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+        }
+    }
+}
+
+// MARK: - Argument list
+
 private struct ArgumentList: View {
     let title: String
     let systemImage: String
@@ -123,9 +382,14 @@ private struct ArgumentList: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Label(title, systemImage: systemImage)
-                .font(.headline)
-                .foregroundStyle(tint)
+            HStack(spacing: 6) {
+                Label(title, systemImage: systemImage)
+                    .font(.headline)
+                    .foregroundStyle(tint)
+                Text("(\(arguments.count))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
 
             if arguments.isEmpty {
                 Text("None recorded.")
@@ -156,7 +420,7 @@ private struct ArgumentRow: View {
                     .font(.subheadline)
                     .foregroundStyle(.primary)
                     .multilineTextAlignment(.leading)
-                Text("Impact \(argument.impactScore, specifier: "%.2f")  ·  Linkage \(argument.linkageScore, specifier: "%.2f")")
+                Text(scoreLine)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
@@ -172,6 +436,17 @@ private struct ArgumentRow: View {
             RoundedRectangle(cornerRadius: 10)
                 .stroke(tint.opacity(0.2), lineWidth: 1)
         )
+    }
+
+    private var scoreLine: String {
+        var parts = [
+            String(format: "Impact %.2f", argument.impactScore),
+            String(format: "Linkage %.2f", argument.linkageScore),
+        ]
+        if let importance = argument.importanceScore {
+            parts.append(String(format: "Importance %.2f", importance))
+        }
+        return parts.joined(separator: " · ")
     }
 }
 

--- a/ios/Sources/Native/Models.swift
+++ b/ios/Sources/Native/Models.swift
@@ -1,10 +1,11 @@
 import Foundation
 
 /// Decoders for the subset of `/api/beliefs` and `/api/beliefs/[id]` shapes the
-/// native Browse tab consumes. Only the fields needed for traversing reasons
-/// to agree / disagree and rendering scores are modeled — not the full
-/// canonical belief payload (Values, Interests, Cost-Benefit, etc.). Add more
-/// here as native screens grow.
+/// native Browse and trading-game tabs consume. Only the fields needed for
+/// traversing reasons to agree / disagree, rendering scores, and pricing
+/// positions are modeled — not the full canonical belief payload (Values,
+/// Interests, etc.). Mirrors `android/.../model/Belief.kt`; when a new field is
+/// needed on either platform, add it here too.
 
 // MARK: - List endpoint
 
@@ -46,11 +47,13 @@ struct BeliefDetailResponse: Decodable {
 
 struct BeliefDetail: Decodable, Identifiable {
     let id: Int
-    let slug: String
+    let slug: String?
     let statement: String
     let category: String?
     let subcategory: String?
     let arguments: [Argument]
+    let costBenefitAnalysis: CostBenefitAnalysis?
+    let impactAnalysis: ImpactAnalysis?
 }
 
 struct BeliefScores: Decodable {
@@ -58,6 +61,10 @@ struct BeliefScores: Decodable {
     let totalCon: Double?
     let totalSupportingEvidence: Double?
     let totalWeakeningEvidence: Double?
+    let overallScore: Double?
+    let cbaLikelihoodScore: Double?
+    let claimStrength: Double?
+    let strengthAdjustedScore: Double?
 }
 
 /// One argument in the belief's tree. `side` is "agree" or "disagree".
@@ -82,4 +89,20 @@ struct ChildBelief: Decodable, Hashable {
     let slug: String?
     let statement: String
     let positivity: Double?
+}
+
+// MARK: - Cost / benefit / impact
+
+struct CostBenefitAnalysis: Decodable, Hashable {
+    let benefits: String?
+    let benefitLikelihood: Double?
+    let costs: String?
+    let costLikelihood: Double?
+}
+
+struct ImpactAnalysis: Decodable, Hashable {
+    let shortTermEffects: String?
+    let shortTermCosts: String?
+    let longTermEffects: String?
+    let longTermChanges: String?
 }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -9,7 +9,7 @@ name: IdeaStockExchange
 options:
   bundleIdPrefix: com.ideastockexchange
   deploymentTarget:
-    iOS: "16.0"
+    iOS: "17.0"
   developmentLanguage: en
   groupSortPosition: top
   generateEmptyDirectories: true
@@ -17,7 +17,7 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.9"
-    IPHONEOS_DEPLOYMENT_TARGET: "16.0"
+    IPHONEOS_DEPLOYMENT_TARGET: "17.0"
     TARGETED_DEVICE_FAMILY: "1,2"      # iPhone + iPad
     ENABLE_PREVIEWS: YES
     CODE_SIGN_STYLE: Automatic
@@ -35,8 +35,8 @@ targets:
       path: Resources/Info.plist
       properties:
         CFBundleDisplayName: Idea Stock Exchange
-        CFBundleShortVersionString: "0.1.0"
-        CFBundleVersion: "1"
+        CFBundleShortVersionString: "0.2.0"
+        CFBundleVersion: "2"
         UILaunchScreen:
           UIColorName: AccentColor
         UISupportedInterfaceOrientations:


### PR DESCRIPTION
## Summary
This PR adds a complete on-device trading game to the iOS app, allowing users to open long/short positions on beliefs and track their performance. The app now has four tabs: Browse (native belief explorer), Portfolio (trading account), Top 10 (leaderboard), and Web (full product).

## Key Changes

**Trading Game Core**
- Added `Trading.swift` with domain models: `Side` (long/short), `Position`, `TradeEvent`, `Portfolio`, and `priceFromScore()` utility
- Implemented `PortfolioStore.swift` — a singleton that persists the user's $10,000 fake-money account to `UserDefaults` as JSON, with reactive `@Published` portfolio for SwiftUI binding
- Positions are marked to market using the latest fetched belief scores; equity gracefully degrades to open price if a mark is unavailable

**UI Components**
- `TradeSheet.swift` — modal for entering buy/short orders with share quantity, cost calculation, and max-affordable helper
- `PortfolioView.swift` — displays cash, equity, P&L, and a list of open positions with Close buttons; pull-to-refresh re-fetches marks
- `LeaderboardView.swift` — top-10 net-worth ranking with nine seed traders + the current user; computed live from the store
- Enhanced `BeliefDetailView.swift` with:
  - `TradeBar` showing market price and Buy/Short buttons
  - `CostBenefitCard` and `ImpactCard` to surface analysis fields
  - Trade confirmation flow with feedback messages
  - Updated `ScoreBanner` to display overall and strength-adjusted scores as percentages

**Data Model Updates**
- Extended `Models.swift` to decode `costBenefitAnalysis` and `impactAnalysis` from the API
- Made `slug` optional in `BeliefDetail`

**Navigation & Layout**
- Updated `RootView.swift` to a four-tab shell: Browse, Portfolio, Top 10, Web
- Bumped iOS deployment target to 17.0 (for `.sheet(item:)` and other modern APIs)

## Implementation Details

- **Persistence**: Portfolio state is atomic JSON in `UserDefaults`; no network backend required for the trading game
- **Price calculation**: `priceFromScore()` converts strength-adjusted (0–1) or overall (−100..100) scores to per-share dollars with a 1¢ floor
- **P&L logic**: Long positions gain/lose on mark-to-market; shorts gain when the mark falls below open price
- **Leaderboard**: Seed traders provide comparators on fresh install; user's row updates live as positions open/close
- **Feedback**: Trade confirmations show a 2.5-second toast with the executed trade details

https://claude.ai/code/session_017FZgHFHbR7jti5WwL6ZSgN