### PR TITLE
Restructure README with clearer philosophy and methodology links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,270 +1,97 @@
-# IdeaStockExchange
+# Idea Stock Exchange
 
-A prediction market for ideas. Claims are valued based on two distinct metrics: ReasonRank (logical fundamentals) and Market Price (capital allocation). Users invest in claims to profit from the gap between an idea's logical integrity and its current market valuation.
+> A prediction market for ideas, where arguments are scored, not just shouted.
 
-## Core Philosophy
+The Idea Stock Exchange is a long-term project to build systematic reasoning infrastructure for public discourse. It treats arguments like financial instruments: each claim has both an intrinsic value derived from logic and evidence (**ReasonRank**) and a market value determined by crowd conviction (**Market Price**). When the two diverge, an arbitrage opportunity exists. The goal is replacing the chronological chaos of social media with structured, evidence-scored debate that accumulates progress instead of relitigating the same questions forever.
 
-Ideas are commodities. Every claim on this platform has an intrinsic value derived from its logical structure and evidence base (ReasonRank), and a market value determined by capital allocation (Market Price). When these two values diverge, an arbitrage opportunity exists.
+> *We do not need more civic engagement. We need better organization of the engagement that already exists.*
 
-This system eliminates noise. Users only participate when they are willing to risk capital on being wrong. There is no social approval mechanism: no likes, no upvotes, no sentiment scores. The only signal is money on the line.
+## Three Pillars
 
-## Two Independent Valuation Systems
+### ReasonRank — the logic score
 
-### ReasonRank (The Fundamentals)
+Every claim is scored on three independent dimensions:
 
-ReasonRank is the intrinsic value of a claim. It is computed algorithmically by analyzing:
+- **Truth** — is the claim accurate and logically coherent?
+- **Relevance** — does the supporting argument actually bear on the conclusion?
+- **Importance** — how much does the argument move the parent claim if true?
 
-- **Logical Validity:** The structural soundness of the argument. Are the premises connected to the conclusion? Are there fallacies?
-- **Evidence Quality:** The strength, relevance, and reliability of cited evidence. Peer-reviewed sources score higher than anecdotes.
-- **Sub-Argument Depth:** Claims with well-developed "pro" and "con" sub-arguments receive deeper analysis. A claim with no counter-arguments is treated as under-examined.
+An argument's contribution to its parent equals **Truth × Relevance × Importance**. Scoring is recursive: a claim's score is computed from the scores of its sub-arguments, the way Google's PageRank computed page authority from inbound links.
 
-ReasonRank operates independently of market activity. A claim can have a high ReasonRank and zero market interest. The algorithm does not care what users think: it cares what the logic supports.
+### Market Price — the conviction score
 
-**Score Range:** 0.0 (no logical merit) to 1.0 (airtight reasoning with strong evidence).
+Independent of the logic score, users invest virtual currency (**IdeaCredits**) in claims via a constant-product market maker. Buying YES shares pushes the price up; buying NO pushes it down. Prices reflect the crowd's collective probability estimate, separately from whether the claim is logically sound.
 
-### Market Price (The Price)
-
-Market Price is determined by a **Constant Product Market Maker (CPMM)**. Users buy YES or NO shares on any claim. The price adjusts automatically based on supply and demand.
-
-**CPMM Formula:**
-
-```
-x * y = k
-
-x = YES shares in the liquidity pool
-y = NO shares in the liquidity pool
-k = constant product (invariant)
-```
-
-When a user buys YES shares, `x` decreases and `y` increases, pushing the YES price up. The reverse happens for NO shares.
-
-**Price Calculation:**
-
-```
-YES price = y / (x + y)
-NO price  = x / (x + y)
-```
-
-Prices always sum to 1.0. A YES price of 0.70 means the market assigns a 70% probability that the claim is true.
-
-### The Arbitrage Opportunity
+### The arbitrage
 
 When ReasonRank and Market Price diverge, rational actors profit:
 
 | Scenario | ReasonRank | Market Price | Action | Rationale |
 |---|---|---|---|---|
-| Undervalued | 0.85 | 0.40 | Buy YES | Logic supports the claim but the market has not caught up. |
-| Overvalued | 0.20 | 0.75 | Buy NO | The market is overpricing a logically weak claim. |
-| Fairly Valued | 0.60 | 0.58 | Hold | No significant edge exists. |
+| Undervalued | High | Low | Buy YES | Logically supported claim the crowd hasn't caught up to yet. |
+| Overvalued | Low | High | Buy NO | Popular claim that doesn't survive scrutiny. |
+| Fairly valued | Aligned | Aligned | Hold | No edge. |
 
-The **Arbitrage Dashboard** surfaces claims with the largest gap between ReasonRank and Market Price. This is where profit opportunities live.
+Both gaps are visible. No other platform shows you both numbers and lets you bet on the gap closing.
 
-## TruthScore
+## Read the Methodology
 
-TruthScore is a composite metric that reflects the fundamental quality of a claim. It is not a popularity measure.
+The methodology is documented in detail across an open wiki. Start with the foundations:
 
-```
-TruthScore = LogicalValidity * EvidenceQuality
-```
+- [Home page on PBworks](http://myclob.pbworks.com/w/page/21957696/Colorado%20Should) — the wiki's entry point
+- [FAQ and common criticisms](http://myclob.pbworks.com/w/page/162495654/Frequently%20Questions%20and%20Critisisms) — eighteen questions answered, including "who decides what's true," "isn't this vulnerable to brigading," and "won't one political tribe dominate"
+- [Truth Score](http://myclob.pbworks.com/w/page/21960078/truth) — the composite metric and what feeds into it
+- [Linkage Scores (Relevance)](http://myclob.pbworks.com/w/page/159338766/Linkage%20Scores) — how the system catches the True-But-Irrelevant pattern
+- [Importance Score](http://myclob.pbworks.com/w/page/162731388/Importance%20Score) — why an argument can be true and relevant but trivial
+- [Logical Validity Score](http://myclob.pbworks.com/w/page/159235779/Logical%20Validity) — six logic battlegrounds: fallacies, contradictions, evidence trees, metaphor analysis, prediction tracking, validity inheritance
+- [ReasonRank algorithm](http://myclob.pbworks.com/w/page/159300543/ReasonRank) — how the scores compose
 
-- **LogicalValidity** (0.0 to 1.0): Measures structural soundness of the argument chain.
-- **EvidenceQuality** (0.0 to 1.0): Measures the strength and reliability of supporting evidence.
+## See It Applied
 
-Market Price is a **separate variable** that reacts to TruthScore. It is never an input to TruthScore. The market can be wrong: that is the entire point.
+The methodology is being applied to real debates on Kialo:
 
-## Investment Mechanics
+- [Should Kialo let users post media that supports or weakens each belief?](https://www.kialo.com/should-kialo-let-users-post-media-that-supports-or-weakens-each-belief-65470) — proposal for a media-list feature with affiliate-revenue sustainability
+- [Should arguments be debated in separate pro/con sections for Truth, Relevance, and Importance?](https://www.kialo.com/should-arguments-be-debated-in-separate-procon-sections-for-logical-validity-verification-importance-and-relevance-65463) — adoption of the three-dimension scoring on Kialo
+- [Should politicians publicly rank the top ten pros and cons for each vote?](https://www.kialo.com/should-we-require-politicians-to-publicly-rank-the-top-10-procon-arguments-for-each-of-their-votes-60142) — show-your-work transparency for elected officials
 
-### IdeaCredits
+## The Code
 
-Users start with a balance of IdeaCredits (the platform currency). These credits are spent to buy shares in claims.
+This repository is a [Next.js](https://nextjs.org) application:
 
-### Buying Shares
+- TypeScript frontend with React 19 (App Router)
+- Prisma 7 with SQLite via `@prisma/adapter-better-sqlite3`
+- Constant-product market maker for the Market Price layer
+- ReasonRank engine for the logic layer
+- Tailwind CSS v4
 
-1. Select a claim.
-2. Choose YES (the claim is true) or NO (the claim is false).
-3. Specify the number of IdeaCredits to invest.
-4. The CPMM calculates how many shares you receive based on current pool state.
+MIT licensed; contributors welcome.
 
-### Resolution and Payout
-
-When a claim resolves (via evidence, expert adjudication, or time expiry):
-- **YES resolves correct:** YES shareholders receive 1.0 credit per share. NO shares are worth 0.
-- **NO resolves correct:** NO shareholders receive 1.0 credit per share. YES shares are worth 0.
-
-### User Portfolio
-
-Every user has a portfolio tracking:
-- **Current Holdings:** Active positions across all claims.
-- **Realized P&L:** Profit and loss from resolved claims.
-- **Unrealized P&L:** Paper gains/losses on open positions.
-- **ROI:** Return on investment calculated from historical accuracy.
-
-## Risk Allocation
-
-Every investment is a risk allocation decision. Users signal their confidence not through social gestures but through capital commitment. A user who stakes 1,000 IdeaCredits on a claim is making a stronger statement than one who stakes 10: and they stand to lose more if they are wrong.
-
-This mechanism filters noise. Frivolous claims attract no capital. Well-reasoned claims attract investment. The market rewards analytical skill and penalizes groupthink.
-
-## Technical Architecture
-
-- **Framework:** Next.js with TypeScript
-- **Database:** PostgreSQL with Prisma ORM
-- **Market Engine:** Constant Product Market Maker (CPMM)
-- **Scoring Engine:** ReasonRank algorithm (logical analysis)
-- **Frontend:** React components with TailwindCSS
-
-## Database Schema
-
-Key tables:
-- `claims`: Core claim data, ReasonRank score, TruthScore
-- `liquidity_pools`: YES/NO share reserves, constant product invariant
-- `shares`: Individual share ownership records
-- `user_portfolios`: Aggregated ROI and P&L tracking
-- `evidence`: Supporting evidence linked to claims
-- `sub_arguments`: Pro/con arguments attached to claims
-
-## Getting Started
+### Getting Started
 
 ```bash
 npm install
-npx prisma generate
-npx prisma db push
+npm run db:generate
+npm run db:push
+npm run db:seed
 npm run dev
 ```
 
+Open [http://localhost:3000](http://localhost:3000) and head to `/beliefs/[slug]` to see the canonical belief page — the heart of the product.
+
+## Related Projects
+
+- [Forward Party Colorado](https://sites.google.com/view/futureofpolitics/forward-colorado) — Process Party platform: parties competing on decision-making methodology, not ideology
+- [How to Fix Search](https://sites.google.com/view/howtofixsearch/home) — applying the methodology to search engines and information ranking
+- [How to Fix Twitter](https://sites.google.com/view/howtofixtwitter/home) — applying the methodology to social media and public conversation
+
+## Contribute
+
+Three ways to help:
+
+- **Developers:** clone the repo, pick an issue labeled `good first issue` or `help wanted`. Priority areas include the belief scoring pipeline, the Belief Equivalency Engine, and frontend belief display components.
+- **Researchers and writers:** use the [Belief Template](http://myclob.pbworks.com/w/page/21959883/Template) to add or improve a belief page. Score arguments using Truth, Relevance, and Importance. Classify evidence as **T1** (peer-reviewed), **T2** (expert/institutional), **T3** (journalism/survey), or **T4** (opinion/anecdote).
+- **Everyone:** star the repo. Share a belief page on social media. Submit a new belief as a [GitHub issue](https://github.com/myklob/ideastockexchange/issues) using the belief taxonomy template. Join the discussion in [GitHub Discussions](https://github.com/myklob/ideastockexchange/discussions).
+
 ## License
 
-MIT
-A platform where ideas are valued like financial instruments. Claims rise and fall based on two independent forces: logical rigor and crowd conviction.
-
-## Core Philosophy
-
-**Arguments are investments.** Every claim functions as a dual-valued asset. It possesses a **ReasonRank** derived from logical proof and a **Market Price** determined by user betting and prediction market sentiment.
-
-This dual-score system ensures that no single dimension of truth dominates. A claim can be logically airtight yet unpopular, or widely believed yet poorly supported. IdeaStockExchange tracks both dimensions independently, giving users a complete picture of each idea's standing.
-
-## Key Concepts
-
-### Truth Score
-
-Truth Score: A composite metric representing the overall validity of a claim. It is calculated by combining the **Logical Validity Score** (structure of the argument) and the **Evidence Score** (quality and independence of supporting data).
-
-The Truth Score is the final output of the ReasonRank algorithm. It is not a simple 0-1 accuracy rating. Instead, it synthesizes multiple dimensions of analysis into a single measure of claim validity.
-
-### Evidence Score
-
-The Evidence Score measures the reliability and independence of source data backing a claim. It evaluates factors such as:
-
-- **Source credibility:** Is the data from a peer-reviewed study, a reputable institution, or an unverified source?
-- **Independence:** Are multiple lines of evidence converging on the same conclusion, or does the claim rest on a single data point?
-- **Reproducibility:** Can the evidence be independently verified?
-
-Note: The Evidence Score is strictly a measure of data quality. It is one input into the Truth Score, not a synonym for it.
-
-### Logical Validity Score
-
-The Logical Validity Score evaluates the structural integrity of an argument. It checks whether conclusions follow from premises, whether logical fallacies are present, and whether the reasoning chain is internally consistent.
-
-This score is the other primary input into the Truth Score.
-
-## The Dual-Score System
-
-IdeaStockExchange tracks two distinct and equally important scores for every claim.
-
-### ReasonRank (The Truth Metric)
-
-This score is objective. It measures the logical strength, evidence quality, and redundancy of an argument. ReasonRank cannot be bought. It must be earned through rigorous proof.
-
-ReasonRank reflects the structural and evidential integrity of a claim:
-
-- **Logical Validity:** Does the argument follow sound reasoning?
-- **Evidence Quality:** Is the supporting data reliable and independent?
-- **Redundancy:** Do multiple independent arguments converge on the same conclusion?
-- **Counterargument Resilience:** Has the claim survived serious challenges?
-
-The Truth Score is the final numeric output of the ReasonRank algorithm.
-
-### Market Price (The Sentiment Metric)
-
-This score is subjective. It represents the "wisdom of the crowd" through a betting market. Users wager virtual currency on whether a claim will be proven true or false.
-
-Market Price reflects collective conviction:
-
-- **Betting Volume:** How much virtual currency is staked on this claim?
-- **Directional Sentiment:** Are users betting for or against?
-- **Predictor Reputation:** Are the bettors historically accurate?
-- **Market Momentum:** Is conviction rising or falling over time?
-
-A high Market Price with a low ReasonRank signals popular belief without logical foundation. A high ReasonRank with a low Market Price signals rigorous proof that the crowd has not yet accepted.
-
-## How It Works
-
-1. **Submit a Claim:** A user posts a claim to the exchange. It starts with a neutral ReasonRank and an initial Market Price.
-2. **Build the Case:** Other users contribute supporting or opposing arguments. Each argument is evaluated for logical validity and evidence quality, directly influencing the claim's ReasonRank.
-3. **Place Your Bets:** Users wager IdeaCredits (virtual currency) on the claim's outcome via the prediction market. This activity sets the Market Price.
-4. **Watch the Scores Diverge or Converge:** Over time, the ReasonRank and Market Price may align (indicating consensus between logic and sentiment) or diverge (indicating a gap between proof and belief).
-
-## Getting Started
-
-### Contributing Arguments (Influence ReasonRank)
-
-1. Browse open claims on the exchange.
-2. Submit evidence-backed arguments for or against a claim.
-3. Your argument is scored for logical validity and evidence quality.
-4. Strong arguments raise (or lower) the claim's ReasonRank.
-
-### Placing Bets (Influence Market Price)
-
-1. Review a claim's current ReasonRank and Market Price.
-2. Stake IdeaCredits on whether you believe the claim will be validated or refuted.
-3. Your bet shifts the Market Price based on volume and direction.
-4. High performers in the market earn additional IdeaCredits and build a reputation as accurate predictors.
-
-### Earning Reputation
-
-- **Argument Quality:** Consistently contributing high-scoring arguments earns you a reputation as a rigorous thinker.
-- **Prediction Accuracy:** Successfully betting on outcomes before they resolve earns you a reputation as an accurate predictor.
-- **IdeaCredits:** Virtual currency earned through accurate predictions and high-quality contributions. IdeaCredits are not real money.
-
-## Terminology Reference
-
-| Term | Definition |
-| --- | --- |
-| **Truth Score** | Composite metric combining Logical Validity and Evidence Score. The final output of ReasonRank. |
-| **Evidence Score** | Measures the reliability and independence of source data. One input into the Truth Score. |
-| **Logical Validity Score** | Measures the structural soundness of an argument. One input into the Truth Score. |
-| **ReasonRank** | The algorithm that produces the Truth Score. Evaluates logic, evidence, and redundancy. |
-| **Market Price** | The crowd-determined value of a claim, set by betting volume and sentiment. |
-| **Market Stake** | A bet placed by a user on a claim's outcome via the prediction market. |
-| **IdeaCredits** | Virtual currency used for betting. Earned through accurate predictions and quality contributions. |
-
-## Architecture
-
-IdeaStockExchange separates truth-seeking from opinion-tracking at the architectural level. The ReasonRank engine and the prediction market operate as independent subsystems. Neither can influence the other's score directly. This separation ensures that popular opinion cannot corrupt logical evaluation, and that rigorous proof cannot suppress genuine crowd insight.
-
-## 🤝 How to Contribute
-
-The ISE is an open-source platform for structured, evidence-based debate. There are three ways to help:
-
-### For Developers
-- Clone the repo and run `npm install && npx prisma generate && npm run dev`
-- - Pick an open issue labeled `good first issue` or `help wanted`
-  - - Priority areas: belief scoring pipeline, Belief Equivalency Engine, frontend belief display components
-    -
-    - ### For Researchers & Writers
-    - - Use the [Belief Template](http://myclob.pbworks.com/w/page/21959883/Template) to add or improve a belief page
-      - - Score arguments using Truth (0–100), Linkage (0–100), and Importance (0–100)
-        - - Classify evidence by type: T1=Peer-reviewed, T2=Expert/Institutional, T3=Journalism/Survey, T4=Opinion/Anecdote
-          - - Add Falsifiability Conditions and Burden of Proof to any belief page missing them
-            -
-            - ### For Everyone
-            - - ⭐ Star the repo to increase visibility and help attract contributors
-              - - Share a belief page on social media with the hashtag #IdeaStockExchange
-                - - Submit a new belief as a GitHub Issue using the belief taxonomy template in `.github/ISSUE_TEMPLATE`
-                  - - Join the discussion in [Discussions](https://github.com/myklob/ideastockexchange/discussions)
-                    -
-                    - All contributions follow the daily review protocol. See `OBJECTIVE.md` for standards.
-                    -
-                    - ## License
-
-This project is open source. See the LICENSE file for details.
+MIT. Maintained by Mike Laub. Methodology documented on the [PBworks wiki](http://myclob.pbworks.com); code on [GitHub](https://github.com/myklob/ideastockexchange); applied examples on [Kialo](https://www.kialo.com).


### PR DESCRIPTION
## Summary

Completely restructured the README to present a clearer, more accessible introduction to the Idea Stock Exchange platform. The new structure emphasizes the core value proposition (dual-scored claims: ReasonRank + Market Price) and directs users to external methodology documentation rather than duplicating it inline.

## Key Changes

- **Simplified opening:** Replaced lengthy philosophy section with a concise tagline and single-paragraph value proposition
- **Three Pillars structure:** Reorganized core concepts into ReasonRank (logic score), Market Price (conviction score), and The Arbitrage (the opportunity)
- **Removed redundancy:** Eliminated duplicate explanations of Truth Score, Evidence Score, and Logical Validity that appeared multiple times in the original
- **Added methodology links:** Created a dedicated "Read the Methodology" section pointing to the PBworks wiki with specific pages for each scoring dimension
- **Added real-world examples:** New "See It Applied" section showing how the methodology is being used on Kialo
- **Streamlined technical section:** Condensed architecture details and added quick-start instructions with clear next steps
- **Clarified contribution paths:** Reorganized contribution guidelines into three distinct tracks (developers, researchers/writers, everyone) with specific, actionable steps
- **Updated license footer:** Added attribution and links to wiki, GitHub, and Kialo

## Notable Details

- Removed ~170 lines of duplicated scoring explanations
- Consolidated CPMM formula and price calculation into a single, clearer explanation
- Moved detailed technical schema documentation out of README (belongs in code comments or separate docs)
- Emphasized that ReasonRank and Market Price are **independent** systems—a key architectural principle
- Added explicit link to the canonical belief page (`/beliefs/[slug]`) as the product's heart

https://claude.ai/code/session_013utppqojrhBjrpiX1k1Yvm