### PR TITLE
Add linkage evaluation template and database schema

### DIFF
--- a/sql/LINKAGE_ARCHITECTURE.md
+++ b/sql/LINKAGE_ARCHITECTURE.md
@@ -1,0 +1,91 @@
+# ISE Linkage Pages: Three-Layer Architecture
+
+This folder, together with `templates/linkage-evaluation-template.html`, contains everything needed to make a linkage page machine-readable from day one, without requiring a database to exist yet.
+
+## The three layers
+
+**Layer 1: HTML scaffolding with `data-*` attributes** (`templates/linkage-evaluation-template.html`)
+
+Every dynamic content slot in the visible HTML carries `data-ise-*` attributes that name what it is, where it comes from, and how it should be treated. A parser reading the HTML can find every score, every argument, every rephrasing without parsing prose. The attributes are invisible to humans; the page renders normally in any browser or wiki.
+
+The conventions are documented in the header comment of the template. The most important ones:
+
+- `data-ise-field="path.to.value"` names the canonical JSON path
+- `data-ise-source="database|computed|generated"` says where the value originates
+- `data-ise-audit-locked="true"` flags fields that must never be hand-edited
+- `data-ise-pattern="mechanism|missing-step|..."` classifies argument rows
+- `data-ise-section="section_name"` tags container elements
+
+**Layer 2: JSON-LD block at the top of the page** (embedded in template)
+
+A single `<script type="application/ld+json">` block at the top of every page contains the canonical machine-readable copy of every dynamic field. Anything reading the page (AI assistants, scoring engines, search indexes, migration scripts) reads this block, not the HTML below.
+
+If the JSON block and the HTML disagree, the JSON wins. The HTML below is a render of the JSON, not the other way around.
+
+The JSON schema is `https://ideastockexchange.org/schemas/v1` (placeholder URL; the real schema lives in this repo). Schema version is included in every page so a parser knows which version it's reading.
+
+**Layer 3: SQL schema** (`sql/linkage_pages_schema.sql`)
+
+The database tables that back the JSON-LD when the platform graduates from "wiki pages with embedded JSON" to "database-generated pages." Field names match the JSON paths exactly, so migration is mechanical.
+
+The schema enforces the audit-lock principle: scores have read-only-from-application semantics, with all changes logged to `score_audit_log`. The five-step check is its own table because the check IS the audit trail.
+
+The Prisma schema in `prisma/schema.prisma` already models the same domain on SQLite (`LinkageArgument`, `LinkageVote`, `LinkageScoreType`, etc.). The MariaDB schema in this folder is the target shape when the project graduates beyond SQLite.
+
+## How they interact today
+
+Right now, you're a human (or AI assistant) editing PBworks pages or the React belief pages directly. The flow is:
+
+1. Open the template, fill in the JSON-LD block with the canonical content
+2. Manually mirror the JSON values into the HTML below (or use a small script)
+3. Save the page on PBworks, or paste rendered output into the wiki
+
+A reader (human or machine) visits the page and:
+
+- A human reads the rendered HTML
+- An AI assistant or migration script reads the JSON-LD block
+
+## How they interact tomorrow
+
+Once the database exists, the flow becomes:
+
+1. A user submits an edit through a form
+2. The form writes to the database (subject to audit-lock, the engine recomputes scores)
+3. The page renderer queries `v_linkage_page` plus the supporting tables
+4. The renderer emits the HTML template with the JSON-LD block populated from the query result
+5. The page is served, with the same data-attribute markup it has today
+
+The migration is cheap because:
+
+- Field names already match between JSON-LD and SQL columns
+- The `data-*` attributes in the HTML are redundant with the JSON-LD, so the renderer doesn't need to maintain two systems
+- Pages built today using the template will be readable by the future renderer because the JSON-LD block is the contract
+
+## Why this is worth doing now, even though the production schema isn't deployed
+
+Without the structured layers, every page built today is a hand-crafted HTML artifact. Migrating a thousand of them later means writing a parser that reads prose and tries to extract structure. That's a worse problem than writing the structure correctly the first time.
+
+With the structured layers, every page built today carries its own machine-readable copy of itself. Migration is `INSERT INTO linkages SELECT ... FROM parsed_json_ld`. A thousand pages migrate in an afternoon.
+
+The `data-*` attributes alone are also worth the cost: they let an AI assistant know what fields it's allowed to edit (anything with `data-ise-source="database"` is database-sourced and shouldn't be hand-edited from the wiki). They let a search index find scores by name. They let an automated audit script verify that every page has a five-step check filled in.
+
+## What to do if you want to evolve the schema
+
+1. Update the canonical methodology page on PBworks first (mirrored at `docs/wiki/LinkageScores.md`)
+2. Update the JSON schema (bump `schema_version`)
+3. Update the SQL schema (add columns; never rename)
+4. Update the HTML template to match
+5. If the change affects the live React page (`src/app/arguments/[id]/linkage/page.tsx`) or the scoring engine (`src/core/scoring/scoring-engine.ts`), file an issue so code matches methodology
+6. Migrate existing pages incrementally; old pages should still validate against their original `schema_version`
+
+Don't fork the schema by editing only one layer. The propagation rule from the methodology applies to the schema too.
+
+## Related files in this repo
+
+- `templates/linkage-evaluation-template.html` &mdash; the template itself
+- `sql/linkage_pages_schema.sql` &mdash; MariaDB/MySQL schema
+- `prisma/schema.prisma` &mdash; the live SQLite schema (`LinkageArgument`, `LinkageVote`, etc.)
+- `src/app/arguments/[id]/linkage/page.tsx` &mdash; the live React linkage debate page
+- `src/core/scoring/scoring-engine.ts` &mdash; `calculateLinkageFromArguments`, depth attenuation
+- `src/features/epistemology/components/LinkageIndicator.tsx` &mdash; the badge component used elsewhere
+- `docs/wiki/LinkageScores.md` &mdash; mirror of the canonical PBworks methodology page

--- a/sql/linkage_pages_schema.sql
+++ b/sql/linkage_pages_schema.sql
@@ -1,0 +1,384 @@
+-- =================================================================
+-- ISE Linkage Pages: SQL Schema
+-- =================================================================
+--
+-- Defines the database tables that back every linkage evaluation page.
+-- The HTML template (templates/linkage-evaluation-template.html) is a
+-- RENDER of the data in these tables. The JSON-LD block embedded in
+-- each page is the on-the-wire serialization of these rows.
+--
+-- Schema version: 1.0.0
+-- Engine: MariaDB 10.4+ / MySQL 8.0+ (uses CHECK constraints, JSON type)
+-- Companion: src/core/scoring/scoring-engine.ts in the GitHub repo
+--   https://github.com/myklob/ideastockexchange
+--
+-- DESIGN PRINCIPLES
+-- -----------------
+-- 1. Audit-lock: scores are never updated by direct UPDATE on the
+--    score columns. They are recomputed by the ReasonRank engine and
+--    written via the recompute_scores() stored procedure (defined
+--    elsewhere). The columns exist for fast read access; the source
+--    of truth is the argument tree, not these columns.
+--
+-- 2. Soft delete: nodes are never deleted, only marked deleted_at.
+--    This preserves linkage history and prevents orphaned references.
+--
+-- 3. Field names match the JSON-LD paths in the template. If you add
+--    a column here, add the matching JSON path. If you rename, rename
+--    in both places at once.
+--
+-- 4. Every score column has a corresponding _computed_at timestamp
+--    so a reader can tell how stale the cached score is.
+--
+-- 5. Provenance columns track who created / last edited each row,
+--    including AI assistant sessions. Required for the audit trail.
+-- =================================================================
+
+
+-- -- Belief / argument / evidence nodes (referenced by linkages) --
+-- Linkage pages connect TWO nodes. Both nodes must already exist in
+-- this table before a linkage page can reference them. This table is
+-- shared with the belief page system; it's reproduced here for clarity
+-- but should be defined in a single canonical place.
+
+CREATE TABLE IF NOT EXISTS `nodes` (
+  `node_id`             VARCHAR(64)   NOT NULL,
+  `node_type`           ENUM('belief', 'argument', 'evidence') NOT NULL,
+  `canonical_statement` TEXT          NOT NULL,
+  `canonical_url`       VARCHAR(500)  DEFAULT NULL,
+
+  -- Cached scores. Source of truth is the recursive engine, not these.
+  `argument_score`      DECIMAL(5,4)  DEFAULT NULL,
+  `truth_score`         DECIMAL(5,4)  DEFAULT NULL,
+  `score_computed_at`   TIMESTAMP     NULL DEFAULT NULL,
+
+  -- Lifecycle
+  `created_at`          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  `created_by`          VARCHAR(128)  DEFAULT NULL,
+  `last_edited_at`      TIMESTAMP     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `last_edited_by`      VARCHAR(128)  DEFAULT NULL,
+  `deleted_at`          TIMESTAMP     NULL DEFAULT NULL,
+
+  PRIMARY KEY (`node_id`),
+  INDEX `idx_node_type` (`node_type`),
+  INDEX `idx_node_score` (`argument_score` DESC)
+);
+
+
+-- -- Linkage pages (the main table) -----------------------------
+-- One row per linkage page. The page's content is split across
+-- this table and the supporting tables below.
+
+CREATE TABLE IF NOT EXISTS `linkages` (
+  `linkage_id`          VARCHAR(64)   NOT NULL,
+
+  -- The two endpoints
+  `x_node_id`           VARCHAR(64)   NOT NULL,
+  `y_node_id`           VARCHAR(64)   NOT NULL,
+
+  -- Linkage metadata
+  `linkage_type`        ENUM('ECLS', 'ACLS') NOT NULL,
+  `direction`           ENUM('supports', 'weakens') NOT NULL,
+
+  -- Cached aggregate score. AUDIT-LOCKED: do not UPDATE directly.
+  -- Recomputed by the engine from the linkage_arguments table.
+  `linkage_score`       DECIMAL(5,4)  DEFAULT NULL,
+  `score_computed_at`   TIMESTAMP     NULL DEFAULT NULL,
+
+  -- Provenance
+  `created_at`          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  `created_by`          VARCHAR(128)  DEFAULT NULL,
+  `last_edited_at`      TIMESTAMP     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `last_edited_by`      VARCHAR(128)  DEFAULT NULL,
+  `template_version`    VARCHAR(16)   DEFAULT '1.0.0',
+  `deleted_at`          TIMESTAMP     NULL DEFAULT NULL,
+
+  PRIMARY KEY (`linkage_id`),
+  UNIQUE KEY `unique_pair` (`x_node_id`, `y_node_id`, `direction`),
+  INDEX `idx_x_node` (`x_node_id`),
+  INDEX `idx_y_node` (`y_node_id`),
+  INDEX `idx_linkage_score` (`linkage_score` DESC),
+
+  CONSTRAINT `fk_linkage_x` FOREIGN KEY (`x_node_id`) REFERENCES `nodes`(`node_id`),
+  CONSTRAINT `fk_linkage_y` FOREIGN KEY (`y_node_id`) REFERENCES `nodes`(`node_id`),
+  CONSTRAINT `chk_linkage_score_range` CHECK (`linkage_score` IS NULL OR (`linkage_score` >= -1 AND `linkage_score` <= 1))
+);
+
+
+-- -- Linkage arguments (the two-column debate on each page) -----
+-- Each row is one argument FOR or AGAINST the linkage. The page's
+-- linkage_score is the recursive aggregate of these rows.
+
+CREATE TABLE IF NOT EXISTS `linkage_arguments` (
+  `arg_id`              VARCHAR(64)   NOT NULL,
+  `linkage_id`          VARCHAR(64)   NOT NULL,
+  `side`                ENUM('agree', 'disagree') NOT NULL,
+  `position`            INT           NOT NULL,  -- ordering within side
+
+  -- Content
+  `claim`               VARCHAR(500)  NOT NULL,  -- short claim, 4-12 words
+  `description`         TEXT          NOT NULL,  -- 1-3 sentences
+
+  -- Pattern classification (matches data-ise-pattern in HTML)
+  `pattern`             ENUM(
+    'mechanism', 'necessity', 'scope-fit', 'monotonicity',
+    'missing-step', 'true-but-irrelevant', 'scope-mismatch',
+    'parent-mechanism-mismatch', 'reversal-at-scale', 'other'
+  ) DEFAULT 'other',
+
+  -- Cached scores. AUDIT-LOCKED.
+  `argument_score`      DECIMAL(5,4)  DEFAULT NULL,
+  `linkage_score_to_this_page` DECIMAL(5,4) DEFAULT NULL,
+  `score_computed_at`   TIMESTAMP     NULL DEFAULT NULL,
+
+  -- Provenance
+  `created_at`          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  `created_by`          VARCHAR(128)  DEFAULT NULL,
+  `deleted_at`          TIMESTAMP     NULL DEFAULT NULL,
+
+  PRIMARY KEY (`arg_id`),
+  INDEX `idx_linkage_side_position` (`linkage_id`, `side`, `position`),
+  INDEX `idx_pattern` (`pattern`),
+
+  CONSTRAINT `fk_arg_linkage` FOREIGN KEY (`linkage_id`) REFERENCES `linkages`(`linkage_id`)
+);
+
+
+-- -- Rephrasings (the equivalency table on each page) -----------
+-- Variants of X and Y, with their equivalency scores and resulting
+-- linkage scores. Drift is computed: drift = abs(L_canonical - L_variant).
+
+CREATE TABLE IF NOT EXISTS `linkage_rephrasings` (
+  `variant_id`          VARCHAR(64)   NOT NULL,
+  `linkage_id`          VARCHAR(64)   NOT NULL,
+  `target`              ENUM('x', 'y') NOT NULL,
+  `position`            INT           NOT NULL,  -- 0 = canonical
+
+  -- Rephrasing
+  `rephrasing_type`     ENUM(
+    'canonical', 'filler-stripped', 'active-voice',
+    'mechanism-explicit', 'quantified', 'scope-narrowed', 'other'
+  ) NOT NULL,
+  `text`                TEXT          NOT NULL,
+
+  -- Scores. AUDIT-LOCKED.
+  `equivalency_to_canonical`     DECIMAL(5,4) DEFAULT NULL,
+  `linkage_under_this_phrasing`  DECIMAL(5,4) DEFAULT NULL,
+  `drift`                        DECIMAL(5,4) DEFAULT NULL,
+  `score_computed_at`            TIMESTAMP    NULL DEFAULT NULL,
+
+  -- Provenance
+  `created_at`          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  `created_by`          VARCHAR(128)  DEFAULT NULL,
+
+  PRIMARY KEY (`variant_id`),
+  INDEX `idx_linkage_target_pos` (`linkage_id`, `target`, `position`),
+
+  CONSTRAINT `fk_rephrasing_linkage` FOREIGN KEY (`linkage_id`) REFERENCES `linkages`(`linkage_id`)
+);
+
+
+-- -- Five-step linkage check records ----------------------------
+-- One row per check performed on this linkage placement. Multiple
+-- checks may exist over time (re-run after edits, by different users).
+-- The most recent non-deleted row is shown on the rendered page.
+
+CREATE TABLE IF NOT EXISTS `linkage_checks` (
+  `check_id`                       VARCHAR(64)  NOT NULL,
+  `linkage_id`                     VARCHAR(64)  NOT NULL,
+
+  -- The five steps
+  `step_1_parent_claim_verbatim`   TEXT         NOT NULL,
+  `step_2_evidence_or_argument_verbatim` TEXT   NOT NULL,
+  `step_3_mechanism_one_sentence`  TEXT         NOT NULL,
+  `step_4_self_assessed_score`     DECIMAL(5,4) NOT NULL,
+  `step_4_dominant_factor`         ENUM(
+    'relevance', 'network-strength', 'contextual-fit', 'uniqueness'
+  ) NOT NULL,
+  `step_5_flagged_below_threshold` BOOLEAN      NOT NULL,
+  `step_5_action_taken`            TEXT         DEFAULT NULL,
+
+  -- Provenance (required for audit trail)
+  `performed_by`                   VARCHAR(128) NOT NULL,
+  `performed_at`                   TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+  `is_ai_assistant_check`          BOOLEAN      DEFAULT FALSE,
+  `ai_session_id`                  VARCHAR(128) DEFAULT NULL,
+
+  PRIMARY KEY (`check_id`),
+  INDEX `idx_linkage_performed` (`linkage_id`, `performed_at` DESC),
+
+  CONSTRAINT `fk_check_linkage` FOREIGN KEY (`linkage_id`) REFERENCES `linkages`(`linkage_id`),
+  CONSTRAINT `chk_step_4_range` CHECK (`step_4_self_assessed_score` >= 0 AND `step_4_self_assessed_score` <= 1)
+);
+
+
+-- -- Failure mode catalog ---------------------------------------
+-- Shared across all linkage pages. The Schiltz case is row 1 and is
+-- marked is_canonical_origin = TRUE. New failure modes are added as
+-- they're caught in the wild.
+
+CREATE TABLE IF NOT EXISTS `failure_modes` (
+  `failure_mode_id`     VARCHAR(64)   NOT NULL,
+  `failure_mode`        VARCHAR(64)   NOT NULL,  -- e.g., 'parent-mechanism-mismatch'
+  `name`                VARCHAR(128)  NOT NULL,  -- e.g., 'Schiltz case'
+  `is_canonical_origin` BOOLEAN       DEFAULT FALSE,
+
+  `x_text`              TEXT          NOT NULL,
+  `y_text`              TEXT          NOT NULL,
+  `why_it_fails`        TEXT          NOT NULL,  -- one sentence
+
+  -- Optional links to actual nodes if the example uses real ones
+  `x_node_id`           VARCHAR(64)   DEFAULT NULL,
+  `y_node_id`           VARCHAR(64)   DEFAULT NULL,
+
+  `created_at`          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  `created_by`          VARCHAR(128)  DEFAULT NULL,
+
+  PRIMARY KEY (`failure_mode_id`),
+  INDEX `idx_failure_mode` (`failure_mode`),
+
+  CONSTRAINT `fk_fm_x` FOREIGN KEY (`x_node_id`) REFERENCES `nodes`(`node_id`),
+  CONSTRAINT `fk_fm_y` FOREIGN KEY (`y_node_id`) REFERENCES `nodes`(`node_id`)
+);
+
+
+-- -- Hidden assumptions -----------------------------------------
+
+CREATE TABLE IF NOT EXISTS `linkage_assumptions` (
+  `assumption_id`       VARCHAR(64)   NOT NULL,
+  `linkage_id`          VARCHAR(64)   NOT NULL,
+  `direction`           ENUM('required-to-hold', 'required-to-fail') NOT NULL,
+  `position`            INT           NOT NULL,
+  `text`                TEXT          NOT NULL,
+
+  -- Optional link to a belief node if the assumption has its own page
+  `belief_node_id`      VARCHAR(64)   DEFAULT NULL,
+
+  `created_at`          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  `created_by`          VARCHAR(128)  DEFAULT NULL,
+
+  PRIMARY KEY (`assumption_id`),
+  INDEX `idx_linkage_dir_pos` (`linkage_id`, `direction`, `position`),
+
+  CONSTRAINT `fk_assumption_linkage` FOREIGN KEY (`linkage_id`) REFERENCES `linkages`(`linkage_id`),
+  CONSTRAINT `fk_assumption_belief` FOREIGN KEY (`belief_node_id`) REFERENCES `nodes`(`node_id`)
+);
+
+
+-- -- Bias risks -------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS `linkage_bias_risks` (
+  `risk_id`             VARCHAR(64)   NOT NULL,
+  `linkage_id`          VARCHAR(64)   NOT NULL,
+  `direction`           ENUM('inflates', 'deflates') NOT NULL,
+  `position`            INT           NOT NULL,
+  `bias_name`           VARCHAR(128)  NOT NULL,
+  `description`         TEXT          NOT NULL,
+
+  `created_at`          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  `created_by`          VARCHAR(128)  DEFAULT NULL,
+
+  PRIMARY KEY (`risk_id`),
+  INDEX `idx_linkage_direction_pos` (`linkage_id`, `direction`, `position`),
+
+  CONSTRAINT `fk_bias_linkage` FOREIGN KEY (`linkage_id`) REFERENCES `linkages`(`linkage_id`)
+);
+
+
+-- =================================================================
+-- READ VIEW: full linkage page in a single query
+-- =================================================================
+-- Convenience view that joins everything needed to render a page.
+-- The renderer queries this view, serializes the result as JSON-LD,
+-- and emits the HTML template with the JSON embedded.
+
+CREATE OR REPLACE VIEW `v_linkage_page` AS
+SELECT
+  l.linkage_id,
+  l.linkage_type,
+  l.direction,
+  l.linkage_score,
+  l.score_computed_at,
+  l.template_version,
+  l.created_at, l.created_by,
+  l.last_edited_at, l.last_edited_by,
+
+  -- X node
+  l.x_node_id,
+  x.canonical_statement AS x_canonical_statement,
+  x.canonical_url       AS x_canonical_url,
+  x.argument_score      AS x_argument_score,
+  x.node_type           AS x_node_type,
+
+  -- Y node
+  l.y_node_id,
+  y.canonical_statement AS y_canonical_statement,
+  y.canonical_url       AS y_canonical_url,
+  y.argument_score      AS y_argument_score,
+  y.node_type           AS y_node_type,
+
+  -- Computed: contribution to Y
+  (x.argument_score * l.linkage_score) AS contribution_to_y
+
+FROM linkages l
+JOIN nodes x ON l.x_node_id = x.node_id
+JOIN nodes y ON l.y_node_id = y.node_id
+WHERE l.deleted_at IS NULL
+  AND x.deleted_at IS NULL
+  AND y.deleted_at IS NULL;
+
+
+-- =================================================================
+-- AUDIT LOG (every score change traces here)
+-- =================================================================
+-- Required to satisfy the audit-lock principle. Any change to a
+-- score column logs a row here with the trigger that caused it.
+
+CREATE TABLE IF NOT EXISTS `score_audit_log` (
+  `audit_id`            BIGINT        NOT NULL AUTO_INCREMENT,
+  `table_name`          VARCHAR(64)   NOT NULL,
+  `row_id`              VARCHAR(64)   NOT NULL,
+  `column_name`         VARCHAR(64)   NOT NULL,
+  `old_value`           DECIMAL(5,4)  DEFAULT NULL,
+  `new_value`           DECIMAL(5,4)  DEFAULT NULL,
+  `triggered_by`        VARCHAR(128)  NOT NULL,  -- e.g., 'recompute_engine', 'manual_override'
+  `triggered_at`        TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  `reason`              TEXT          DEFAULT NULL,
+
+  PRIMARY KEY (`audit_id`),
+  INDEX `idx_table_row` (`table_name`, `row_id`),
+  INDEX `idx_triggered_at` (`triggered_at` DESC)
+);
+
+
+-- =================================================================
+-- NOTES FOR IMPLEMENTERS
+-- =================================================================
+--
+-- 1. The HTML template is a RENDER, not a source. Don't edit content
+--    on a rendered page expecting it to persist. Edit the database
+--    (or the JSON-LD if working in a wiki-only flow) and regenerate.
+--
+-- 2. Every score column is read-only from application code. Scores
+--    are written by recompute_scores(linkage_id) and similar stored
+--    procedures defined in the engine. Direct UPDATEs trigger the
+--    audit log and should be reviewed.
+--
+-- 3. AI assistants writing to this database MUST set is_ai_assistant
+--    flags and provide ai_session_id where applicable. This is the
+--    audit trail for AI-generated content.
+--
+-- 4. The five-step check is REQUIRED before inserting any new
+--    linkage_arguments row that affects the linkage_score. Check
+--    rows persist; they are not transient. The check IS the audit.
+--
+-- 5. To migrate an existing PBworks page to this schema: parse the
+--    embedded JSON-LD block, INSERT into linkages, then INSERT
+--    rows into the supporting tables. The data-* attributes in the
+--    HTML are redundant with the JSON-LD; parse the JSON-LD only.
+--
+-- 6. Note for SQLite parity: this schema uses MariaDB/MySQL ENUMs
+--    and CHECK constraints. The companion Prisma schema in
+--    prisma/schema.prisma already models the same domain on SQLite
+--    (LinkageArgument, LinkageVote, LinkageScoreType). When
+--    promoting from SQLite to MariaDB, this file is the target.

--- a/templates/linkage-evaluation-template.html
+++ b/templates/linkage-evaluation-template.html
@@ -1,0 +1,934 @@
+<!-- page=Linkage Evaluation Template -->
+<!-- content-type=text/html -->
+<!--
+  =================================================================
+  ISE LINKAGE EVALUATION PAGE TEMPLATE
+  =================================================================
+
+  WHAT THIS PAGE IS
+  -----------------
+  A linkage page evaluates a single CONNECTION between an argument (or
+  evidence) X and a claim Y. The proposition under debate is not whether
+  X is true and not whether Y is true. The proposition is whether X
+  actually bears on Y the way the placement implies.
+
+  Every linkage in the ISE argument graph deserves its own page when the
+  linkage is contested or important. The linkage score is computed from
+  this page's own argument tree, recursively, the same way belief scores
+  are computed from sub-arguments. Audit-lock applies: no manual scoring.
+
+  CANONICAL SOURCES (read these before editing this template)
+  -----------------------------------------------------------
+  Methodology page (the WHAT and WHY of linkage scores):
+    https://myclob.pbworks.com/w/page/159338766/Linkage%20Scores
+    docs/wiki/LinkageScores.md (mirror in this repo)
+
+  Companion templates and rules:
+    Belief page master template:  templates/belief-analysis-template.html
+    Belief page rules:            docs/BELIEF_PAGE_RULES.md
+    Argument scoring rules:
+      https://myclob.pbworks.com/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores
+    Evidence tiers and quality:
+      https://myclob.pbworks.com/w/page/159353568/Evidence
+    Belief Equivalency Engine (powers the rephrasings table):
+      https://myclob.pbworks.com/w/page/21956921/Beliefs
+
+  Live code that implements the scoring described on this page:
+    https://github.com/myklob/ideastockexchange
+    Specifically:
+      src/core/scoring/scoring-engine.ts    -- ReasonRank engine
+      src/core/scoring/all-scores.ts        -- All score types
+      src/app/arguments/[id]/linkage/page.tsx -- Live linkage debate page
+    If the methodology page and the code disagree, the methodology page
+    is canonical. File a code issue rather than amending the methodology
+    silently.
+
+  HOW THIS TEMPLATE RELATES TO THE BELIEF TEMPLATE
+  ------------------------------------------------
+  The belief template (templates/belief-analysis-template.html) describes
+  a CLAIM's place in the world: arguments for and against, evidence,
+  values, interests, costs, benefits, laws, compromises. A belief page
+  is multi-dimensional because beliefs are multi-dimensional.
+
+  This template describes a SINGLE EDGE in the argument graph: the
+  bridge between one X and one Y. It deliberately strips out the
+  world-context sections (values, interests, cost-benefit, legal
+  framework) because those describe what a belief means in the world,
+  not whether a logical connection holds. Loading them onto a linkage
+  page would dilute the page's job.
+
+  What the linkage template KEEPS from the belief template:
+    - Argument trees (two columns, recursive scoring)
+    - Hidden assumptions (because weak linkages reveal them)
+    - Bias risks (because motivated reasoning shows up in placements)
+    - Belief mapping (because a linkage participates in a graph)
+
+  What the linkage template ADDS that the belief template doesn't have:
+    - Proposition box (the "if X were true, would it necessarily...")
+    - Equivalent rephrasings of X and Y, with drift columns
+    - Five-step linkage check as a worked record for THIS placement
+    - Failure mode worked examples (Schiltz case is the canonical entry)
+
+  WHY THIS PAGE EXISTS AT ALL: THE SCHILTZ CASE
+  ---------------------------------------------
+  The Schiltz misplacement is the canonical failing case. The evidence
+  (96 court orders violated by ICE in January 2026) is high-tier T1.
+  The parent claim (MAGA broke the norms that constrain the powerful)
+  reads adjacent. The fluent restructuring looks fine on the page. It
+  only fails the linkage check, which is why the linkage check earns
+  its keep. Court order defiance is a separation-of-powers argument,
+  not a wealthy-elites-evading-rules argument. Different mechanism,
+  different parent.
+
+  This template exists because fluent prose is not a linkage check.
+  Naming the failure modes and forcing the explicit check is the only
+  reliable defense against confident-sounding misplacement.
+
+  HARD RULES (every linkage page must follow)
+  -------------------------------------------
+    1. The proposition is "If X were true, would it necessarily
+       [support / weaken] Y?" Not "is X true." Not "is Y true."
+
+    2. Reasons to agree must be about the BRIDGE: mechanism, entailment,
+       scope fit, temporal fit, monotonicity. Not about whether X or Y
+       is true on its own.
+
+    3. Reasons to disagree should test for known failure modes:
+       True But Irrelevant, missing intermediate step, scope mismatch,
+       scale mismatch, temporal mismatch, parent-mechanism mismatch.
+
+    4. Equivalent rephrasings of both X and Y are mandatory. If the
+       linkage only holds under one phrasing, it's rhetorical, not
+       logical. If it holds across five phrasings, it's robust.
+
+    5. Score cells stay blank until real sub-argument scoring exists.
+       Audit-lock: every score traces to linked nodes, never assigned
+       by hand. See the GitHub repo for the engine that computes them.
+
+    6. Default sort is argument score (evidence-counted). Vote ratio is
+       a SECONDARY view, never the default.
+
+    7. Contribution to parent = Argument Score (X) x Linkage Score
+       (this page's score). The linkage page produces the second number.
+
+    8. No broken links. No href="#". No href="[url]". Plain text if the
+       target page does not exist yet, with a TODO note at the bottom.
+
+    9. If the methodology evolves, update the canonical Linkage Scores
+       page FIRST, then propagate the change to this template, then to
+       individual linkage pages built from it. Don't fork the methodology.
+
+  STRUCTURED DATA ARCHITECTURE
+  ----------------------------
+  This template uses a three-layer architecture so machines can read
+  the same content humans see:
+
+  Layer 1: Static structure (HTML scaffolding). The tables, headers,
+           and section comments. Doesn't change between pages.
+
+  Layer 2: Dynamic content tagged with data-* attributes. Every slot
+           that varies between pages carries:
+             data-ise-field="json.path.to.value"
+                 Names the path into the JSON-LD block above where
+                 this value's canonical form lives.
+             data-ise-section="section_name"
+                 Tags container elements (tables, divs) so a parser
+                 can find the section without DOM walking.
+             data-ise-source="database|computed|generated"
+                 Tells the renderer where the value comes from.
+                 'database' = source of truth is the SQL row
+                 'computed' = derived from other fields (scores)
+                 'generated' = produced by templating from other fields
+             data-ise-audit-locked="true"
+                 Flags fields that must never be hand-edited. The
+                 linkage score itself is the canonical example.
+             data-ise-pattern="mechanism|missing-step|..."
+                 Tags argument rows with the canonical pattern they
+                 represent. Lets a parser group arguments by failure
+                 mode across pages.
+             data-ise-rephrasing-type="filler-stripped|active-voice|..."
+                 Tags rephrasing rows with which transformation type
+                 they apply.
+
+  Layer 3: A JSON-LD <script> block at the top of the page contains
+           the canonical machine-readable copy of every data-tagged
+           field. The HTML below is a render of this JSON. If they
+           disagree, the JSON wins.
+
+  WHY THIS MATTERS: today, the JSON block is filled in by hand or by
+  AI assistant. Tomorrow, it's queried from a SQL database (schema in
+  sql/linkage_pages_schema.sql) and the HTML is generated. Migration
+  is cheap because the field names already match. Scores updated in
+  the database propagate to every page that references them, no HTML
+  edits required.
+-->
+<div style="font-family:'Segoe UI', Arial, sans-serif; max-width:960px; margin:0 auto;">
+
+<!--
+  =================================================================
+  STRUCTURED DATA BLOCK (machine-readable canonical data)
+  =================================================================
+
+  This script tag embeds the canonical machine-readable version of
+  every dynamic field on this page. Humans see the HTML below; AI
+  assistants, scoring engines, search indexes, and migration scripts
+  should read THIS block instead of parsing HTML.
+
+  The HTML below is a RENDER of this JSON. If they disagree, this
+  block wins. The propagation rule is: edit the JSON first (or edit
+  the database that generates the JSON), then regenerate the HTML.
+
+  Field names match the SQL schema in:
+    sql/linkage_pages_schema.sql
+
+  Schema version is incremented when fields are added, removed, or
+  renamed. Old pages should still validate against the schema they
+  were created under; the renderer handles backward compatibility.
+-->
+<script type="application/ld+json" id="ise-linkage-data">
+{
+  "@context": "https://ideastockexchange.org/schemas/v1",
+  "@type": "LinkagePage",
+  "schema_version": "1.0.0",
+
+  "linkage_id": "[uuid-or-slug-for-this-linkage]",
+  "linkage_type": "[ECLS-or-ACLS]",
+  "direction": "[supports-or-weakens]",
+
+  "x_node": {
+    "node_id": "[uuid-or-slug]",
+    "node_type": "[argument-or-evidence]",
+    "canonical_statement": "[X full statement, verbatim]",
+    "canonical_url": "[URL of X's own page]"
+  },
+
+  "y_node": {
+    "node_id": "[uuid-or-slug]",
+    "node_type": "[claim-or-belief]",
+    "canonical_statement": "[Y full statement, verbatim]",
+    "canonical_url": "[URL of Y's own page]"
+  },
+
+  "scores": {
+    "linkage_score": null,
+    "linkage_score_computed_at": null,
+    "linkage_score_source": "argument-tree-aggregate",
+    "audit_lock": true,
+    "contribution_to_y": null,
+    "x_argument_score": null
+  },
+
+  "linkage_arguments": {
+    "agree": [
+      {
+        "arg_id": "[uuid]",
+        "claim": "[short claim, 4-12 words]",
+        "description": "[1-3 sentences]",
+        "argument_score": null,
+        "linkage_score_to_this_page": null,
+        "pattern": "mechanism|necessity|scope-fit|monotonicity|other"
+      }
+    ],
+    "disagree": [
+      {
+        "arg_id": "[uuid]",
+        "claim": "[short claim, 4-12 words]",
+        "description": "[1-3 sentences]",
+        "argument_score": null,
+        "linkage_score_to_this_page": null,
+        "pattern": "missing-step|true-but-irrelevant|scope-mismatch|parent-mechanism-mismatch|reversal-at-scale|other"
+      }
+    ]
+  },
+
+  "rephrasings": {
+    "x_variants": [
+      {
+        "variant_id": "[uuid]",
+        "rephrasing_type": "filler-stripped|active-voice|mechanism-explicit|quantified|scope-narrowed",
+        "text": "[rephrased X]",
+        "equivalency_to_canonical": null,
+        "linkage_under_this_phrasing": null,
+        "drift": null
+      }
+    ],
+    "y_variants": [
+      {
+        "variant_id": "[uuid]",
+        "rephrasing_type": "filler-stripped|active-voice|mechanism-explicit|quantified|scope-narrowed",
+        "text": "[rephrased Y]",
+        "equivalency_to_canonical": null,
+        "linkage_under_this_phrasing": null,
+        "drift": null
+      }
+    ]
+  },
+
+  "five_step_check": {
+    "step_1_parent_claim_verbatim": "[Y verbatim]",
+    "step_2_evidence_or_argument_verbatim": "[X verbatim]",
+    "step_3_mechanism_one_sentence": "[mechanism]",
+    "step_4_self_assessed_score": null,
+    "step_4_dominant_factor": "relevance|network-strength|contextual-fit|uniqueness",
+    "step_5_flagged_below_threshold": null,
+    "step_5_action_taken": "[if flagged, what was done]",
+    "performed_by": "[user_id or ai_assistant_session_id]",
+    "performed_at": null
+  },
+
+  "failure_mode_examples": [
+    {
+      "failure_mode": "parent-mechanism-mismatch",
+      "name": "Schiltz case",
+      "is_canonical_origin": true,
+      "x_text": "Chief Judge Schiltz, January 2026: ICE violated 96 court orders in 74 cases.",
+      "y_text": "MAGA broke the norms that constrain the powerful (insider trading, nepotism, financial disclosure).",
+      "why_it_fails": "X is about executive defiance of judicial orders, a separation-of-powers argument. Y is about wealthy and connected people evading rules that bind ordinary citizens. Different mechanism, different parent."
+    }
+  ],
+
+  "graph_position": {
+    "other_y_nodes_x_supports": [],
+    "other_x_nodes_supporting_y": []
+  },
+
+  "hidden_assumptions": {
+    "required_for_linkage_to_hold": [],
+    "required_for_linkage_to_fail": []
+  },
+
+  "bias_risks": {
+    "biases_inflating_score": [],
+    "biases_deflating_score": []
+  },
+
+  "provenance": {
+    "created_at": null,
+    "created_by": null,
+    "last_edited_at": null,
+    "last_edited_by": null,
+    "template_version": "1.0.0",
+    "canonical_methodology_url": "https://myclob.pbworks.com/w/page/159338766/Linkage%20Scores",
+    "engine_repo": "https://github.com/myklob/ideastockexchange",
+    "source_document": "ise_kialo_conversation.md"
+  }
+}
+</script>
+
+<style>
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 16px;
+  }
+  table th, table td {
+    border: 1px solid #b0b8c1;
+    padding: 8px 10px;
+    vertical-align: top;
+    text-align: left;
+  }
+  table thead th {
+    background-color: #f0f3f6;
+    font-weight: bold;
+  }
+  table tbody tr:nth-child(even) {
+    background-color: #fafbfc;
+  }
+  .arg-claim {
+    font-weight: 600;
+    display: block;
+    margin-bottom: 4px;
+  }
+  .arg-desc {
+    display: block;
+    color: #333;
+    font-size: 95%;
+    line-height: 1.45;
+  }
+  .prop-box {
+    background-color: #f7f9fb;
+    border: 1px solid #b0b8c1;
+    border-left: 4px solid #2c5282;
+    padding: 14px 18px;
+    margin-bottom: 16px;
+    border-radius: 3px;
+  }
+  .prop-box .prop-label {
+    font-size: 85%;
+    color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+  }
+  .prop-box .prop-text {
+    font-size: 110%;
+    line-height: 1.5;
+  }
+  .score-pill {
+    display: inline-block;
+    padding: 2px 10px;
+    background: #e8eef5;
+    border: 1px solid #b0b8c1;
+    border-radius: 12px;
+    font-size: 90%;
+    font-weight: 600;
+  }
+</style>
+
+<h1 data-ise-field="page_title" data-ise-source="generated">Linkage: <span data-ise-field="x_node.canonical_statement">[X]</span> &rarr; <span data-ise-field="y_node.canonical_statement">[Y]</span></h1>
+
+<!--
+  PROPOSITION BOX
+  ---------------
+  This is the single sentence that organizes the entire page. Every
+  argument, every rephrasing, every score below answers THIS question
+  and not "is X true" or "is Y true." Those are different pages.
+
+  If you can't write the proposition cleanly, the linkage probably
+  doesn't deserve its own page. Either the connection is obvious
+  (linkage ~ 1.0, no debate, leave inline on the parent belief page)
+  or the connection is so weak the placement should be removed
+  entirely (linkage near 0, find better evidence per Hard Rule #5).
+
+  The proposition box only earns its keep for CONTESTED linkages
+  somewhere in the 0.3 to 0.85 range, where the bridge is genuinely
+  arguable and the score moves the parent belief's outcome.
+-->
+<div class="prop-box" data-ise-section="proposition">
+  <div class="prop-label">Linkage proposition</div>
+  <div class="prop-text">
+    If <strong data-ise-field="x_node.canonical_statement">[X: short-form argument or evidence statement]</strong> were true, would it necessarily <strong data-ise-field="direction">[support / weaken]</strong> <strong data-ise-field="y_node.canonical_statement">[Y: short-form claim statement]</strong>?
+  </div>
+</div>
+
+<p data-ise-section="header_metadata">
+  <strong>Linkage Score:</strong> <span class="score-pill" data-ise-field="scores.linkage_score" data-ise-source="database" data-ise-audit-locked="true">[0.00&ndash;1.00]</span>
+  &nbsp;|&nbsp;
+  <strong>Type:</strong> <a href="https://myclob.pbworks.com/w/page/159338766/Linkage%20Scores" data-ise-field="linkage_type">[ECLS&nbsp;/&nbsp;ACLS]</a>
+  &nbsp;|&nbsp;
+  <strong>Direction:</strong> <span data-ise-field="direction">[Supports / Weakens]</span><br />
+  <strong>Argument or Evidence X:</strong> <a data-ise-field="x_node.canonical_url" href="[canonical X page]"><span data-ise-field="x_node.canonical_statement">[X full statement]</span></a><br />
+  <strong>Claim Y:</strong> <a data-ise-field="y_node.canonical_url" href="[canonical Y page]"><span data-ise-field="y_node.canonical_statement">[Y full statement]</span></a><br />
+  <strong>Contribution to Y:</strong> <span data-ise-field="scores.x_argument_score">[X arg score]</span> &times; <span data-ise-field="scores.linkage_score">[linkage]</span> = <span data-ise-field="scores.contribution_to_y" data-ise-source="computed">[computed from <a href="https://myclob.pbworks.com/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">sub-argument scores</a>]</span><br />
+  <strong>Scope note (optional):</strong> [Use only when the linkage is easily confused with a different one between similar X and Y. State what bridge this page is and is not evaluating.]
+</p>
+
+<h2>&nbsp;</h2>
+
+<!--
+  LINKAGE ARGUMENTS (the core of the page)
+  ----------------------------------------
+  This is where the linkage debate happens. Each row is its own argument
+  with its own argument score; the linkage score for this page is the
+  net aggregate, computed recursively by the ReasonRank engine. See
+  src/core/scoring/scoring-engine.ts in the GitHub repo.
+
+  CRITICAL: arguments here are about the BRIDGE, not the endpoints.
+  Wrong: "X is well-evidenced" (that's an X-page argument)
+  Wrong: "Y is morally correct" (that's a Y-page argument)
+  Right: "X's mechanism doesn't bear on Y because the populations differ"
+  Right: "X entails Y because of [named causal pathway]"
+
+  The pre-seeded rows map to the four canonical agree-side patterns
+  (mechanism, necessity, scope fit, monotonicity) and four canonical
+  disagree-side failure modes (missing step, True But Irrelevant,
+  scope mismatch, parent-mechanism mismatch). Replace placeholders
+  with actual arguments. Add rows as needed; keep symmetry between
+  columns where possible.
+-->
+<h1>&#128279; <a href="https://myclob.pbworks.com/Reasons">Linkage Arguments</a></h1>
+<p>Each argument below tests the bridge between X and Y, not the truth of X or Y. Reasons to agree explain why the connection is direct, necessary, or unavoidable. Reasons to disagree explain why the connection breaks: missing steps, mismatched scope, alternative explanations, or the True But Irrelevant pattern.</p>
+<table data-ise-section="linkage_arguments">
+<thead>
+  <tr>
+    <th width="50%">&#9989; Reasons the linkage is strong</th>
+    <th width="50%">&#10060; Reasons the linkage is weak</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td data-ise-field="linkage_arguments.agree[0]" data-ise-pattern="mechanism">
+      <span class="arg-claim" data-ise-field="linkage_arguments.agree[0].claim">1. [Mechanism: X causes Y through a named pathway]</span>
+      <span class="arg-desc" data-ise-field="linkage_arguments.agree[0].description">[1-3 sentences naming the causal or logical mechanism. The bridge from X to Y is direct, with few intermediate steps. Branch out to the relevant canonical page if the mechanism has its own treatment.]</span>
+    </td>
+    <td data-ise-field="linkage_arguments.disagree[0]" data-ise-pattern="missing-step">
+      <span class="arg-claim" data-ise-field="linkage_arguments.disagree[0].claim">1. [Missing intermediate step]</span>
+      <span class="arg-desc" data-ise-field="linkage_arguments.disagree[0].description">[1-3 sentences identifying what hidden assumption must be true for X to support Y. Link to <a href="https://myclob.pbworks.com/Assumptions">Assumptions</a> if the gap reveals a foundational premise.]</span>
+    </td>
+  </tr>
+  <tr>
+    <td data-ise-field="linkage_arguments.agree[1]" data-ise-pattern="necessity">
+      <span class="arg-claim" data-ise-field="linkage_arguments.agree[1].claim">2. [Necessity: if X is true, Y must be strengthened]</span>
+      <span class="arg-desc" data-ise-field="linkage_arguments.agree[1].description">[Explain why no plausible scenario allows X to be true while Y stays unchanged.]</span>
+    </td>
+    <td data-ise-field="linkage_arguments.disagree[1]" data-ise-pattern="true-but-irrelevant">
+      <span class="arg-claim" data-ise-field="linkage_arguments.disagree[1].claim">2. [True But Irrelevant: X is true but does not bear on Y]</span>
+      <span class="arg-desc" data-ise-field="linkage_arguments.disagree[1].description">[Identify why X, even granted as fact, does not move the needle on Y. This is the most common linkage failure mode.]</span>
+    </td>
+  </tr>
+  <tr>
+    <td data-ise-field="linkage_arguments.agree[2]" data-ise-pattern="scope-fit">
+      <span class="arg-claim" data-ise-field="linkage_arguments.agree[2].claim">3. [Scope fit: X's domain matches Y's domain]</span>
+      <span class="arg-desc" data-ise-field="linkage_arguments.agree[2].description">[Population, timeframe, and context align between X and Y.]</span>
+    </td>
+    <td data-ise-field="linkage_arguments.disagree[2]" data-ise-pattern="scope-mismatch">
+      <span class="arg-claim" data-ise-field="linkage_arguments.disagree[2].claim">3. [Scope or scale mismatch]</span>
+      <span class="arg-desc" data-ise-field="linkage_arguments.disagree[2].description">[X is from a different population, scale, or time period than Y. Extrapolation fails.]</span>
+    </td>
+  </tr>
+  <tr>
+    <td data-ise-field="linkage_arguments.agree[3]" data-ise-pattern="monotonicity">
+      <span class="arg-claim" data-ise-field="linkage_arguments.agree[3].claim">4. [Monotonicity: more X means more Y, consistently]</span>
+      <span class="arg-desc" data-ise-field="linkage_arguments.agree[3].description">[The relationship doesn&apos;t reverse direction at any plausible value of X.]</span>
+    </td>
+    <td data-ise-field="linkage_arguments.disagree[3]" data-ise-pattern="parent-mechanism-mismatch">
+      <span class="arg-claim" data-ise-field="linkage_arguments.disagree[3].claim">4. [Parent-mechanism mismatch]</span>
+      <span class="arg-desc" data-ise-field="linkage_arguments.disagree[3].description">[X belongs under a different parent claim than Y. The fluent reading is misleading. (See Schiltz case in <em>Failure Mode Worked Examples</em> below.)]</span>
+    </td>
+  </tr>
+</tbody>
+</table>
+<p><em>Linkage arguments are scored by the same recursive engine as belief arguments. Each row above has its own argument score; the linkage score for this page is the net aggregate. See <a href="https://myclob.pbworks.com/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">Argument Scores from Sub-Argument Scores</a>.</em></p>
+
+<h2>&nbsp;</h2>
+
+<!--
+  EQUIVALENT REPHRASINGS (the robustness check)
+  ---------------------------------------------
+  This is the section that no other debate platform has. It tests
+  whether the linkage is logical or merely rhetorical. If you can
+  rephrase X five ways and the linkage to Y stays steady, the linkage
+  is robust. If the linkage only holds under one specific phrasing,
+  the connection depends on word choice, not logic.
+
+  The five rephrasing types map to the Pinker-style writing rules
+  the ISE uses elsewhere:
+    1. Filler-stripped: cut zombie nouns, hedges, throat-clearing
+    2. Active voice: name the actor, name the date
+    3. Mechanism-explicit: state the causal pathway in the sentence
+    4. Quantified: replace adjectives with numbers where possible
+    5. Scope-narrowed: pin down the population, time, and context
+
+  Each rephrasing type tests a different way the original might be
+  doing rhetorical work. If the linkage falls apart under "active
+  voice with named actor," the original was probably hiding behind
+  passive construction. If it falls apart under "scope-narrowed,"
+  the original was overgeneralizing.
+
+  Equivalency scores come from the Belief Equivalency Engine. See
+  src/core/scoring/all-scores.ts (calculateBeliefEquivalencyScore).
+  Scores combine mechanical similarity (token overlap after synonym
+  canonicalization) and semantic similarity (cosine of embeddings).
+-->
+<h1>&#128221; Equivalent Rephrasings</h1>
+<p>If the same linkage holds across multiple phrasings of X and Y, it&apos;s logically robust. If it only holds under one phrasing, the linkage is rhetorical, not logical. Equivalency scores come from the <a href="https://myclob.pbworks.com/w/page/21956921/Beliefs">Belief Equivalency Engine</a>; if a rephrasing produces a substantially different linkage score, the linkage is fragile and that fragility itself is informative.</p>
+
+<h3>Rephrasings of X (the argument or evidence)</h3>
+<table data-ise-section="rephrasings.x_variants">
+<thead>
+  <tr>
+    <th width="6%">#</th>
+    <th width="54%">Rephrased X</th>
+    <th width="14%">Equivalency to canonical X</th>
+    <th width="14%">Linkage to Y under this phrasing</th>
+    <th width="12%">Drift</th>
+  </tr>
+</thead>
+<tbody>
+  <tr data-ise-rephrasing-type="canonical"><td>0</td><td><strong data-ise-field="x_node.canonical_statement">[Canonical X]</strong></td><td>1.00</td><td data-ise-field="x_variants[0].linkage_under_this_phrasing">[L0]</td><td>&mdash;</td></tr>
+  <tr data-ise-rephrasing-type="filler-stripped"><td>1</td><td data-ise-field="x_variants[1].text">[Filler-stripped, plain language]</td><td data-ise-field="x_variants[1].equivalency_to_canonical"></td><td data-ise-field="x_variants[1].linkage_under_this_phrasing"></td><td data-ise-field="x_variants[1].drift"></td></tr>
+  <tr data-ise-rephrasing-type="active-voice"><td>2</td><td data-ise-field="x_variants[2].text">[Active voice, named actor and date]</td><td data-ise-field="x_variants[2].equivalency_to_canonical"></td><td data-ise-field="x_variants[2].linkage_under_this_phrasing"></td><td data-ise-field="x_variants[2].drift"></td></tr>
+  <tr data-ise-rephrasing-type="mechanism-explicit"><td>3</td><td data-ise-field="x_variants[3].text">[Mechanism-explicit form]</td><td data-ise-field="x_variants[3].equivalency_to_canonical"></td><td data-ise-field="x_variants[3].linkage_under_this_phrasing"></td><td data-ise-field="x_variants[3].drift"></td></tr>
+  <tr data-ise-rephrasing-type="quantified"><td>4</td><td data-ise-field="x_variants[4].text">[Quantified form, where possible]</td><td data-ise-field="x_variants[4].equivalency_to_canonical"></td><td data-ise-field="x_variants[4].linkage_under_this_phrasing"></td><td data-ise-field="x_variants[4].drift"></td></tr>
+  <tr data-ise-rephrasing-type="scope-narrowed"><td>5</td><td data-ise-field="x_variants[5].text">[Scope-narrowed form]</td><td data-ise-field="x_variants[5].equivalency_to_canonical"></td><td data-ise-field="x_variants[5].linkage_under_this_phrasing"></td><td data-ise-field="x_variants[5].drift"></td></tr>
+</tbody>
+</table>
+
+<h3>Rephrasings of Y (the claim being supported or weakened)</h3>
+<table data-ise-section="rephrasings.y_variants">
+<thead>
+  <tr>
+    <th width="6%">#</th>
+    <th width="54%">Rephrased Y</th>
+    <th width="14%">Equivalency to canonical Y</th>
+    <th width="14%">Linkage from X under this phrasing</th>
+    <th width="12%">Drift</th>
+  </tr>
+</thead>
+<tbody>
+  <tr data-ise-rephrasing-type="canonical"><td>0</td><td><strong data-ise-field="y_node.canonical_statement">[Canonical Y]</strong></td><td>1.00</td><td data-ise-field="y_variants[0].linkage_under_this_phrasing">[L0]</td><td>&mdash;</td></tr>
+  <tr data-ise-rephrasing-type="filler-stripped"><td>1</td><td data-ise-field="y_variants[1].text">[Filler-stripped, plain language]</td><td data-ise-field="y_variants[1].equivalency_to_canonical"></td><td data-ise-field="y_variants[1].linkage_under_this_phrasing"></td><td data-ise-field="y_variants[1].drift"></td></tr>
+  <tr data-ise-rephrasing-type="active-voice"><td>2</td><td data-ise-field="y_variants[2].text">[Active voice, named outcome]</td><td data-ise-field="y_variants[2].equivalency_to_canonical"></td><td data-ise-field="y_variants[2].linkage_under_this_phrasing"></td><td data-ise-field="y_variants[2].drift"></td></tr>
+  <tr data-ise-rephrasing-type="mechanism-explicit"><td>3</td><td data-ise-field="y_variants[3].text">[Mechanism-explicit form]</td><td data-ise-field="y_variants[3].equivalency_to_canonical"></td><td data-ise-field="y_variants[3].linkage_under_this_phrasing"></td><td data-ise-field="y_variants[3].drift"></td></tr>
+  <tr data-ise-rephrasing-type="quantified"><td>4</td><td data-ise-field="y_variants[4].text">[Quantified form, where possible]</td><td data-ise-field="y_variants[4].equivalency_to_canonical"></td><td data-ise-field="y_variants[4].linkage_under_this_phrasing"></td><td data-ise-field="y_variants[4].drift"></td></tr>
+  <tr data-ise-rephrasing-type="scope-narrowed"><td>5</td><td data-ise-field="y_variants[5].text">[Scope-narrowed form]</td><td data-ise-field="y_variants[5].equivalency_to_canonical"></td><td data-ise-field="y_variants[5].linkage_under_this_phrasing"></td><td data-ise-field="y_variants[5].drift"></td></tr>
+</tbody>
+</table>
+<p style="font-size:90%; color:#555;"><strong>Drift</strong> is the difference between the linkage score under the rephrased version and the canonical version. High drift means the linkage depends on specific wording. Low drift means the linkage survives translation, which is what we want.</p>
+
+<h2>&nbsp;</h2>
+
+<!--
+  FIVE-STEP LINKAGE CHECK (the forcing function)
+  ----------------------------------------------
+  The check exists because fluent prose is not a linkage check. An AI
+  assistant or a hurried contributor can produce a placement that
+  reads beautifully and is still wrong. The five steps interrupt the
+  fluent generation and demand explicit transparent walk-through.
+
+  Origin: this check was developed in response to the Schiltz
+  misplacement, where Claude (the AI) generated a confident-sounding
+  restructuring that placed a separation-of-powers piece of evidence
+  under a wealthy-elites parent claim. The fluent reading was fine;
+  the linkage was wrong. The fix is to require the steps below before
+  any placement is considered locked in.
+
+  USER-FACING FORCING FUNCTION: the prompt "linkage check before
+  placing" should trigger the assistant to walk through these steps
+  explicitly before producing the final placement. This is a habit
+  worth wiring into the AI rewrite pipeline as a literal preprocessing
+  step, not just a guideline.
+
+  This section on the page is the WORKED RECORD for THIS specific
+  X-Y placement, not generic instructions. Future contributors should
+  be able to see exactly how the linkage was justified, in the words
+  used at the time of the check.
+-->
+<h1>&#9989; Five-Step Linkage Check (Worked Record)</h1>
+<p>Every placement of evidence under a claim, or argument under a parent argument, should pass through these five steps. This forces transparency: a linkage score is only as defensible as the check that produced it. The user-facing forcing function is the prompt &ldquo;linkage check before placing,&rdquo; which interrupts fluent restructuring and demands an explicit walk-through.</p>
+<table data-ise-section="five_step_check">
+<thead>
+  <tr>
+    <th width="6%">Step</th>
+    <th width="24%">Question</th>
+    <th width="70%">Answer for THIS placement</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><strong>1</strong></td>
+    <td>Exact wording of the parent claim Y</td>
+    <td data-ise-field="five_step_check.step_1_parent_claim_verbatim">[Verbatim. No paraphrase.]</td>
+  </tr>
+  <tr>
+    <td><strong>2</strong></td>
+    <td>Exact wording of the evidence or argument X</td>
+    <td data-ise-field="five_step_check.step_2_evidence_or_argument_verbatim">[Verbatim. No paraphrase.]</td>
+  </tr>
+  <tr>
+    <td><strong>3</strong></td>
+    <td>Mechanism by which X supports Y, in one sentence</td>
+    <td data-ise-field="five_step_check.step_3_mechanism_one_sentence">[If you can&apos;t write this sentence cleanly, the linkage is probably weak.]</td>
+  </tr>
+  <tr>
+    <td><strong>4</strong></td>
+    <td>Self-assessed linkage score (0&ndash;1)</td>
+    <td><span data-ise-field="five_step_check.step_4_self_assessed_score">[Score]</span>, dominant factor: <span data-ise-field="five_step_check.step_4_dominant_factor">[relevance / network strength / contextual fit / uniqueness]</span></td>
+  </tr>
+  <tr>
+    <td><strong>5</strong></td>
+    <td>Flag if score &lt; 0.7</td>
+    <td data-ise-field="five_step_check.step_5_action_taken">[If flagged, action: find better evidence rather than reach with what&apos;s at hand.]</td>
+  </tr>
+</tbody>
+</table>
+
+<h2>&nbsp;</h2>
+
+<!--
+  FAILURE MODE WORKED EXAMPLES (the teaching content)
+  ---------------------------------------------------
+  Linkage failures fall into recognizable patterns. Naming them
+  creates muscle memory. Once a contributor has seen the Schiltz
+  case, they start spotting parent-mechanism mismatches everywhere.
+  The pattern names below are stable; the examples accumulate as
+  failures are caught in the wild.
+
+  CANONICAL ENTRY: the Schiltz case (parent-mechanism mismatch) is
+  documented in full in the ISE/Kialo conversation export. It is
+  the founding worked example for this template. Do not delete the
+  Schiltz row even after the template has been in use for years;
+  it's the page's origin story and the most reliable teaching aid.
+
+  ADDING NEW FAILURE MODES: if a contributor catches a linkage
+  failure in the wild, document it here using the same four-column
+  format. Three things to capture: the X verbatim, the Y verbatim,
+  and the one-sentence explanation of WHY the linkage fails. The
+  brevity of the explanation is the test: if you can't say why the
+  linkage fails in one sentence, you haven't actually identified the
+  failure mode yet.
+-->
+<h1>&#128269; Failure Mode Worked Examples</h1>
+<p>Linkage failures fall into recognizable patterns. Naming them creates muscle memory: once you&apos;ve seen the Schiltz case, you start spotting parent-mechanism mismatches everywhere. Add new failure modes as they&apos;re caught in the wild.</p>
+<table>
+<thead>
+  <tr>
+    <th width="22%">Failure Mode</th>
+    <th width="32%">X (evidence or argument)</th>
+    <th width="32%">Y (claim it was placed under)</th>
+    <th width="14%">Why the linkage fails</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><strong>Parent-mechanism mismatch</strong> <em>(the Schiltz case)</em></td>
+    <td>Chief Judge Schiltz, January 2026: ICE violated 96 court orders in 74 cases.</td>
+    <td>MAGA broke the norms that constrain the powerful (insider trading, nepotism, financial disclosure).</td>
+    <td>X is about executive defiance of judicial orders, a separation-of-powers argument. Y is about wealthy and connected people evading rules that bind ordinary citizens. Different mechanism, different parent. Correct parent for X is &ldquo;MAGA defies judicial constraint,&rdquo; not Y.</td>
+  </tr>
+  <tr>
+    <td><strong>True But Irrelevant</strong></td>
+    <td>[X that is well-evidenced and true]</td>
+    <td>[Y that X is supposed to support]</td>
+    <td>[Why the connection requires assumptions not in evidence.]</td>
+  </tr>
+  <tr>
+    <td><strong>Scope mismatch</strong></td>
+    <td>[X applies to a specific population, time, or context]</td>
+    <td>[Y is a broader or different-scope claim]</td>
+    <td>[Extrapolation requires unstated similarity assumption.]</td>
+  </tr>
+  <tr>
+    <td><strong>Missing intermediate step</strong></td>
+    <td>[X]</td>
+    <td>[Y, where the chain X &rarr; A &rarr; B &rarr; Y has uncertain middle links]</td>
+    <td>[Each missing step compounds uncertainty. Name the steps.]</td>
+  </tr>
+  <tr>
+    <td><strong>Reversal at scale</strong></td>
+    <td>[X is true at small scale]</td>
+    <td>[Y is the same claim at large scale]</td>
+    <td>[The relationship reverses or collapses outside the tested range.]</td>
+  </tr>
+</tbody>
+</table>
+
+<h2>&nbsp;</h2>
+
+<!--
+  BELIEFS THIS LINKAGE PARTICIPATES IN
+  ------------------------------------
+  A linkage is a single edge in a graph. The graph matters because
+  it surfaces patterns: is X being applied consistently across the
+  claims it supports, or stretched to support whatever the user
+  wanted supported? Is Y being held up by genuinely diverse arguments,
+  or by ten variations of the same argument with different wording?
+
+  Default sort is argument score (the audit-locked one that counts
+  evidence quality and logical validity). Vote ratio is offered as
+  a secondary view in the column header but never the default. This
+  is per Hard Rule #6 and per the platform's general principle that
+  popularity is not truth.
+
+  The "other claims X is placed under" table is especially useful
+  for catching motivated reasoning. If X (a specific T1 study) is
+  used to support six different Y claims, all of them flattering to
+  the same political position, that pattern is detectable here.
+-->
+<h1>&#129517; Beliefs This Linkage Participates In</h1>
+<p>A linkage is a single edge, but the graph it lives in matters. The tables below show other places X is used to support claims, and other arguments used to support Y. Default sort is by <a href="https://myclob.pbworks.com/w/page/159300543/ReasonRank">argument score</a>, which counts evidence quality and logical validity. Vote ratio is a secondary view, never the default.</p>
+
+<h3>Other claims X is placed under</h3>
+<p><em>Same X, different Y. Useful for spotting whether X is being applied consistently or stretched into places it doesn&apos;t belong.</em></p>
+<table>
+<thead>
+  <tr>
+    <th width="50%">Other Y (claim X also supports or weakens)</th>
+    <th width="15%">Linkage Score</th>
+    <th width="15%">Argument Score of that linkage</th>
+    <th width="20%">Sort: <strong>argument score</strong> | linkage | upvote ratio</th>
+  </tr>
+</thead>
+<tbody>
+  <tr><td>1. [Other Y]</td><td></td><td></td><td></td></tr>
+  <tr><td>2. [Other Y]</td><td></td><td></td><td></td></tr>
+  <tr><td>3. [Other Y]</td><td></td><td></td><td></td></tr>
+</tbody>
+</table>
+
+<h3>Other arguments and evidence placed under Y</h3>
+<p><em>Same Y, different X. Lets the reader see how this linkage compares to the other support Y is built on.</em></p>
+<table>
+<thead>
+  <tr>
+    <th width="50%">Other X (argument or evidence supporting or weakening Y)</th>
+    <th width="15%">Linkage Score</th>
+    <th width="15%">Argument Score of that linkage</th>
+    <th width="20%">Sort: <strong>argument score</strong> | linkage | upvote ratio</th>
+  </tr>
+</thead>
+<tbody>
+  <tr><td>1. [Other X]</td><td></td><td></td><td></td></tr>
+  <tr><td>2. [Other X]</td><td></td><td></td><td></td></tr>
+  <tr><td>3. [Other X]</td><td></td><td></td><td></td></tr>
+</tbody>
+</table>
+
+<h2>&nbsp;</h2>
+
+<!--
+  HIDDEN ASSUMPTIONS REQUIRED
+  ---------------------------
+  Weak linkages reveal foundational premises. This is the section
+  that earns its keep most at the linkage layer because surfacing
+  assumptions IS what linkage analysis does.
+
+  If the linkage from X to Y scores 0.6, something must be true in
+  addition to X for Y to follow. That "something" is a hidden
+  assumption. Naming it does two things:
+    1. Lets opponents attack the assumption directly instead of
+       arguing against X or Y, which they may both accept.
+    2. Often reveals that the same hidden assumption is doing the
+       real work across many linkages, which means it deserves its
+       own belief page.
+
+  This section is one of the few inheritances from the belief
+  template, slightly renamed. The belief template's "Required to
+  Accept / Reject This Belief" maps to "Required for the linkage to
+  hold / fail" here. Same shape, different question.
+-->
+<h1>&#128220; <a href="https://myclob.pbworks.com/Assumptions">Hidden Assumptions Required</a></h1>
+<p>If the linkage from X to Y is below 1.0, something must be true in addition to X for Y to follow. Naming those assumptions is half the work of evaluating any linkage.</p>
+<table>
+<thead>
+  <tr>
+    <th width="50%">Required for the linkage to hold</th>
+    <th width="50%">Required for the linkage to fail</th>
+  </tr>
+</thead>
+<tbody>
+  <tr><td>1.</td><td>1.</td></tr>
+  <tr><td>2.</td><td>2.</td></tr>
+  <tr><td>3.</td><td>3.</td></tr>
+</tbody>
+</table>
+
+<h2>&nbsp;</h2>
+
+<!--
+  BIAS RISKS SPECIFIC TO THIS LINKAGE
+  -----------------------------------
+  Motivated reasoning expresses itself most clearly through linkage
+  PLACEMENT, not through claims themselves. People rarely make up
+  evidence; they place real evidence under conclusions it doesn't
+  support. The Schiltz case is exactly this: the evidence is real
+  and undisputed, but the placement implies a connection the
+  evidence doesn't actually make.
+
+  This section names the bias risks for THIS linkage specifically,
+  not generic bias categories. "What bias would push someone to
+  inflate this particular score" and "what bias would push someone
+  to deflate it" are the questions to answer.
+
+  Symmetry matters. If the inflation column has three entries and
+  the deflation column has zero, that itself is a signal that the
+  page is being maintained from one side only.
+-->
+<h1>&#129504; <a href="https://myclob.pbworks.com/w/page/21956934/bias">Bias Risks Specific to This Linkage</a></h1>
+<table>
+<thead>
+  <tr>
+    <th width="50%">Biases that inflate this linkage score</th>
+    <th width="50%">Biases that deflate this linkage score</th>
+  </tr>
+</thead>
+<tbody>
+  <tr><td>1. [e.g., motivated reasoning toward Y]</td><td>1. [e.g., contrarian bias against Y]</td></tr>
+  <tr><td>2. [e.g., availability bias if X is recent and salient]</td><td>2. [e.g., scope insensitivity dismissing X&apos;s relevance]</td></tr>
+</tbody>
+</table>
+
+<h2>&nbsp;</h2>
+
+<!--
+  DEFINITIONS GO LAST
+  -------------------
+  Same rule as the belief template. Reader sees the analysis first,
+  then the definitions if they need them. Don't front-load jargon.
+  The definitions section here links out to canonical pages rather
+  than re-explaining concepts; the canonical pages are the source
+  of truth, this page is the application.
+-->
+<h1>&#128214; Definitions and Scoring Concepts</h1>
+<p>
+  <strong>Linkage Score:</strong> How directly X strengthens or weakens Y. Computed as Relevance &times; Network Strength &times; Contextual Fit &times; Uniqueness. See <a href="https://myclob.pbworks.com/w/page/159338766/Linkage%20Scores">Linkage Scores</a>.
+</p>
+<p>
+  <strong>ECLS vs ACLS:</strong> ECLS is Evidence-to-Conclusion Linkage (a study supports a conclusion). ACLS is Argument-to-Conclusion Linkage (a logical claim supports a conclusion). The five-step check applies to both.
+</p>
+<p>
+  <strong>Contribution to parent:</strong> An argument&apos;s effect on its parent claim equals Argument Score &times; Linkage Score. A perfect argument with a 0.3 linkage contributes less than a moderate argument with a 0.9 linkage. See <a href="https://myclob.pbworks.com/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">Argument scores from sub-argument scores</a>.
+</p>
+<p>
+  <strong>Equivalency Score:</strong> How similar two phrasings of the same statement are. Used in the rephrasings table to test linkage robustness. See the <a href="https://myclob.pbworks.com/w/page/21956921/Beliefs">Belief Equivalency Engine</a>.
+</p>
+<p>
+  <strong>Audit-lock:</strong> Linkage scores are computed from sub-arguments, never assigned by hand. If the score on this page changes, the change traces to a specific edit in the linkage argument tree above.
+</p>
+
+<h2>&nbsp;</h2>
+
+<h1>&#128300; Contribute</h1>
+<p>
+  <strong><a href="https://myclob.pbworks.com/w/page/160433328/Contact%20Me">Contact me</a></strong> to add linkage arguments, equivalent rephrasings, or new failure mode examples.
+  &nbsp;|&nbsp;
+  <strong><a href="https://github.com/myklob/ideastockexchange">GitHub</a></strong> for the scoring algorithm.
+</p>
+
+</div>
+
+<!--
+  =================================================================
+  MAINTENANCE NOTES (read before editing this template)
+  =================================================================
+
+  CANONICAL SOURCE OF TRUTH for the linkage methodology:
+    https://myclob.pbworks.com/w/page/159338766/Linkage%20Scores
+    (mirrored locally at docs/wiki/LinkageScores.md)
+
+  CANONICAL SOURCE OF TRUTH for the scoring engine:
+    https://github.com/myklob/ideastockexchange
+    (See src/core/scoring/scoring-engine.ts for the live algorithm.)
+
+  PROPAGATION RULE
+  ----------------
+  If the linkage methodology changes (new failure mode discovered,
+  new factor added to the linkage score formula, new section added):
+    1. Update the canonical Linkage Scores page on PBworks first.
+    2. Update this template second, with comments explaining what
+       changed and why.
+    3. Apply the change to existing linkage pages built from this
+       template, prioritizing the high-traffic ones.
+    4. If the change affects the scoring algorithm, file an issue
+       on the GitHub repo so the code matches the methodology.
+
+  Don't fork the methodology by editing only this template or only
+  the canonical page. The two should always agree, and the canonical
+  page is the tiebreaker.
+
+  AI ASSISTANT INSTRUCTIONS
+  -------------------------
+  If you are an AI assistant generating or editing a linkage page
+  built from this template:
+    - Read the canonical Linkage Scores page first.
+    - Apply the five-step linkage check explicitly before placing
+      any X under any Y. Don't skip it because the placement "looks
+      obvious." The Schiltz case is the cautionary tale.
+    - Never assign linkage scores by hand. The scores come from the
+      recursive engine, computed from the sub-arguments you help
+      add to the page.
+    - Preserve all existing comments. Add new ones rather than
+      replacing them.
+    - If you find yourself rephrasing a placement to make it sound
+      better, stop and run the linkage check. Fluency is not
+      linkage.
+
+  TEMPLATE PROVENANCE
+  -------------------
+  Template created in collaboration with Mike Laub and Claude (the
+  AI assistant), drawing on the ISE/Kialo working session that
+  identified the Schiltz misplacement and produced the five-step
+  linkage check. The conversation export ise_kialo_conversation.md
+  is the source document; the failure modes and the check itself
+  trace back to that session.
+-->


### PR DESCRIPTION
## Summary

This PR introduces the complete infrastructure for linkage evaluation pages in the ISE argument graph system. Linkage pages evaluate the logical connection between two nodes (evidence/argument X and claim Y), separate from evaluating the truth of either endpoint.

## Key Changes

- **Linkage Evaluation Template** (`templates/linkage-evaluation-template.html`)
  - 934-line HTML template with embedded JSON-LD for machine-readable canonical data
  - Three-layer architecture: HTML scaffolding with `data-ise-*` attributes, JSON-LD block, and SQL schema alignment
  - Sections for: proposition box, linkage arguments (agree/disagree), equivalent rephrasings, five-step linkage check, failure mode examples, hidden assumptions, and bias risks
  - Comprehensive documentation of hard rules, design principles, and canonical failure modes (Schiltz case)
  - Audit-lock enforcement: scores computed by engine, never hand-edited

- **Database Schema** (`sql/linkage_pages_schema.sql`)
  - 384-line MariaDB/MySQL schema defining tables for linkages, linkage arguments, rephrasings, five-step checks, failure modes, assumptions, and bias risks
  - Enforces audit-lock principle with `_computed_at` timestamps and read-only score semantics
  - Soft-delete pattern (marked `deleted_at` rather than removed)
  - Field names match JSON-LD paths for mechanical migration from wiki pages to database
  - Includes convenience view `v_linkage_page` for single-query page rendering
  - Foreign key constraints and CHECK constraints for data integrity

- **Architecture Documentation** (`sql/LINKAGE_ARCHITECTURE.md`)
  - Explains three-layer architecture and how layers interact
  - Documents migration path from wiki-based pages to database-generated pages
  - Clarifies relationship to existing Prisma schema

## Notable Implementation Details

- **Structured Data First**: JSON-LD block is canonical; HTML is a render of it. If they disagree, JSON wins.
- **Audit Trail**: Five-step linkage check is its own table, creating an explicit record of how each placement was justified
- **Pattern Classification**: Arguments tagged with canonical patterns (mechanism, missing-step, true-but-irrelevant, scope-mismatch, parent-mechanism-mismatch, etc.) for cross-page analysis
- **Rephrasing Robustness**: Five rephrasing types (filler-stripped, active-voice, mechanism-explicit, quantified, scope-narrowed) test whether linkage is logical or merely rhetorical
- **Contribution Calculation**: Contribution to parent = Argument Score (X) × Linkage Score (this page's score)
- **No Manual Scoring**: All scores are computed by ReasonRank engine from sub-argument trees; manual assignment is forbidden

The template and schema are designed to support both current wiki-based workflow and future database-backed rendering without requiring changes to field names or structure.

https://claude.ai/code/session_01MrQsQu1XqjS8ECZr1drdrv