### PR TITLE
Add Next.js 14 app with ISE design system

### DIFF
--- a/app/(document)/beliefs/BeliefsClient.tsx
+++ b/app/(document)/beliefs/BeliefsClient.tsx
@@ -1,0 +1,174 @@
+'use client';
+import { useState, useMemo } from 'react';
+import Link from 'next/link';
+import { Belief } from '@/lib/types';
+
+type SortKey = 'positivity' | 'specificity' | 'claimStrength' | 'statement' | 'reasonRank';
+type SortDir = 'asc' | 'desc';
+
+const VALENCE_OPTIONS = [
+  { label: 'Any valence', minPos: -100, maxPos: 100 },
+  { label: 'Positive (>+20)', minPos: 20, maxPos: 100 },
+  { label: 'Neutral (−20 to +20)', minPos: -20, maxPos: 20 },
+  { label: 'Negative (<−20)', minPos: -100, maxPos: -20 },
+];
+
+const SPECIFICITY_OPTIONS = [
+  { label: 'Any specificity', min: 0, max: 1 },
+  { label: 'Highly General (<0.2)', min: 0, max: 0.2 },
+  { label: 'Moderately General (0.2–0.45)', min: 0.2, max: 0.45 },
+  { label: 'Case-Level (0.45–0.7)', min: 0.45, max: 0.7 },
+  { label: 'Highly Specific (>0.7)', min: 0.7, max: 1 },
+];
+
+const INTENSITY_OPTIONS = [
+  { label: 'Any intensity', min: 0, max: 1 },
+  { label: 'Weak (<0.35)', min: 0, max: 0.35 },
+  { label: 'Moderate (0.35–0.65)', min: 0.35, max: 0.65 },
+  { label: 'Strong (0.65–0.85)', min: 0.65, max: 0.85 },
+  { label: 'Extreme (>0.85)', min: 0.85, max: 1 },
+];
+
+export function BeliefsClient({ beliefs }: { beliefs: Belief[] }) {
+  const [valenceIdx, setValenceIdx]     = useState(0);
+  const [specificityIdx, setSpecificityIdx] = useState(0);
+  const [intensityIdx, setIntensityIdx] = useState(0);
+  const [sortBy, setSortBy]             = useState<SortKey>('positivity');
+  const [sortDir, setSortDir]           = useState<SortDir>('asc');
+
+  const filtered = useMemo(() => {
+    const v = VALENCE_OPTIONS[valenceIdx];
+    const s = SPECIFICITY_OPTIONS[specificityIdx];
+    const i = INTENSITY_OPTIONS[intensityIdx];
+    return beliefs.filter(b =>
+      b.spectrums.positivity >= v.minPos &&
+      b.spectrums.positivity <= v.maxPos &&
+      b.spectrums.specificity >= s.min &&
+      b.spectrums.specificity <= s.max &&
+      b.spectrums.claimStrength >= i.min &&
+      b.spectrums.claimStrength <= i.max
+    ).sort((a, b) => {
+      let av: number | string;
+      let bv: number | string;
+      if (sortBy === 'statement') { av = a.statement; bv = b.statement; }
+      else if (sortBy === 'positivity') { av = a.spectrums.positivity; bv = b.spectrums.positivity; }
+      else if (sortBy === 'specificity') { av = a.spectrums.specificity; bv = b.spectrums.specificity; }
+      else if (sortBy === 'claimStrength') { av = a.spectrums.claimStrength; bv = b.spectrums.claimStrength; }
+      else { av = a.reasonRank; bv = b.reasonRank; }
+      if (av < bv) return sortDir === 'asc' ? -1 : 1;
+      if (av > bv) return sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }, [beliefs, valenceIdx, specificityIdx, intensityIdx, sortBy, sortDir]);
+
+  const signal = (b: Belief) => b.reasonRank > b.marketPrice ? 'UNDER' : 'OVER';
+
+  return (
+    <>
+      {/* Filter bar */}
+      <div className="flex flex-wrap gap-3 mb-6 p-4 bg-gray-50 border border-gray-200 rounded-lg">
+        <div className="flex items-center gap-2 text-sm">
+          <label className="text-[var(--muted-foreground)] font-medium">Valence:</label>
+          <select
+            value={valenceIdx}
+            onChange={e => setValenceIdx(Number(e.target.value))}
+            className="border border-gray-300 rounded px-2 py-1 text-sm bg-white"
+          >
+            {VALENCE_OPTIONS.map((o, i) => <option key={i} value={i}>{o.label}</option>)}
+          </select>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <label className="text-[var(--muted-foreground)] font-medium">Specificity:</label>
+          <select
+            value={specificityIdx}
+            onChange={e => setSpecificityIdx(Number(e.target.value))}
+            className="border border-gray-300 rounded px-2 py-1 text-sm bg-white"
+          >
+            {SPECIFICITY_OPTIONS.map((o, i) => <option key={i} value={i}>{o.label}</option>)}
+          </select>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <label className="text-[var(--muted-foreground)] font-medium">Intensity:</label>
+          <select
+            value={intensityIdx}
+            onChange={e => setIntensityIdx(Number(e.target.value))}
+            className="border border-gray-300 rounded px-2 py-1 text-sm bg-white"
+          >
+            {INTENSITY_OPTIONS.map((o, i) => <option key={i} value={i}>{o.label}</option>)}
+          </select>
+        </div>
+        <div className="flex items-center gap-2 text-sm ml-auto">
+          <label className="text-[var(--muted-foreground)] font-medium">Sort:</label>
+          <select
+            value={sortBy}
+            onChange={e => setSortBy(e.target.value as SortKey)}
+            className="border border-gray-300 rounded px-2 py-1 text-sm bg-white"
+          >
+            <option value="positivity">Positivity</option>
+            <option value="specificity">Specificity</option>
+            <option value="claimStrength">Claim Strength</option>
+            <option value="reasonRank">ReasonRank</option>
+            <option value="statement">Statement</option>
+          </select>
+          <button
+            onClick={() => setSortDir(d => d === 'asc' ? 'desc' : 'asc')}
+            className="border border-gray-300 rounded px-2 py-1 text-sm bg-white hover:bg-gray-100 font-mono"
+          >
+            {sortDir === 'asc' ? '↑ Asc' : '↓ Desc'}
+          </button>
+        </div>
+      </div>
+
+      <p className="text-sm text-[var(--muted-foreground)] mb-4">
+        {filtered.length} belief{filtered.length !== 1 ? 's' : ''}
+      </p>
+
+      {/* Grid */}
+      <div className="grid grid-cols-2 gap-3">
+        {filtered.map(b => {
+          const sig = signal(b);
+          return (
+            <Link
+              key={b.slug}
+              href={`/beliefs/${b.slug}`}
+              className="card-hover block p-[18px] border border-gray-200 rounded-lg bg-white no-underline"
+            >
+              <div className="text-[11px] font-mono text-[var(--muted-foreground)] uppercase tracking-wider mb-1.5">
+                {b.slug}
+              </div>
+              <div className="font-semibold text-base leading-snug mb-3 text-[var(--foreground)]">
+                {b.statement}
+              </div>
+              <div className="flex gap-4 text-xs text-gray-500 items-center">
+                <span>
+                  RR <span className="font-mono font-bold">{b.reasonRank.toFixed(1)}%</span>
+                </span>
+                <span>
+                  Mkt <span className="font-mono font-bold">{b.marketPrice.toFixed(1)}%</span>
+                </span>
+                <span>
+                  Vol <span className="font-mono font-bold">{b.volume.toLocaleString()}</span>
+                </span>
+                <span className="ml-auto">
+                  <span className={`inline-block px-2 py-0.5 rounded text-[11px] font-semibold ${
+                    sig === 'UNDER'
+                      ? 'bg-green-100 text-green-800'
+                      : 'bg-red-100 text-red-700'
+                  }`}>
+                    {sig === 'UNDER' ? 'UNDERVALUED' : 'OVERVALUED'}
+                  </span>
+                </span>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-[var(--muted-foreground)]">
+          No beliefs match the current filters.
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/(document)/beliefs/[slug]/TradeButton.tsx
+++ b/app/(document)/beliefs/[slug]/TradeButton.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useState } from 'react';
+import { TradePanel } from '@/components/arbitrage/TradePanel';
+
+interface BeliefSummary {
+  slug: string;
+  statement: string;
+  reasonRank: number;
+  marketPrice: number;
+}
+
+export default function TradeButton({ belief }: { belief: BeliefSummary }) {
+  const [open, setOpen] = useState(false);
+
+  async function handleTrade(side: 'YES' | 'NO', amount: number) {
+    await fetch('/api/trades', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ beliefSlug: belief.slug, side, amount }),
+    });
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        style={{
+          padding: '8px 16px', background: '#2563eb', color: '#fff',
+          border: 'none', borderRadius: 6, fontWeight: 500, fontSize: 14,
+          cursor: 'pointer', flexShrink: 0,
+        }}
+      >
+        Trade
+      </button>
+      {open && (
+        <TradePanel
+          belief={belief}
+          onClose={() => setOpen(false)}
+          onTrade={handleTrade}
+        />
+      )}
+    </>
+  );
+}

--- a/app/(document)/beliefs/[slug]/page.tsx
+++ b/app/(document)/beliefs/[slug]/page.tsx
@@ -1,0 +1,84 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getBelief, beliefs } from '@/lib/data'
+import { SpectrumsHeader } from '@/components/belief/SpectrumsHeader'
+import { ScoreDashboard } from '@/components/belief/ScoreDashboard'
+import { ProConTable } from '@/components/belief/ProConTable'
+import { EvidenceLedger } from '@/components/belief/EvidenceLedger'
+import { SectionHeading } from '@/components/ui/SectionHeading'
+import { Callout } from '@/components/ui/Callout'
+import TradeButton from './TradeButton'
+
+export function generateStaticParams() {
+  return beliefs.map(b => ({ slug: b.slug }))
+}
+
+export function generateMetadata({ params }: { params: { slug: string } }) {
+  const b = getBelief(params.slug)
+  return { title: b ? `${b.statement.slice(0, 60)} — ISE` : 'Belief — ISE' }
+}
+
+export default function BeliefPage({ params }: { params: { slug: string } }) {
+  const belief = getBelief(params.slug)
+  if (!belief) notFound()
+
+  return (
+    <div className="max-w-[960px] mx-auto px-6 py-8">
+      {/* Breadcrumb */}
+      <div className="text-xs text-[var(--muted-foreground)] font-mono mb-4 flex items-center gap-1">
+        <Link href="/" className="text-[var(--muted-foreground)] no-underline hover:text-[var(--foreground)] transition-colors uppercase">Home</Link>
+        <span className="opacity-40">/</span>
+        <Link href="/beliefs" className="text-[var(--muted-foreground)] no-underline hover:text-[var(--foreground)] transition-colors uppercase">Beliefs</Link>
+        <span className="opacity-40">/</span>
+        <span className="text-[var(--foreground)] uppercase">{belief.slug}</span>
+      </div>
+
+      <h1 className="text-[38px] font-bold m-0 mb-2 tracking-[-0.02em] leading-[1.15]">
+        {belief.statement}
+      </h1>
+      <p className="text-sm text-[var(--muted-foreground)] m-0 mb-6">
+        Last evaluated {belief.lastEvaluated} · {belief.argCount} sub-arguments · {belief.contributors} contributors
+      </p>
+
+      <SpectrumsHeader
+        positivity={belief.spectrums.positivity}
+        specificity={belief.spectrums.specificity}
+        claimStrength={belief.spectrums.claimStrength}
+      />
+
+      <div className="flex justify-between items-start mb-4">
+        <SectionHeading emoji="📊" title="Live Score" subtitle="The arbitrage opportunity between logic and market." />
+        <TradeButton belief={{ slug: belief.slug, statement: belief.statement, reasonRank: belief.reasonRank, marketPrice: belief.marketPrice }} />
+      </div>
+      <ScoreDashboard
+        reasonRank={belief.reasonRank}
+        marketPrice={belief.marketPrice}
+        volume={belief.volume}
+      />
+
+      <div className="h-8" />
+
+      <SectionHeading
+        emoji="🔍"
+        title="Argument Trees"
+        subtitle="Each reason is a belief with its own page. Scoring is recursive based on truth, linkage, and importance."
+      />
+      <ProConTable proArgs={belief.proArgs} conArgs={belief.conArgs} />
+
+      <div className="h-8" />
+
+      <SectionHeading
+        emoji="⚖️"
+        title="The Evidence Ledger"
+        subtitle="Weighing the raw data. Quality scores based on methodology, sample size, and reproducibility."
+      />
+      <EvidenceLedger evidence={belief.evidence} />
+
+      <div className="h-6" />
+      <Callout tone="warn" title="Why this matters:">
+        A claim supported by a criterion scoring 92% carries far more evidential weight than one supported by a
+        criterion scoring 15% — regardless of how confidently either claim is stated.
+      </Callout>
+    </div>
+  )
+}

--- a/app/(document)/beliefs/page.tsx
+++ b/app/(document)/beliefs/page.tsx
@@ -1,0 +1,16 @@
+import { beliefs } from '@/lib/data';
+import { BeliefsClient } from './BeliefsClient';
+
+export const metadata = { title: 'Beliefs — Idea Stock Exchange' };
+
+export default function BeliefsPage() {
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 py-8">
+      <h1 className="text-3xl font-bold m-0">Beliefs</h1>
+      <p className="text-sm text-[var(--muted-foreground)] mt-1.5 mb-6">
+        Every belief has its own canonical page — a verification dashboard, not a text dump.
+      </p>
+      <BeliefsClient beliefs={beliefs} />
+    </div>
+  );
+}

--- a/app/(document)/cba/page.tsx
+++ b/app/(document)/cba/page.tsx
@@ -1,0 +1,65 @@
+import { carbonTaxCBA } from '@/lib/data';
+import { SectionHeading } from '@/components/ui/SectionHeading';
+import { Callout } from '@/components/ui/Callout';
+import { CBATable } from '@/components/cba/CBATable';
+
+export const metadata = { title: 'Cost-Benefit Analysis — ISE' };
+
+export default function CBAPage() {
+  const benefits = carbonTaxCBA.filter(r => r.side === 'benefit');
+  const costs    = carbonTaxCBA.filter(r => r.side === 'cost');
+
+  const evBenefits = benefits.reduce((s, r) => s + r.impactValue * r.likelihood / 100, 0);
+  const evCosts    = costs.reduce(   (s, r) => s + r.impactValue * r.likelihood / 100, 0);
+  const netEV      = evBenefits + evCosts;
+
+  return (
+    <div style={{ maxWidth: 1080, margin: '0 auto', padding: '32px 24px' }}>
+      <h1 style={{ fontSize: 32, fontWeight: 700, margin: 0, letterSpacing: '-0.01em' }}>
+        Cost-Benefit Analysis
+      </h1>
+      <p style={{ fontSize: 14, color: '#737373', margin: '6px 0 18px' }}>
+        Carbon tax (revenue-neutral, $50/ton starting 2027) · 10-year horizon
+      </p>
+
+      <Callout tone="info" title="Calibrated EV:">
+        Each cost and benefit's <em>predicted impact</em> is multiplied by its{' '}
+        <em>likelihood score</em> — a nested belief that must survive its own argument tree.
+        Impacts don't count unless their probabilities survive attack.
+      </Callout>
+
+      {/* Summary tiles */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, margin: '20px 0 28px' }}>
+        <EVTile label="Expected Benefits" val={`+$${evBenefits.toFixed(1)}B`} tone="pro" />
+        <EVTile label="Expected Costs"    val={`−$${Math.abs(evCosts).toFixed(1)}B`} tone="con" />
+        <EVTile
+          label="Net Expected Value"
+          val={`${netEV >= 0 ? '+' : '−'}$${Math.abs(netEV).toFixed(1)}B`}
+          tone={netEV >= 0 ? 'pro' : 'con'}
+        />
+      </div>
+
+      <SectionHeading emoji="📈" title="Benefits Ledger" subtitle="Predicted impact × likelihood = expected value" />
+      <CBATable rows={benefits} kind="benefit" />
+
+      <div style={{ height: 24 }} />
+
+      <SectionHeading emoji="📉" title="Costs Ledger" />
+      <CBATable rows={costs} kind="cost" />
+    </div>
+  );
+}
+
+function EVTile({ label, val, tone }: { label: string; val: string; tone: 'pro' | 'con' }) {
+  const color = tone === 'pro' ? '#15803d' : '#b91c1c';
+  return (
+    <div style={{ padding: 18, border: '1px solid #e5e5e5', borderRadius: 8, background: '#fff' }}>
+      <div style={{ fontSize: 11, color: '#737373', fontFamily: 'var(--font-mono)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+        {label}
+      </div>
+      <div style={{ fontFamily: 'var(--font-mono)', fontWeight: 700, fontSize: 32, color, marginTop: 6, lineHeight: 1, fontVariantNumeric: 'tabular-nums' }}>
+        {val}
+      </div>
+    </div>
+  );
+}

--- a/app/(document)/debate-topics/page.tsx
+++ b/app/(document)/debate-topics/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'Debate Topics — ISE' };
+
+export default function DebateTopicsPage() {
+  return (
+    <div style={{ maxWidth: 960, margin: '0 auto', padding: '64px 24px' }}>
+      <h1 style={{ fontSize: 32, fontWeight: 700, margin: '0 0 8px' }}>Debate Topics</h1>
+      <p style={{ color: '#737373', maxWidth: 600, lineHeight: 1.6 }}>
+        The full Debate Topics surface is under active development. This view will list canonical debate
+        positions with objective criteria agreed before measurement — Validity, Reliability, Linkage,
+        Importance — so scoring precedes argument.
+      </p>
+      <Link href="/" style={{ display: 'inline-block', marginTop: 16, padding: '10px 18px', background: '#2563eb', color: '#fff', textDecoration: 'none', borderRadius: 8, fontSize: 14, fontWeight: 500 }}>
+        Back to home
+      </Link>
+    </div>
+  );
+}

--- a/app/(document)/layout.tsx
+++ b/app/(document)/layout.tsx
@@ -1,0 +1,12 @@
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
+
+export default function DocumentLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Header />
+      <main>{children}</main>
+      <Footer />
+    </>
+  );
+}

--- a/app/(document)/login/page.tsx
+++ b/app/(document)/login/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+import { signIn } from 'next-auth/react';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function LoginPage() {
+  const [email, setEmail]       = useState('demo@ise.io');
+  const [password, setPassword] = useState('password');
+  const [error, setError]       = useState('');
+  const [loading, setLoading]   = useState(false);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    const res = await signIn('credentials', { email, password, redirect: false });
+    setLoading(false);
+    if (res?.error) {
+      setError('Invalid email or password');
+    } else {
+      router.push('/');
+      router.refresh();
+    }
+  }
+
+  const input: React.CSSProperties = {
+    width: '100%', padding: '10px 12px', border: '1px solid #e5e5e5', borderRadius: 6,
+    fontSize: 14, fontFamily: 'inherit', outline: 'none', marginTop: 6,
+  };
+
+  return (
+    <div style={{ maxWidth: 400, margin: '80px auto', padding: '0 24px' }}>
+      <h1 style={{ fontSize: 28, fontWeight: 700, margin: '0 0 6px' }}>Sign in</h1>
+      <p style={{ fontSize: 14, color: '#737373', margin: '0 0 32px' }}>
+        Demo credentials: <code style={{ fontFamily: 'var(--font-mono)', background: '#f5f5f5', padding: '1px 6px', borderRadius: 3 }}>demo@ise.io</code> / <code style={{ fontFamily: 'var(--font-mono)', background: '#f5f5f5', padding: '1px 6px', borderRadius: 3 }}>password</code>
+      </p>
+
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <label style={{ fontSize: 14 }}>
+          Email
+          <input
+            type="email" value={email}
+            onChange={e => setEmail(e.target.value)}
+            style={input} required
+          />
+        </label>
+        <label style={{ fontSize: 14 }}>
+          Password
+          <input
+            type="password" value={password}
+            onChange={e => setPassword(e.target.value)}
+            style={input} required
+          />
+        </label>
+        {error && <p style={{ fontSize: 13, color: '#dc2626', margin: 0 }}>{error}</p>}
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            padding: '12px', background: '#2563eb', color: '#fff', border: 'none',
+            borderRadius: 8, fontWeight: 600, fontSize: 15, cursor: 'pointer',
+            opacity: loading ? 0.7 : 1,
+          }}
+        >
+          {loading ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/(document)/markets/page.tsx
+++ b/app/(document)/markets/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'Markets — ISE' };
+
+export default function MarketsPage() {
+  return (
+    <div style={{ maxWidth: 960, margin: '0 auto', padding: '64px 24px' }}>
+      <h1 style={{ fontSize: 32, fontWeight: 700, margin: '0 0 8px' }}>Markets</h1>
+      <p style={{ color: '#737373', maxWidth: 600, lineHeight: 1.6 }}>
+        The Markets surface shows live YES/NO prediction markets for all tracked beliefs. Browse open positions,
+        volume, and price history. Real market mechanics coming soon.
+      </p>
+      <Link href="/arbitrage" style={{ display: 'inline-block', marginTop: 16, padding: '10px 18px', background: '#2563eb', color: '#fff', textDecoration: 'none', borderRadius: 8, fontSize: 14, fontWeight: 500 }}>
+        View Arbitrage Dashboard
+      </Link>
+    </div>
+  );
+}

--- a/app/(document)/page.tsx
+++ b/app/(document)/page.tsx
@@ -1,0 +1,128 @@
+import Link from 'next/link';
+import { beliefs } from '@/lib/data';
+
+const FEATURE_CARDS = [
+  { title: 'Plain-English Decode',  description: 'What the claim actually asserts, stripped of rhetoric.',                              href: '/beliefs/carbon-tax-reduces-emissions' },
+  { title: 'Three Spectrums',       description: 'Valence × Specificity × Intensity. Direction is not strength.',                       href: '/beliefs/carbon-tax-reduces-emissions' },
+  { title: 'Argument Trees',        description: 'Recursive pro/con structure scored by Linkage Score, Truth Score, and impact.',        href: '/beliefs/carbon-tax-reduces-emissions' },
+  { title: 'Evidence Ledger',       description: 'Supporting vs weakening evidence with T1–T4 quality tiers.',                           href: '/beliefs/carbon-tax-reduces-emissions' },
+  { title: 'Objective Criteria',    description: 'Validity, Reliability, Linkage, Importance — agreed before measurement.',             href: '/beliefs/carbon-tax-reduces-emissions' },
+  { title: 'Stakeholder Ledger',    description: "Who pays, who benefits, who's the silent victim of second-order effects.",             href: '/beliefs/carbon-tax-reduces-emissions' },
+];
+
+const PILLARS = [
+  {
+    heading: 'ReasonRank',
+    colorBar: 'var(--accent)',
+    body: 'The logic score. Truth × Relevance × Importance, computed recursively from the network of sub-arguments — like PageRank for claims.',
+    footer: `Used by ${beliefs.length.toLocaleString()} beliefs`,
+  },
+  {
+    heading: 'Market Price',
+    colorBar: 'var(--pro)',
+    body: 'The conviction score. Users invest virtual IdeaCredits in YES/NO shares; price reflects crowd probability — separate from logical soundness.',
+    footer: '$3.2M virtual volume / mo',
+  },
+  {
+    heading: 'The Arbitrage',
+    colorBar: 'var(--con)',
+    body: 'When ReasonRank and Market Price diverge, profit lives in the gap. Buy YES on the undervalued; buy NO on the overhyped.',
+    footer: `${beliefs.filter(b => Math.abs(b.reasonRank - b.marketPrice) >= 10).length} open opportunities`,
+  },
+];
+
+export default function HomePage() {
+  return (
+    <div>
+      {/* ── Hero ─────────────────────────────────────────────────── */}
+      <section className="border-b border-[var(--border)]">
+        <div className="max-w-[1280px] mx-auto px-6 py-[72px]">
+          <h1 className="m-0 text-[56px] font-bold tracking-[-0.025em] leading-[1.05]">
+            The architecture of reason.
+          </h1>
+          <p className="mt-3 mb-6 text-xl text-[var(--muted-foreground)]">
+            Computational Epistemology Platform
+          </p>
+          <p className="text-[17px] leading-[1.7] max-w-[720px] mb-3">
+            Every claim is a bet on reality. It says: "If we believe X, we'll get outcome Y."
+            But unlike every other bet humans make,{' '}
+            <strong>we're not allowed to check the math</strong>.
+          </p>
+          <p className="text-[17px] leading-[1.7] max-w-[720px] mb-7">
+            Idea Stock Exchange turns each belief into something you can{' '}
+            <strong>test, argue about, and improve</strong> — and lets you trade on the gap
+            between logic and crowd.
+          </p>
+          <div className="flex gap-3">
+            <Link href="/beliefs" className="inline-block px-[22px] py-3 rounded-lg bg-[var(--accent)] text-white font-medium text-[15px] no-underline hover:bg-[var(--accent-hover)] transition-colors">
+              Browse Beliefs
+            </Link>
+            <Link href="/arbitrage" className="inline-block px-[22px] py-3 rounded-lg bg-transparent text-[var(--foreground)] border border-[var(--border)] font-medium text-[15px] no-underline hover:border-[var(--accent)] transition-colors">
+              View Arbitrage
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <main className="max-w-[1280px] mx-auto px-6 py-12">
+
+        {/* ── Three Pillars ─────────────────────────────────────── */}
+        <section className="mb-16">
+          <h2 className="text-[28px] font-bold tracking-tight m-0 mb-5">The Three Pillars</h2>
+          <div className="flex gap-4">
+            {PILLARS.map(p => (
+              <div key={p.heading} className="flex-1 p-5 border border-[var(--border)] rounded-lg bg-white flex flex-col gap-2.5">
+                <div className="h-[3px] w-7 rounded-full" style={{ background: p.colorBar }} />
+                <h3 className="m-0 text-lg font-bold">{p.heading}</h3>
+                <p className="m-0 text-sm text-[#525252] leading-relaxed">{p.body}</p>
+                <div className="mt-auto pt-3 border-t border-[var(--muted)] font-mono text-xs text-[var(--muted-foreground)]">
+                  {p.footer}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Belief Page Features ──────────────────────────────── */}
+        <section className="mb-16">
+          <h2 className="text-[28px] font-bold tracking-tight m-0 mb-2">The Belief Page: A Diagnostic Panel</h2>
+          <p className="text-base text-[var(--muted-foreground)] max-w-[720px] leading-relaxed m-0 mb-5">
+            Each belief gets one permanent, canonical page. Not a text dump — a verification dashboard.
+          </p>
+          <div className="grid grid-cols-3 gap-3">
+            {FEATURE_CARDS.map(c => (
+              <Link
+                key={c.title}
+                href={c.href}
+                className="card-hover block p-4 border border-[var(--border)] rounded-lg bg-white no-underline"
+              >
+                <h3 className="m-0 text-base font-semibold text-[var(--foreground)]">{c.title}</h3>
+                <p className="m-0 mt-1.5 text-[13px] text-[var(--muted-foreground)] leading-[1.5]">{c.description}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        {/* ── CTA ──────────────────────────────────────────────── */}
+        <section className="text-center rounded-xl px-6 py-14" style={{ background: 'linear-gradient(180deg, #eff6ff 0%, rgba(239,246,255,0.3) 100%)' }}>
+          <h2 className="text-[28px] font-bold tracking-tight m-0 mb-2">
+            The legal code stops being sacred when it becomes auditable.
+          </h2>
+          <p className="text-lg text-[var(--muted-foreground)] m-0 mb-7">Start debugging.</p>
+          <div className="flex gap-3 justify-center flex-wrap">
+            <Link href="/debate-topics" className="inline-block px-[22px] py-3 rounded-lg bg-[var(--accent)] text-white font-medium text-[15px] no-underline hover:bg-[var(--accent-hover)] transition-colors">
+              Browse Topics
+            </Link>
+            <Link href="/cba" className="inline-block px-[22px] py-3 rounded-lg bg-[var(--accent)] text-white font-medium text-[15px] no-underline hover:bg-[var(--accent-hover)] transition-colors">
+              Cost-Benefit Analysis
+            </Link>
+            <Link href="/arbitrage" className="inline-block px-[22px] py-3 rounded-lg bg-transparent text-[var(--foreground)] border border-[var(--border)] font-medium text-[15px] no-underline hover:border-[var(--accent)] transition-colors">
+              Arbitrage Dashboard
+            </Link>
+          </div>
+        </section>
+
+      </main>
+    </div>
+  );
+}

--- a/app/(document)/protocol/page.tsx
+++ b/app/(document)/protocol/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export const metadata = { title: 'Schlicht Protocol — ISE' };
+
+export default function ProtocolPage() {
+  return (
+    <div style={{ maxWidth: 960, margin: '0 auto', padding: '64px 24px' }}>
+      <h1 style={{ fontSize: 32, fontWeight: 700, margin: '0 0 8px' }}>Schlicht Protocol</h1>
+      <p style={{ color: '#737373', maxWidth: 640, lineHeight: 1.6, marginBottom: 12 }}>
+        The Schlicht Protocol is ISE's verification log for AI-agent reasoning chains. Each agent inference
+        is cryptographically timestamped, scored by the argument engine, and published as an immutable ledger
+        entry. The goal: auditability of machine-generated claims at the same standard as human arguments.
+      </p>
+      <p style={{ color: '#737373', maxWidth: 640, lineHeight: 1.6 }}>
+        Live protocol log and AI-agent verification dashboard under development.
+      </p>
+      <Link href="/" style={{ display: 'inline-block', marginTop: 16, padding: '10px 18px', background: '#2563eb', color: '#fff', textDecoration: 'none', borderRadius: 8, fontSize: 14, fontWeight: 500 }}>
+        Back to home
+      </Link>
+    </div>
+  );
+}

--- a/app/api/arbitrage/route.ts
+++ b/app/api/arbitrage/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { arbitrageRows } from '@/lib/data';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const minDivergence = parseFloat(searchParams.get('minDiv') ?? '0');
+  const rows = arbitrageRows.filter(r => Math.abs(r.reasonRank - r.marketPrice) >= minDivergence);
+  return NextResponse.json(rows);
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,5 @@
+import NextAuth from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/app/api/beliefs/[slug]/route.ts
+++ b/app/api/beliefs/[slug]/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getBelief } from '@/lib/data';
+
+export async function GET(_req: Request, { params }: { params: { slug: string } }) {
+  const belief = getBelief(params.slug);
+  if (!belief) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(belief);
+}

--- a/app/api/beliefs/route.ts
+++ b/app/api/beliefs/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { beliefs } from '@/lib/data';
+
+export async function GET() {
+  const summary = beliefs.map(b => ({
+    slug: b.slug,
+    statement: b.statement,
+    reasonRank: b.reasonRank,
+    marketPrice: b.marketPrice,
+    volume: b.volume,
+    signal: b.reasonRank > b.marketPrice ? 'UNDER' : 'OVER',
+  }));
+  return NextResponse.json(summary);
+}

--- a/app/api/trades/route.ts
+++ b/app/api/trades/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { addTrade, getBelief, users } from '@/lib/data';
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  const body = await req.json() as { beliefSlug: string; side: 'YES' | 'NO'; amount: number };
+  const { beliefSlug, side, amount } = body;
+
+  if (!beliefSlug || !side || !amount || amount <= 0) {
+    return NextResponse.json({ error: 'Invalid params' }, { status: 400 });
+  }
+
+  const belief = getBelief(beliefSlug);
+  if (!belief) return NextResponse.json({ error: 'Belief not found' }, { status: 404 });
+
+  const userId = session ? (session.user as { id?: string }).id ?? 'guest' : 'guest';
+  const user   = users.find(u => u.id === userId);
+  if (user && user.credits < amount) {
+    return NextResponse.json({ error: 'Insufficient credits' }, { status: 402 });
+  }
+
+  const price  = side === 'YES' ? belief.marketPrice / 100 : 1 - belief.marketPrice / 100;
+  const shares = amount / price;
+
+  const trade = addTrade({ userId, beliefSlug, side, amount, price, shares });
+  if (user) user.credits -= amount;
+
+  return NextResponse.json({ trade, newMarketPrice: belief.marketPrice });
+}
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ trades: [] });
+  // Return trades for this user
+  const { getTradesByUser } = await import('@/lib/data');
+  const userId = (session.user as { id?: string }).id ?? '';
+  return NextResponse.json({ trades: getTradesByUser(userId) });
+}

--- a/app/arbitrage/layout.tsx
+++ b/app/arbitrage/layout.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: 'Arbitrage Dashboard — ISE' };
+
+export default function ArbitrageLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ background: '#0a0a0a', minHeight: '100vh', color: '#ededed' }}>
+      <DarkHeader />
+      {children}
+    </div>
+  );
+}
+
+function DarkHeader() {
+  const NAV = [
+    { href: '/',           label: 'Home' },
+    { href: '/beliefs',    label: 'Beliefs' },
+    { href: '/debate-topics', label: 'Debate Topics' },
+    { href: '/markets',    label: 'Markets' },
+    { href: '/arbitrage',  label: 'Arbitrage', active: true },
+    { href: '/cba',        label: 'CBA' },
+    { href: '/protocol',   label: 'Protocol' },
+  ];
+  return (
+    <header style={{ borderBottom: '1px solid #262626', background: '#0a0a0a', position: 'sticky', top: 0, zIndex: 10 }}>
+      <div style={{ maxWidth: 1280, margin: '0 auto', padding: '0 24px', display: 'flex', alignItems: 'center', gap: 32, height: 56 }}>
+        <a href="/" style={{ display: 'flex', alignItems: 'center', gap: 10, textDecoration: 'none' }}>
+          <ISEMarkDark size={28} />
+          <span style={{ fontWeight: 700, fontSize: 16, color: '#ededed', letterSpacing: '-0.01em' }}>
+            Idea Stock Exchange
+          </span>
+        </a>
+        <nav style={{ display: 'flex', gap: 4, flex: 1 }}>
+          {NAV.map(n => (
+            <a key={n.href} href={n.href} style={{
+              padding: '8px 10px', fontSize: 14, fontWeight: n.active ? 600 : 400,
+              color: n.active ? '#ededed' : '#a3a3a3',
+              borderBottom: n.active ? '2px solid #3b82f6' : '2px solid transparent',
+              textDecoration: 'none',
+            }}>
+              {n.label}
+            </a>
+          ))}
+        </nav>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: '#737373' }}>Credits</span>
+          <span style={{ fontFamily: 'var(--font-mono)', fontWeight: 700, fontSize: 14, color: '#ededed' }}>1,250</span>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function ISEMarkDark({ size }: { size: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 144 144" aria-hidden="true">
+      <rect width="144" height="144" rx="28" fill="#0f172a"/>
+      <g stroke="#3b82f6" strokeWidth="1.3" strokeOpacity="0.5" fill="none" strokeLinecap="round">
+        <line x1="32" y1="110" x2="56" y2="92"/>
+        <line x1="56" y1="92"  x2="72" y2="78"/>
+        <line x1="72" y1="78"  x2="92" y2="58"/>
+        <line x1="92" y1="58"  x2="115" y2="38"/>
+        <line x1="56" y1="92"  x2="48" y2="74"/>
+        <line x1="72" y1="78"  x2="64" y2="64"/>
+        <line x1="92" y1="58"  x2="106" y2="74"/>
+      </g>
+      <path d="M 32 110 L 56 92 L 72 78 L 92 58 L 115 38" stroke="#60a5fa" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" fill="none"/>
+      <circle cx="32" cy="110" r="5"   fill="#ef4444"/>
+      <circle cx="72" cy="78"  r="4.5" fill="#22c55e"/>
+      <circle cx="92" cy="58"  r="6"   fill="#3b82f6"/>
+      <circle cx="115" cy="38" r="7"   fill="#60a5fa"/>
+    </svg>
+  );
+}

--- a/app/arbitrage/page.tsx
+++ b/app/arbitrage/page.tsx
@@ -1,0 +1,161 @@
+'use client';
+import { useState } from 'react';
+import { arbitrageRows } from '@/lib/data';
+import { ArbitrageRow } from '@/lib/types';
+import { TradePanel } from '@/components/arbitrage/TradePanel';
+import { beliefs } from '@/lib/data';
+
+function potentialReturn(row: ArbitrageRow): number {
+  const rr = row.reasonRank / 100;
+  const mkt = row.marketPrice / 100;
+  if (row.signal === 'UNDER') {
+    return mkt > 0 ? (rr - mkt) / mkt : 0;
+  } else {
+    const noPrice = 1 - mkt;
+    return noPrice > 0 ? (mkt - rr) / noPrice : 0;
+  }
+}
+
+export default function ArbitragePage() {
+  const [minDiv, setMinDiv]       = useState(0.05);
+  const [selected, setSelected]   = useState<ArbitrageRow | null>(null);
+  const [tradeOpen, setTradeOpen] = useState(false);
+
+  const rows = arbitrageRows.filter(r =>
+    Math.abs(r.reasonRank - r.marketPrice) / 100 >= minDiv
+  );
+
+  function handleRowClick(row: ArbitrageRow) {
+    setSelected(row);
+    setTradeOpen(true);
+  }
+
+  const belief = selected ? beliefs.find(b => b.slug === selected.id) : null;
+
+  async function handleTrade(side: 'YES' | 'NO', amount: number) {
+    if (!selected) return;
+    await fetch('/api/trades', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ beliefSlug: selected.id, side, amount }),
+    });
+  }
+
+  const openOpps = arbitrageRows.filter(r => Math.abs(r.reasonRank - r.marketPrice) / 100 >= 0.05).length;
+  const totalVol = arbitrageRows.reduce((s, r) => s + r.volume, 0);
+  const medDiv   = [...arbitrageRows]
+    .map(r => Math.abs(r.reasonRank - r.marketPrice))
+    .sort((a, b) => a - b)[Math.floor(arbitrageRows.length / 2)] ?? 0;
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-6 py-8">
+      {/* Page header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-2xl font-bold">Arbitrage Dashboard</h2>
+          <p className="text-sm text-[var(--neutral)] mt-1">
+            Claims where ReasonRank and Market Price diverge. Profit lives in the gap.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <label htmlFor="minDiv" className="text-[var(--neutral)]">Min Divergence:</label>
+          <select
+            id="minDiv"
+            value={minDiv}
+            onChange={e => setMinDiv(parseFloat(e.target.value))}
+            className="bg-[var(--card-bg)] border border-[var(--border)] rounded px-2 py-1 text-white"
+          >
+            <option value={0.05}>5%</option>
+            <option value={0.10}>10%</option>
+            <option value={0.20}>20%</option>
+            <option value={0.30}>30%</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-3 gap-3 mb-7">
+        <DarkTile label="Open Opportunities" val={String(openOpps)} hint="+12 today" tone="profit" />
+        <DarkTile label="24h Volume"          val={`$${Math.round(totalVol / 1000)}K`} hint="virtual credits" tone="neutral" />
+        <DarkTile label="Median Divergence"   val={`${medDiv.toFixed(1)}%`} hint="across signals" tone="neutral" />
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="text-center py-12 text-[var(--neutral)]">
+          No arbitrage opportunities found at this threshold.
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {/* Header */}
+          <div className="grid grid-cols-7 gap-4 text-xs font-semibold text-[var(--neutral)] uppercase tracking-wide px-4">
+            <div className="col-span-2">Claim</div>
+            <div className="text-right">ReasonRank</div>
+            <div className="text-right">Market Price</div>
+            <div className="text-right">Divergence</div>
+            <div className="text-right">Signal</div>
+            <div className="text-right">Potential Return</div>
+          </div>
+
+          {/* Rows */}
+          {rows.map(o => {
+            const div = o.reasonRank - o.marketPrice;
+            const ret = potentialReturn(o);
+            return (
+              <button
+                key={o.id}
+                onClick={() => handleRowClick(o)}
+                className="grid grid-cols-7 gap-4 items-center bg-[var(--card-bg)] border border-[var(--border)] rounded-lg px-4 py-3 text-left cursor-pointer row-hover-dark"
+                style={{ fontFamily: 'inherit', color: 'var(--foreground)', fontSize: 13 }}
+              >
+                <div className="col-span-2">
+                  <span className="font-medium">{o.title}</span>
+                  <span className="ml-2 text-xs text-[var(--neutral)]">{o.category}</span>
+                </div>
+                <div className="text-right font-mono tabular-nums">
+                  {(o.reasonRank / 100 * 100).toFixed(1)}%
+                </div>
+                <div className="text-right font-mono tabular-nums">
+                  {(o.marketPrice / 100 * 100).toFixed(1)}%
+                </div>
+                <div className={`text-right font-mono tabular-nums font-semibold ${div > 0 ? 'text-[var(--profit)]' : 'text-[var(--loss)]'}`}>
+                  {div > 0 ? '+' : ''}{div.toFixed(1)}%
+                </div>
+                <div className="text-right">
+                  <span className={`inline-block px-2 py-0.5 rounded text-xs font-semibold font-mono ${
+                    o.signal === 'UNDER'
+                      ? 'bg-green-900/40 text-[var(--profit)]'
+                      : 'bg-red-900/40 text-[var(--loss)]'
+                  }`}>
+                    {o.signal === 'UNDER' ? 'BUY YES' : 'BUY NO'}
+                  </span>
+                </div>
+                <div className={`text-right font-mono tabular-nums font-semibold ${ret > 0 ? 'text-[var(--profit)]' : 'text-[var(--loss)]'}`}>
+                  {(ret * 100).toFixed(0)}%
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {tradeOpen && belief && (
+        <TradePanel
+          belief={{ slug: belief.slug, statement: belief.statement, reasonRank: belief.reasonRank, marketPrice: belief.marketPrice }}
+          onClose={() => setTradeOpen(false)}
+          onTrade={handleTrade}
+        />
+      )}
+    </div>
+  );
+}
+
+function DarkTile({ label, val, hint, tone }: { label: string; val: string; hint: string; tone: string }) {
+  const color = tone === 'profit' ? 'var(--profit)' : tone === 'loss' ? 'var(--loss)' : 'var(--foreground)';
+  return (
+    <div className="bg-[var(--card-bg)] border border-[var(--border)] rounded-lg p-4">
+      <div className="text-[11px] text-[var(--neutral)] uppercase tracking-wider font-mono">{label}</div>
+      <div className="font-mono font-bold text-[28px] mt-1.5 tabular-nums" style={{ color }}>{val}</div>
+      <div className="text-xs text-[var(--neutral)] mt-1">{hint}</div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,142 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  /* Source-aligned CSS variables */
+  --profit:               #22c55e;
+  --loss:                 #ef4444;
+  --neutral:              #6b7280;
+  --background:           #ffffff;
+  --foreground:           #0a0a0a;
+  --muted-foreground:     #737373;
+  --accent:               #2563eb;
+  --accent-hover:         #1d4ed8;
+  --card-bg:              #ffffff;
+  --border:               #e5e5e5;
+  --destructive:          #dc2626;
+  --success:              #16a34a;
+  --warning:              #ea580c;
+
+  /* Legacy aliases (kept for backwards compat) */
+  --ise-accent:           #2563eb;
+  --ise-accent-hover:     #1d4ed8;
+  --ise-accent-soft:      #eff6ff;
+
+  --bg:                   #ffffff;
+  --fg:                   #0a0a0a;
+  --muted:                #f5f5f5;
+  --muted-fg:             #737373;
+  --border-strong:        #d4d4d4;
+
+  --bg-dark:              #0a0a0a;
+  --fg-dark:              #ededed;
+  --card-bg-dark:         #141414;
+  --border-dark:          #262626;
+
+  --pro:                  #22c55e;
+  --pro-700:              #15803d;
+  --pro-50:               #f0fdf4;
+  --pro-100:              #dcfce7;
+
+  --con:                  #ef4444;
+  --con-600:              #dc2626;
+  --con-700:              #b91c1c;
+  --con-50:               #fef2f2;
+  --con-100:              #fee2e2;
+
+  --strength-weak:        #d4edda;
+  --strength-moderate:    #fff3cd;
+  --strength-strong:      #ffd8a8;
+  --strength-extreme:     #f8d7da;
+
+  --score-excellent:      #15803d;
+  --score-good:           #1d4ed8;
+  --score-moderate:       #c2410c;
+  --score-weak:           #b91c1c;
+
+  --tier-t1:              #15803d;
+  --tier-t2:              #1d4ed8;
+  --tier-t3:              #c2410c;
+  --tier-t4:              #6b7280;
+
+  --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "Cascadia Mono", "Courier New", monospace;
+
+  --radius-sm:   3px;
+  --radius:      6px;
+  --radius-md:   8px;
+  --radius-lg:   12px;
+  --radius-full: 9999px;
+
+  --shadow-md: 0 4px 6px -1px rgba(10,10,10,0.06), 0 2px 4px -2px rgba(10,10,10,0.04);
+  --shadow-lg: 0 10px 15px -3px rgba(10,10,10,0.08), 0 4px 6px -4px rgba(10,10,10,0.04);
+
+  --duration: 200ms;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background:       #0a0a0a;
+    --foreground:       #f5f5f5;
+    --muted:            #1a1a1a;
+    --muted-foreground: #a3a3a3;
+    --border:           #262626;
+    --card-bg:          #141414;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-sans);
+  color: var(--foreground);
+  background: var(--background);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: inherit; text-decoration: none; }
+
+/* Mono numerals everywhere they matter */
+.num {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Score quality color */
+.score-color-excellent { color: var(--score-excellent); }
+.score-color-good      { color: var(--score-good); }
+.score-color-moderate  { color: var(--score-moderate); }
+.score-color-weak      { color: var(--score-weak); }
+
+/* Fade-in for newly posted rows */
+@keyframes logEntryFadeIn {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.fade-in { animation: logEntryFadeIn 250ms ease forwards; }
+
+@layer utilities {
+  .text-profit { color: var(--profit); }
+  .text-loss   { color: var(--loss); }
+  .text-neutral { color: var(--neutral); }
+}
+
+/* Hover border swap — use on cards / rows that need the blue accent on hover */
+.card-hover {
+  transition: border-color 200ms ease;
+}
+.card-hover:hover {
+  border-color: var(--accent) !important;
+}
+
+/* Dark row hover */
+.row-hover-dark {
+  transition: border-color 200ms ease;
+}
+.row-hover-dark:hover {
+  border-color: #3b82f6 !important;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Idea Stock Exchange',
+  description: 'Computational Epistemology Platform — where arguments are scored, not just shouted.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/components/arbitrage/TradePanel.tsx
+++ b/components/arbitrage/TradePanel.tsx
@@ -1,0 +1,160 @@
+'use client';
+import { useState } from 'react';
+import { X } from 'lucide-react';
+
+interface TradePanelProps {
+  belief: {
+    slug: string;
+    statement: string;
+    reasonRank: number;
+    marketPrice: number;
+  };
+  onClose: () => void;
+  onTrade?: (side: 'YES' | 'NO', amount: number) => Promise<void>;
+}
+
+export function TradePanel({ belief, onClose, onTrade }: TradePanelProps) {
+  const [side, setSide] = useState<'YES' | 'NO'>('YES');
+  const [amount, setAmount] = useState('250');
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const yesPrice   = belief.marketPrice / 100;
+  const noPrice    = 1 - yesPrice;
+  const rr         = belief.reasonRank / 100;
+  const divergence = rr - yesPrice;
+  const signal     = Math.abs(divergence) < 0.05 ? 'HOLD' : divergence > 0 ? 'BUY YES' : 'BUY NO';
+  const parsed     = parseFloat(amount) || 0;
+  const shares     = parsed / (side === 'YES' ? yesPrice : noPrice);
+
+  async function handleTrade() {
+    if (!parsed || !onTrade) return;
+    setSubmitting(true);
+    try {
+      await onTrade(side, parsed);
+      setDone(true);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.65)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 50 }}
+      onClick={onClose}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        style={{ background: '#141414', border: '1px solid #262626', borderRadius: 12, padding: 20, width: 400, color: '#ededed', boxShadow: 'var(--shadow-lg)' }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 14 }}>
+          <h3 style={{ margin: 0, fontSize: 16, fontWeight: 600, lineHeight: 1.3, paddingRight: 12 }}>
+            {belief.statement.length > 60 ? belief.statement.slice(0, 60) + '…' : belief.statement}
+          </h3>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', color: '#a3a3a3', cursor: 'pointer', padding: 2 }} aria-label="Close">
+            <X size={18} />
+          </button>
+        </div>
+
+        {done ? (
+          <div style={{ padding: '24px 0', textAlign: 'center' }}>
+            <div style={{ fontSize: 20, marginBottom: 8 }}>✓</div>
+            <div style={{ fontWeight: 600, marginBottom: 4 }}>Trade placed</div>
+            <div style={{ fontSize: 13, color: '#a3a3a3' }}>
+              {parsed} credits → ~{shares.toFixed(2)} {side} shares
+            </div>
+            <button onClick={onClose} style={{ marginTop: 16, padding: '8px 18px', background: '#262626', color: '#ededed', border: 'none', borderRadius: 6, cursor: 'pointer' }}>
+              Close
+            </button>
+          </div>
+        ) : (
+          <>
+            {/* Signal block */}
+            <div style={{ padding: 12, borderRadius: 6, background: '#0a0a0a', border: '1px solid #262626', marginBottom: 14 }}>
+              <div style={{ fontSize: 11, color: '#a3a3a3', marginBottom: 4, fontFamily: 'var(--font-mono)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                Arbitrage Signal
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <span style={{ fontSize: 13 }}>
+                  RR <span style={{ fontFamily: 'var(--font-mono)' }}>{belief.reasonRank.toFixed(1)}%</span>
+                  {' / '}
+                  Mkt <span style={{ fontFamily: 'var(--font-mono)' }}>{belief.marketPrice.toFixed(1)}%</span>
+                </span>
+                <span style={{
+                  padding: '2px 8px', borderRadius: 4, fontSize: 11, fontWeight: 700, fontFamily: 'var(--font-mono)',
+                  background: signal === 'BUY YES' ? 'rgba(34,197,94,0.18)' : signal === 'BUY NO' ? 'rgba(239,68,68,0.18)' : 'rgba(107,114,128,0.18)',
+                  color: signal === 'BUY YES' ? '#22c55e' : signal === 'BUY NO' ? '#ef4444' : '#9ca3af',
+                }}>
+                  {signal}
+                </span>
+              </div>
+            </div>
+
+            {/* YES / NO buttons */}
+            <div style={{ display: 'flex', gap: 8, marginBottom: 14 }}>
+              <button
+                onClick={() => setSide('YES')}
+                style={{
+                  flex: 1, padding: 10, borderRadius: 6, fontWeight: 600, fontSize: 13, cursor: 'pointer',
+                  background: side === 'YES' ? '#16a34a' : '#0a0a0a',
+                  color: side === 'YES' ? '#fff' : '#a3a3a3',
+                  border: side === 'YES' ? '1px solid #16a34a' : '1px solid #262626',
+                  fontFamily: 'inherit',
+                }}
+              >
+                YES {(yesPrice * 100).toFixed(1)}c
+              </button>
+              <button
+                onClick={() => setSide('NO')}
+                style={{
+                  flex: 1, padding: 10, borderRadius: 6, fontWeight: 600, fontSize: 13, cursor: 'pointer',
+                  background: side === 'NO' ? '#dc2626' : '#0a0a0a',
+                  color: side === 'NO' ? '#fff' : '#a3a3a3',
+                  border: side === 'NO' ? '1px solid #dc2626' : '1px solid #262626',
+                  fontFamily: 'inherit',
+                }}
+              >
+                NO {(noPrice * 100).toFixed(1)}c
+              </button>
+            </div>
+
+            {/* Amount */}
+            <label style={{ display: 'block', fontSize: 11, color: '#a3a3a3', marginBottom: 4, fontFamily: 'var(--font-mono)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+              Investment (IdeaCredits)
+            </label>
+            <input
+              type="number"
+              value={amount}
+              onChange={e => setAmount(e.target.value)}
+              style={{
+                width: '100%', background: '#0a0a0a', border: '1px solid #262626',
+                color: '#fff', borderRadius: 6, padding: '8px 10px',
+                fontFamily: 'var(--font-mono)', fontSize: 14, marginBottom: 12,
+                outline: 'none',
+              }}
+            />
+
+            {parsed > 0 && (
+              <div style={{ fontSize: 11, color: '#a3a3a3', marginBottom: 14 }}>
+                Estimated: ~{shares.toFixed(2)} {side} shares (slippage may apply)
+              </div>
+            )}
+
+            <button
+              onClick={handleTrade}
+              disabled={submitting || !parsed}
+              style={{
+                width: '100%', padding: 10, background: parsed ? '#fff' : '#262626',
+                color: parsed ? '#0a0a0a' : '#a3a3a3',
+                border: 'none', borderRadius: 6, fontWeight: 600, fontSize: 14,
+                cursor: parsed ? 'pointer' : 'not-allowed',
+              }}
+            >
+              {submitting ? 'Placing…' : `Buy ${side} Shares`}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/belief/EvidenceLedger.tsx
+++ b/components/belief/EvidenceLedger.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link'
+import { Evidence, EvidenceTier } from '@/lib/types'
+
+const tierBg: Record<EvidenceTier, string> = {
+  T1: 'var(--tier-t1)',
+  T2: 'var(--tier-t2)',
+  T3: 'var(--tier-t3)',
+  T4: 'var(--tier-t4)',
+}
+
+function scoreColor(q: number): string {
+  if (q >= 80) return 'var(--score-excellent)'
+  if (q >= 60) return 'var(--score-moderate)'
+  return 'var(--score-weak)'
+}
+
+function EvidenceCell({ e }: { e?: Evidence }) {
+  if (!e) return <td className="border border-[var(--border)] p-3 align-top" />
+  return (
+    <td className="border border-[var(--border)] p-3 align-top text-[13px]">
+      <Link href="#" className="font-semibold text-[var(--accent)] no-underline hover:underline">
+        {e.title}
+      </Link>
+      <div className="text-[11px] text-[var(--muted-foreground)] mt-0.5">{e.source}</div>
+      <div className="mt-1 leading-snug">{e.finding}</div>
+    </td>
+  )
+}
+
+function QualityCell({ e }: { e?: Evidence }) {
+  if (!e) return <td className="border border-[var(--border)] p-3 align-top" />
+  return (
+    <td className="border border-[var(--border)] p-3 align-middle text-center">
+      <span
+        className="inline-block px-1.5 py-0.5 rounded text-[11px] font-bold font-mono text-white"
+        style={{ background: tierBg[e.tier] }}
+      >
+        {e.tier}
+      </span>
+      <div
+        className="font-mono font-bold mt-1 tabular-nums text-[13px]"
+        style={{ color: scoreColor(e.quality) }}
+      >
+        {e.quality}%
+      </div>
+    </td>
+  )
+}
+
+export function EvidenceLedger({ evidence }: { evidence: Evidence[] }) {
+  const proEvidence = evidence.filter(e => e.side === 'pro')
+  const conEvidence = evidence.filter(e => e.side === 'con')
+  const rowCount = Math.max(proEvidence.length, conEvidence.length)
+
+  return (
+    <table className="w-full border-collapse border border-[var(--border-strong)] text-sm">
+      <thead>
+        <tr className="bg-[var(--muted)]">
+          <th className="border border-[var(--border)] p-2.5 text-left font-semibold w-[46%]">Supporting Evidence</th>
+          <th className="border border-[var(--border)] p-2.5 text-center font-semibold w-[8%]">Quality</th>
+          <th className="border border-[var(--border)] p-2.5 text-left font-semibold w-[38%]">Weakening Evidence</th>
+          <th className="border border-[var(--border)] p-2.5 text-center font-semibold w-[8%]">Quality</th>
+        </tr>
+      </thead>
+      <tbody>
+        {Array.from({ length: rowCount }, (_, i) => (
+          <tr key={i} className="hover:bg-gray-50 transition-colors">
+            <EvidenceCell e={proEvidence[i]} />
+            <QualityCell  e={proEvidence[i]} />
+            <EvidenceCell e={conEvidence[i]} />
+            <QualityCell  e={conEvidence[i]} />
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/components/belief/ProConTable.tsx
+++ b/components/belief/ProConTable.tsx
@@ -1,0 +1,119 @@
+import { Argument } from '@/lib/types'
+
+function linkageLabel(label: string): string {
+  switch (label) {
+    case 'Strong':    return 'Strong'
+    case 'Moderate':  return 'Moderate'
+    case 'Context':   return 'Context'
+    case 'Weak':      return 'Weak'
+    case 'Anecdotal': return 'Anecdotal'
+    default:          return label
+  }
+}
+
+function LinkageBadge({ linkage, label }: { linkage: number; label: string }) {
+  const fraction = linkage / 100
+  let colorClass = 'bg-gray-100 text-gray-700 border-gray-300'
+  if (fraction < 0.05) colorClass = 'bg-red-50 text-red-500 border-red-200'
+  else if (fraction < 0.35) colorClass = 'bg-orange-50 text-orange-700 border-orange-300'
+  else if (fraction < 0.65) colorClass = 'bg-gray-50 text-gray-600 border-gray-300'
+  else if (fraction < 0.95) colorClass = 'bg-blue-50 text-blue-800 border-blue-400'
+  else colorClass = 'bg-green-50 text-green-800 border-green-500'
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs font-mono px-2 py-0.5 rounded border ${colorClass}`}
+    >
+      <span>{linkage}%</span>
+      <span className="text-[10px] text-[var(--muted-foreground)]">({linkageLabel(label)})</span>
+    </span>
+  )
+}
+
+function ContributionBadge({ linkage, truth }: { linkage: number; truth: number }) {
+  const fraction = (linkage / 100) * (truth / 100)
+  const pct = (fraction * 100).toFixed(0)
+  let colorClass = 'bg-gray-50 text-gray-600 border-gray-300'
+  if (fraction >= 0.65) colorClass = 'bg-green-50 text-green-800 border-green-500'
+  else if (fraction >= 0.35) colorClass = 'bg-blue-50 text-blue-800 border-blue-300'
+  else if (fraction >= 0.10) colorClass = 'bg-orange-50 text-orange-700 border-orange-300'
+  else colorClass = 'bg-red-50 text-red-600 border-red-200'
+
+  return (
+    <span
+      title="Contribution = Linkage Score × Truth Score"
+      className={`inline-flex items-center text-xs font-mono px-2 py-0.5 rounded border ${colorClass}`}
+    >
+      {pct}%
+    </span>
+  )
+}
+
+function ArgTable({ rows, side }: { rows: Argument[]; side: 'pro' | 'con' }) {
+  const isPro = side === 'pro'
+  const total = rows.reduce((s, r) => s + parseFloat(r.impact.replace(/[^0-9.\-]/g, '') || '0'), 0)
+
+  return (
+    <table className="w-full border-collapse border border-gray-300 text-sm">
+      <thead>
+        <tr className={isPro ? 'bg-green-50' : 'bg-red-50'}>
+          <th className="px-3 py-2 text-left w-[48%] font-semibold">
+            Top Scoring Reasons to {isPro ? 'Agree' : 'Disagree'}
+          </th>
+          <th className="px-3 py-2 text-center w-[13%] font-semibold">Truth Score</th>
+          <th className="px-3 py-2 text-center w-[14%] font-semibold">Linkage Score</th>
+          <th className="px-3 py-2 text-center w-[12%] font-semibold" title="Linkage Score × Truth Score">
+            Contribution
+          </th>
+          <th className="px-3 py-2 text-center w-[13%] font-semibold">Impact</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.length > 0 ? (
+          rows.map(r => (
+            <tr key={r.id} className="border-b border-gray-200 hover:bg-gray-50 transition-colors">
+              <td className="px-3 py-3 text-sm">{r.title}</td>
+              <td className="px-3 py-3 text-center text-sm font-mono">
+                {r.truth}%
+              </td>
+              <td className="px-3 py-3 text-center">
+                <LinkageBadge linkage={r.linkage} label={r.linkageLabel} />
+              </td>
+              <td className="px-3 py-3 text-center">
+                <ContributionBadge linkage={r.linkage} truth={r.truth} />
+              </td>
+              <td className={`px-3 py-3 text-center text-sm font-bold font-mono ${isPro ? 'text-green-700' : 'text-red-700'}`}>
+                {r.impact}
+              </td>
+            </tr>
+          ))
+        ) : (
+          <tr className="border-b border-gray-200">
+            <td className="px-3 py-3 text-sm text-[var(--muted-foreground)] italic" colSpan={5}>
+              No arguments yet. Be the first to contribute.
+            </td>
+          </tr>
+        )}
+        <tr className="bg-gray-100 font-semibold">
+          <td colSpan={4} className="px-3 py-2 text-right text-sm">Total {isPro ? 'Pro' : 'Con'}:</td>
+          <td className={`px-3 py-2 text-center text-sm font-mono ${isPro ? 'text-green-700' : 'text-red-700'}`}>
+            {isPro ? '+' : '-'}{Math.abs(total).toFixed(1)}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  )
+}
+
+export function ProConTable({ proArgs, conArgs }: { proArgs: Argument[]; conArgs: Argument[] }) {
+  return (
+    <>
+      <div className="mb-6 overflow-x-auto">
+        <ArgTable rows={proArgs} side="pro" />
+      </div>
+      <div className="overflow-x-auto">
+        <ArgTable rows={conArgs} side="con" />
+      </div>
+    </>
+  )
+}

--- a/components/belief/ScoreDashboard.tsx
+++ b/components/belief/ScoreDashboard.tsx
@@ -1,0 +1,69 @@
+function scoreColor(pct: number): string {
+  if (pct >= 80) return 'var(--score-excellent)'
+  if (pct >= 60) return 'var(--score-good)'
+  if (pct >= 40) return 'var(--score-moderate)'
+  return 'var(--score-weak)'
+}
+
+function ScoreTile({
+  label, value, suffix, colorStyle, sub,
+}: {
+  label: string; value: string; suffix: string; colorStyle: string; sub: string;
+}) {
+  return (
+    <div className="border border-[var(--border)] rounded-lg p-3.5 bg-white">
+      <div className="text-[11px] text-[var(--muted-foreground)] font-mono uppercase tracking-wider mb-1.5">
+        {label}
+      </div>
+      <div className="font-mono font-bold text-[28px] leading-none tabular-nums" style={{ color: colorStyle }}>
+        {value}
+        <span className="text-base ml-0.5">{suffix}</span>
+      </div>
+      <div className="text-[11px] text-[var(--muted-foreground)] mt-1.5">{sub}</div>
+    </div>
+  )
+}
+
+export function ScoreDashboard({
+  reasonRank,
+  marketPrice,
+  volume,
+}: {
+  reasonRank: number
+  marketPrice: number
+  volume: number
+}) {
+  const divergence = reasonRank - marketPrice
+  return (
+    <div className="grid grid-cols-4 gap-3">
+      <ScoreTile
+        label="ReasonRank"
+        value={reasonRank.toFixed(1)}
+        suffix="%"
+        colorStyle={scoreColor(reasonRank)}
+        sub="Truth × Relevance × Importance"
+      />
+      <ScoreTile
+        label="Market Price"
+        value={marketPrice.toFixed(1)}
+        suffix="c"
+        colorStyle="var(--score-good)"
+        sub="YES share price"
+      />
+      <ScoreTile
+        label="Divergence"
+        value={`${divergence >= 0 ? '+' : ''}${divergence.toFixed(1)}`}
+        suffix="%"
+        colorStyle={divergence >= 0 ? 'var(--score-excellent)' : 'var(--score-weak)'}
+        sub={divergence >= 0 ? 'Undervalued by crowd' : 'Overvalued by crowd'}
+      />
+      <ScoreTile
+        label="Volume"
+        value={volume.toLocaleString()}
+        suffix=""
+        colorStyle="var(--foreground)"
+        sub="credits this month"
+      />
+    </div>
+  )
+}

--- a/components/belief/SpectrumsHeader.tsx
+++ b/components/belief/SpectrumsHeader.tsx
@@ -1,0 +1,106 @@
+import Link from 'next/link'
+import { getStrengthBand, formatStrength } from '@/lib/claim-strength'
+
+interface SpectrumsHeaderProps {
+  positivity: number
+  specificity: number
+  claimStrength: number
+}
+
+function valenceLabel(positivity: number): string {
+  if (positivity >= 60) return 'Extremely Positive'
+  if (positivity >= 20) return 'Mildly Positive'
+  if (positivity > -20) return 'Neutral'
+  if (positivity > -60) return 'Mildly Negative'
+  return 'Extremely Negative'
+}
+
+function specificityLabel(specificity: number): string {
+  if (specificity < 0.2) return 'Highly General'
+  if (specificity < 0.45) return 'Moderately General'
+  if (specificity < 0.7) return 'Case-Level'
+  return 'Highly Specific'
+}
+
+interface SpectrumRowProps {
+  label: string
+  leftLabel: string
+  rightLabel: string
+  value: string
+  pct: number
+  gradient: string
+}
+
+function SpectrumRow({ label, leftLabel, rightLabel, value, pct, gradient }: SpectrumRowProps) {
+  const clamped = Math.max(0, Math.min(100, pct))
+  return (
+    <div className="flex items-center gap-3">
+      <div className="w-20 shrink-0 font-mono uppercase tracking-wide text-[var(--muted-foreground)] text-[10px]">
+        {label}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div
+          className="relative h-3 rounded-full overflow-hidden border border-gray-200"
+          style={{ background: gradient }}
+        >
+          <div
+            className="absolute top-0 h-full w-0.5 bg-gray-900"
+            style={{ left: `calc(${clamped}% - 1px)` }}
+          />
+        </div>
+        <div className="flex justify-between mt-0.5 text-[10px] text-gray-500">
+          <span>{leftLabel}</span>
+          <span className="text-[var(--foreground)] font-semibold">{value}</span>
+          <span>{rightLabel}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function SpectrumsHeader({ positivity, specificity, claimStrength }: SpectrumsHeaderProps) {
+  const valencePct = ((positivity + 100) / 200) * 100
+  const specPct = specificity * 100
+  const strengthPct = claimStrength * 100
+  const band = getStrengthBand(claimStrength)
+
+  return (
+    <div className="border border-[var(--border)] rounded p-3 mb-8 bg-gray-50">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)] mb-2 flex items-center gap-2">
+        <span>Three Spectrums</span>
+        <Link
+          href="/One%20Page%20Per%20Belief"
+          className="text-[var(--accent)] hover:underline text-[10px] font-normal"
+        >
+          (what is this?)
+        </Link>
+      </div>
+      <div className="space-y-2 text-xs">
+        <SpectrumRow
+          label="Valence"
+          leftLabel="Negative"
+          rightLabel="Positive"
+          value={`${valenceLabel(positivity)} (${positivity >= 0 ? '+' : ''}${positivity.toFixed(0)})`}
+          pct={valencePct}
+          gradient="linear-gradient(to right, #f8d7da 0%, #fff3cd 50%, #d4edda 100%)"
+        />
+        <SpectrumRow
+          label="Specificity"
+          leftLabel="General"
+          rightLabel="Specific"
+          value={specificityLabel(specificity)}
+          pct={specPct}
+          gradient="linear-gradient(to right, #e0e7ff 0%, #c7d2fe 100%)"
+        />
+        <SpectrumRow
+          label="Intensity"
+          leftLabel="Weak"
+          rightLabel="Extreme"
+          value={`${band.label} (${formatStrength(claimStrength)})`}
+          pct={strengthPct}
+          gradient="linear-gradient(to right, #d4edda 0%, #fff3cd 40%, #ffd8a8 75%, #f8d7da 100%)"
+        />
+      </div>
+    </div>
+  )
+}

--- a/components/cba/CBATable.tsx
+++ b/components/cba/CBATable.tsx
@@ -1,0 +1,69 @@
+import { CBAItem } from '@/lib/types';
+import { Badge } from '@/components/ui/Badge';
+
+const th: React.CSSProperties = { border: '1px solid #e5e5e5', padding: '8px 10px', textAlign: 'left', fontWeight: 600 };
+const td: React.CSSProperties = { border: '1px solid #e5e5e5', padding: '10px 12px', verticalAlign: 'top' };
+
+function LikelihoodMeter({ pct }: { pct: number }) {
+  const color = pct >= 70 ? '#16a34a' : pct >= 40 ? '#ea580c' : '#dc2626';
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <div style={{ flex: 1, height: 6, borderRadius: 99, background: '#f5f5f5', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: `${pct}%`, background: color }} />
+      </div>
+      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
+        {pct}%
+      </span>
+    </div>
+  );
+}
+
+export function CBATable({ rows, kind }: { rows: CBAItem[]; kind: 'benefit' | 'cost' }) {
+  const isPro = kind === 'benefit';
+  const totalEV = rows.reduce((s, r) => s + (r.impactValue * r.likelihood / 100), 0);
+
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse', border: '1px solid #d4d4d4', fontSize: 13 }}>
+      <thead>
+        <tr style={{ background: isPro ? '#f0fdf4' : '#fef2f2' }}>
+          <th style={{ ...th, width: '40%' }}>Line Item</th>
+          <th style={{ ...th, textAlign: 'right',  width: '17%' }}>Predicted Impact</th>
+          <th style={{ ...th, textAlign: 'center', width: '15%' }}>Likelihood</th>
+          <th style={{ ...th, textAlign: 'center', width: '12%' }}>Evidence</th>
+          <th style={{ ...th, textAlign: 'right',  width: '16%' }}>Expected Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(r => {
+          const ev = r.impactValue * r.likelihood / 100;
+          const evLabel = `${ev >= 0 ? '+' : '−'}$${Math.abs(ev).toFixed(1)}B`;
+          return (
+            <tr key={r.id} style={{ borderBottom: '1px solid #e5e5e5' }}>
+              <td style={td}>{r.label}</td>
+              <td style={{ ...td, textAlign: 'right', fontFamily: 'var(--font-mono)', color: isPro ? '#15803d' : '#b91c1c', fontVariantNumeric: 'tabular-nums' }}>
+                {r.impact}
+              </td>
+              <td style={{ ...td, textAlign: 'center' }}>
+                <LikelihoodMeter pct={r.likelihood} />
+              </td>
+              <td style={{ ...td, textAlign: 'center' }}>
+                <Badge tone={r.evidence >= 80 ? 'pro' : r.evidence >= 60 ? 'info' : 'warn'}>
+                  {r.evidence}%
+                </Badge>
+              </td>
+              <td style={{ ...td, textAlign: 'right', fontFamily: 'var(--font-mono)', fontWeight: 700, color: isPro ? '#15803d' : '#b91c1c', fontVariantNumeric: 'tabular-nums' }}>
+                {evLabel}
+              </td>
+            </tr>
+          );
+        })}
+        <tr style={{ background: '#f5f5f5', fontWeight: 700 }}>
+          <td colSpan={4} style={{ ...td, textAlign: 'right' }}>Total Expected Value</td>
+          <td style={{ ...td, textAlign: 'right', fontFamily: 'var(--font-mono)', color: isPro ? '#15803d' : '#b91c1c', fontVariantNumeric: 'tabular-nums' }}>
+            {totalEV >= 0 ? '+' : '−'}${Math.abs(totalEV).toFixed(1)}B
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link';
+
+const RESOURCES = [
+  'Schlicht Protocol', 'Product Reviews', 'Cost-Benefit Analysis',
+  'Browse Laws', 'Prediction Markets', 'FAQ & Criticisms',
+];
+const FRAMEWORK = ['Truth', 'Interests', 'Evidence', 'Assumptions', 'Strong-to-Weak Spectrum'];
+
+export function Footer() {
+  return (
+    <footer className="border-t border-[var(--border)] mt-16 bg-white">
+      <div className="max-w-[1280px] mx-auto px-6 py-10 grid grid-cols-3 gap-8">
+        <div>
+          <h4 className="m-0 text-sm font-bold text-[var(--foreground)]">Idea Stock Exchange</h4>
+          <p className="text-[13px] text-[var(--muted-foreground)] mt-2 leading-relaxed">
+            Computational Epistemology Platform. Making confidence inspectable.
+          </p>
+        </div>
+        <div>
+          <h4 className="m-0 text-sm font-bold text-[var(--foreground)]">Resources</h4>
+          <ul className="list-none p-0 mt-3 flex flex-col gap-2">
+            {RESOURCES.map(l => (
+              <li key={l}>
+                <Link href="#" className="text-[13px] text-[#525252] no-underline hover:text-[var(--foreground)] transition-colors">
+                  {l}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h4 className="m-0 text-sm font-bold text-[var(--foreground)]">Framework</h4>
+          <ul className="list-none p-0 mt-3 flex flex-col gap-2">
+            {FRAMEWORK.map(l => (
+              <li key={l}>
+                <Link href="#" className="text-[13px] text-[#525252] no-underline hover:text-[var(--foreground)] transition-colors">
+                  {l}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+      <div className="border-t border-[var(--border)] px-6 py-5 text-center text-[13px] text-[var(--muted-foreground)]">
+        No ideological ownership. Good ideas win by surviving reality.
+      </div>
+    </footer>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,0 +1,59 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LogoMark } from '@/components/ui/LogoMark';
+
+const NAV = [
+  { href: '/',              label: 'Home' },
+  { href: '/beliefs',       label: 'Beliefs' },
+  { href: '/debate-topics', label: 'Debate Topics' },
+  { href: '/markets',       label: 'Markets' },
+  { href: '/arbitrage',     label: 'Arbitrage' },
+  { href: '/cba',           label: 'CBA' },
+  { href: '/protocol',      label: 'Protocol' },
+];
+
+export function Header({ credits = 1250 }: { credits?: number }) {
+  const path = usePathname();
+
+  return (
+    <header className="border-b border-[var(--border)] bg-white sticky top-0 z-10">
+      <div className="max-w-[1280px] mx-auto px-6 flex items-center gap-8 h-14">
+        <Link href="/" className="flex items-center gap-2.5 no-underline shrink-0">
+          <LogoMark size={28} />
+          <span className="font-bold text-base text-[var(--foreground)] tracking-tight">
+            Idea Stock Exchange
+          </span>
+        </Link>
+
+        <nav className="flex gap-1 flex-1">
+          {NAV.map(n => {
+            const active = n.href === '/' ? path === '/' : path.startsWith(n.href);
+            return (
+              <Link
+                key={n.href}
+                href={n.href}
+                className={[
+                  'px-2.5 py-2 text-sm no-underline whitespace-nowrap transition-colors duration-[var(--duration)]',
+                  'border-b-2',
+                  active
+                    ? 'font-semibold text-[var(--foreground)] border-[var(--accent)]'
+                    : 'font-medium text-[#525252] border-transparent hover:text-[var(--foreground)]',
+                ].join(' ')}
+              >
+                {n.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div className="flex items-baseline gap-1.5 shrink-0">
+          <span className="font-mono text-xs text-[var(--muted-foreground)]">Credits</span>
+          <span className="font-mono font-bold text-sm text-[var(--foreground)]">
+            {credits.toLocaleString()}
+          </span>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react'
+
+type BadgeTone = 'pro' | 'con' | 'info' | 'warn' | 'neutral'
+
+const styles: Record<BadgeTone, string> = {
+  pro:     'bg-[#dcfce7] text-[#15803d] border-[#86efac]',
+  con:     'bg-[#fee2e2] text-[#b91c1c] border-[#fecaca]',
+  info:    'bg-[#dbeafe] text-[#1e40af] border-[#93c5fd]',
+  warn:    'bg-[#fed7aa] text-[#7c2d12] border-[#fdba74]',
+  neutral: 'bg-[var(--muted)] text-[#525252] border-[var(--border)]',
+}
+
+export function Badge({ tone = 'neutral', children }: { tone?: BadgeTone; children: ReactNode }) {
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded border font-mono text-[11px] font-bold tracking-wider ${styles[tone]}`}>
+      {children}
+    </span>
+  )
+}

--- a/components/ui/Callout.tsx
+++ b/components/ui/Callout.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react'
+
+type CalloutTone = 'info' | 'warn' | 'ok'
+
+const styles: Record<CalloutTone, string> = {
+  info: 'border-l-[var(--accent)]   bg-[var(--ise-accent-soft)]',
+  warn: 'border-l-[var(--con-600)]  bg-[var(--con-50)]',
+  ok:   'border-l-[var(--success)]  bg-[#f0fdf4]',
+}
+
+export function Callout({
+  tone = 'info',
+  title,
+  children,
+}: {
+  tone?: CalloutTone
+  title?: string
+  children: ReactNode
+}) {
+  return (
+    <div className={`border-l-4 ${styles[tone]} px-3.5 py-3 rounded-r-[var(--radius)] text-sm leading-relaxed`}>
+      {title && <strong>{title} </strong>}
+      {children}
+    </div>
+  )
+}

--- a/components/ui/LogoMark.tsx
+++ b/components/ui/LogoMark.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { useId } from 'react';
+
+export function LogoMark({ size = 32 }: { size?: number }) {
+  const id = useId();
+  return (
+    <svg width={size} height={size} viewBox="0 0 144 144" aria-hidden="true">
+      <defs>
+        <radialGradient id={`bg-${id}`} cx="58%" cy="38%" r="80%">
+          <stop offset="0%"   stopColor="#0f172a" />
+          <stop offset="100%" stopColor="#020617" />
+        </radialGradient>
+        <radialGradient id={`glow-${id}`} cx="50%" cy="50%" r="50%">
+          <stop offset="0%"   stopColor="#60a5fa" stopOpacity="0.55" />
+          <stop offset="100%" stopColor="#60a5fa" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <rect width="144" height="144" rx="28" fill={`url(#bg-${id})`} />
+      <circle cx="115" cy="38" r="34" fill={`url(#glow-${id})`} />
+      <g stroke="#3b82f6" strokeWidth="1.3" strokeOpacity="0.5" fill="none" strokeLinecap="round">
+        <line x1="32"  y1="110" x2="56"  y2="92" />
+        <line x1="56"  y1="92"  x2="72"  y2="78" />
+        <line x1="72"  y1="78"  x2="92"  y2="58" />
+        <line x1="92"  y1="58"  x2="115" y2="38" />
+        <line x1="56"  y1="92"  x2="48"  y2="74" />
+        <line x1="72"  y1="78"  x2="64"  y2="64" />
+        <line x1="92"  y1="58"  x2="106" y2="74" />
+      </g>
+      <path
+        d="M 32 110 L 56 92 L 72 78 L 92 58 L 115 38"
+        stroke="#60a5fa" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" fill="none"
+      />
+      <circle cx="32"  cy="110" r="5"   fill="#ef4444" />
+      <circle cx="56"  cy="92"  r="3.5" fill="#e2e8f0" />
+      <circle cx="48"  cy="74"  r="3"   fill="#94a3b8" />
+      <circle cx="72"  cy="78"  r="4.5" fill="#22c55e" />
+      <circle cx="64"  cy="64"  r="3"   fill="#e2e8f0" />
+      <circle cx="92"  cy="58"  r="6"   fill="#3b82f6" />
+      <circle cx="92"  cy="58"  r="2.2" fill="#f8fafc" />
+      <circle cx="106" cy="74"  r="3.5" fill="#ef4444" />
+      <circle cx="115" cy="38"  r="7"   fill="#60a5fa" />
+      <circle cx="115" cy="38"  r="2.4" fill="#f8fafc" />
+    </svg>
+  );
+}

--- a/components/ui/SectionHeading.tsx
+++ b/components/ui/SectionHeading.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+
+interface SectionHeadingProps {
+  emoji: string
+  title: string
+  href?: string
+  subtitle?: string
+  /** @deprecated use href */
+  link?: string
+}
+
+export function SectionHeading({ emoji, title, href, subtitle, link }: SectionHeadingProps) {
+  const dest = href ?? link
+  return (
+    <div className="mb-4">
+      <h2 className="flex items-center gap-2 text-[22px] font-bold m-0">
+        <span aria-hidden="true">{emoji}</span>
+        {dest ? (
+          <Link href={dest} className="text-[var(--accent)] hover:underline">
+            {title}
+          </Link>
+        ) : (
+          title
+        )}
+      </h2>
+      {subtitle && (
+        <p className="text-sm text-[var(--muted-foreground)] italic mt-1 mb-0">{subtitle}</p>
+      )}
+    </div>
+  )
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,38 @@
+import { NextAuthOptions } from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import bcrypt from 'bcryptjs';
+import { getUserByEmail } from './data';
+
+export const authOptions: NextAuthOptions = {
+  session: { strategy: 'jwt' },
+  providers: [
+    CredentialsProvider({
+      name: 'credentials',
+      credentials: {
+        email:    { label: 'Email',    type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) return null;
+        const user = getUserByEmail(credentials.email);
+        if (!user) return null;
+        const valid = await bcrypt.compare(credentials.password, user.passwordHash);
+        if (!valid) return null;
+        return { id: user.id, email: user.email, name: user.name };
+      },
+    }),
+  ],
+  pages: { signIn: '/login' },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) token.id = user.id;
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user && token.id) {
+        (session.user as typeof session.user & { id: string }).id = token.id as string;
+      }
+      return session;
+    },
+  },
+};

--- a/lib/claim-strength.ts
+++ b/lib/claim-strength.ts
@@ -1,0 +1,96 @@
+export interface StrengthBand {
+  value: number
+  label: string
+  percentage: string
+  descriptor: string
+  evidenceRequired: string
+  typicalScoreRange: { min: number; max: number }
+  bgColor: string
+  textColor: string
+  hexColor: string
+}
+
+export const STRENGTH_BANDS: StrengthBand[] = [
+  {
+    value: 0.2,
+    label: 'Weak',
+    percentage: '20%',
+    descriptor: 'Highly Defensible',
+    evidenceRequired: 'Any credible indication of imperfection. Easy to defend.',
+    typicalScoreRange: { min: 0.75, max: 0.95 },
+    bgColor: 'bg-green-100',
+    textColor: 'text-green-800',
+    hexColor: '#d4edda',
+  },
+  {
+    value: 0.5,
+    label: 'Moderate',
+    percentage: '50%',
+    descriptor: 'Defensible',
+    evidenceRequired: 'Specific data showing measurable effects across relevant domains.',
+    typicalScoreRange: { min: 0.55, max: 0.80 },
+    bgColor: 'bg-yellow-100',
+    textColor: 'text-yellow-800',
+    hexColor: '#fff3cd',
+  },
+  {
+    value: 0.8,
+    label: 'Strong',
+    percentage: '80%',
+    descriptor: 'Contested',
+    evidenceRequired: 'Comprehensive cost-benefit evidence across multiple domains.',
+    typicalScoreRange: { min: 0.30, max: 0.60 },
+    bgColor: 'bg-orange-100',
+    textColor: 'text-orange-800',
+    hexColor: '#ffd8a8',
+  },
+  {
+    value: 1.0,
+    label: 'Extreme',
+    percentage: '100%',
+    descriptor: 'Indefensible',
+    evidenceRequired: 'Near-total evidence dominance. Almost never achieved.',
+    typicalScoreRange: { min: 0.00, max: 0.25 },
+    bgColor: 'bg-red-100',
+    textColor: 'text-red-800',
+    hexColor: '#f8d7da',
+  },
+]
+
+export function getStrengthBand(claimStrength: number): StrengthBand {
+  const clamped = Math.max(0, Math.min(1, claimStrength))
+  let closest = STRENGTH_BANDS[0]
+  let minDist = Math.abs(clamped - STRENGTH_BANDS[0].value)
+  for (const band of STRENGTH_BANDS) {
+    const dist = Math.abs(clamped - band.value)
+    if (dist < minDist) {
+      minDist = dist
+      closest = band
+    }
+  }
+  return closest
+}
+
+export function getStrengthLabel(claimStrength: number): string {
+  return getStrengthBand(claimStrength).label
+}
+
+export function formatStrength(claimStrength: number): string {
+  return `${Math.round(claimStrength * 100)}%`
+}
+
+export function applyStrengthPenalty(rawScore: number, claimStrength: number): number {
+  const clamped = Math.max(0, Math.min(1, claimStrength))
+  const burdenFactor = 1.0 - 0.75 * clamped
+  return Math.max(0, Math.min(1, rawScore * burdenFactor))
+}
+
+export function getStrengthRationale(claimStrength: number): string {
+  const band = getStrengthBand(claimStrength)
+  const factor = Math.round((1.0 - 0.75 * claimStrength) * 100)
+  return (
+    `${band.label} claim (${band.percentage}): ` +
+    `Only ${factor}% of evidence strength transmits to the final score. ` +
+    `${band.evidenceRequired}`
+  )
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,203 @@
+import { Belief, ArbitrageRow, CBAItem, User, Trade } from './types';
+
+// ─── Beliefs ──────────────────────────────────────────────────────────────────
+
+export const beliefs: Belief[] = [
+  {
+    slug: 'carbon-tax-reduces-emissions',
+    statement: 'A revenue-neutral carbon tax materially reduces emissions',
+    reasonRank: 78.4,
+    marketPrice: 52.3,
+    volume: 24140,
+    contributors: 18,
+    argCount: 47,
+    lastEvaluated: '12 May 2026',
+    spectrums: { positivity: 62, specificity: 0.55, claimStrength: 0.5 },
+    proArgs: [
+      { id: 'p1', title: 'BC carbon tax → 5–15% emissions decline (Murray & Rivers 2015)', linkage: 92, linkageLabel: 'Strong', truth: 88, impact: '+18.4', side: 'pro' },
+      { id: 'p2', title: 'Sweden carbon tax cut transport emissions 11% vs counterfactual', linkage: 78, linkageLabel: 'Strong', truth: 82, impact: '+11.2', side: 'pro' },
+      { id: 'p3', title: 'Price elasticity of fuel demand is non-zero in long run',          linkage: 71, linkageLabel: 'Context', truth: 90, impact: '+9.6',  side: 'pro' },
+    ],
+    conArgs: [
+      { id: 'c1', title: 'Leakage offsets domestic gains via imports',             linkage: 41, linkageLabel: 'Context', truth: 62, impact: '−5.8', side: 'con' },
+      { id: 'c2', title: 'Revenue rebates may rebound consumption',                linkage: 34, linkageLabel: 'Weak',    truth: 52, impact: '−4.1', side: 'con' },
+    ],
+    evidence: [
+      { id: 'e1', title: 'Murray & Rivers — Review of BC Carbon Tax', source: 'Energy Policy 2015', quality: 92, tier: 'T1', finding: 'Found 5–15% reduction vs synthetic counterfactual. Replicated.', side: 'pro' },
+      { id: 'e2', title: 'Carbon Leakage in Open Economies',          source: 'NBER 2018',          quality: 71, tier: 'T2', finding: 'Estimates 10–25% of abatement offset by imports.', side: 'con' },
+      { id: 'e3', title: 'Sweden Transport Sector Analysis',          source: 'IMF Working Paper',  quality: 78, tier: 'T2', finding: '11% reduction in long-run elasticity model.', side: 'pro' },
+      { id: 'e4', title: 'Op-Ed — The Rebate Trap',                  source: 'WSJ Opinion 2021',   quality: 28, tier: 'T4', finding: 'Argues rebates rebound consumption; mostly speculative.', side: 'con' },
+    ],
+  },
+  {
+    slug: 'fifteen-dollar-minimum-wage',
+    statement: '$15 federal minimum wage reduces poverty long-run',
+    reasonRank: 31.2,
+    marketPrice: 68.4,
+    volume: 11820,
+    contributors: 12,
+    argCount: 33,
+    lastEvaluated: '8 May 2026',
+    spectrums: { positivity: -20, specificity: 0.6, claimStrength: 0.72 },
+    proArgs: [
+      { id: 'p1', title: 'Higher wages increase purchasing power among low earners', linkage: 65, linkageLabel: 'Moderate', truth: 74, impact: '+12.0', side: 'pro' },
+      { id: 'p2', title: 'Dube (2019): minimum wage reduces poverty rate 10–14%',   linkage: 72, linkageLabel: 'Strong',   truth: 68, impact: '+9.4',  side: 'pro' },
+    ],
+    conArgs: [
+      { id: 'c1', title: 'CBO (2021): 1.4M jobs lost nationally at $15',            linkage: 78, linkageLabel: 'Strong',   truth: 82, impact: '−22.1', side: 'con' },
+      { id: 'c2', title: 'Regional price differences make a single floor distortive', linkage: 61, linkageLabel: 'Moderate', truth: 72, impact: '−11.3', side: 'con' },
+      { id: 'c3', title: 'Employers substitute capital for labor at higher wages',    linkage: 54, linkageLabel: 'Moderate', truth: 66, impact: '−8.2',  side: 'con' },
+    ],
+    evidence: [
+      { id: 'e1', title: 'Dube — Impacts of Minimum Wages on Poverty', source: 'Journal of Labor Economics 2019', quality: 84, tier: 'T1', finding: 'Finds 10–14% poverty reduction per 10% minimum wage increase.', side: 'pro' },
+      { id: 'e2', title: 'CBO — The Effects on Employment of a $15 Federal Minimum Wage', source: 'Congressional Budget Office 2021', quality: 88, tier: 'T1', finding: 'Projects 1.4M job losses and 900K people lifted from poverty.', side: 'con' },
+      { id: 'e3', title: 'Seattle Min Wage Study (UW)',   source: 'University of Washington 2018', quality: 76, tier: 'T2', finding: 'Mixed: hours reduced, but earnings for retained workers rose.', side: 'con' },
+    ],
+  },
+  {
+    slug: 'new-nuclear-cheaper-than-gas',
+    statement: 'New nuclear is cheaper than gas peakers by 2030',
+    reasonRank: 62.1,
+    marketPrice: 39.7,
+    volume: 18230,
+    contributors: 9,
+    argCount: 28,
+    lastEvaluated: '5 May 2026',
+    spectrums: { positivity: 40, specificity: 0.75, claimStrength: 0.45 },
+    proArgs: [
+      { id: 'p1', title: 'SMR learning curves show 40% cost reduction by 2035 (IAEA 2024)', linkage: 68, linkageLabel: 'Moderate', truth: 58, impact: '+14.2', side: 'pro' },
+      { id: 'p2', title: 'Carbon pricing makes gas increasingly uneconomical', linkage: 72, linkageLabel: 'Moderate', truth: 74, impact: '+9.1', side: 'pro' },
+    ],
+    conArgs: [
+      { id: 'c1', title: 'Vogtle 3&4 overran $17B over budget — nuclear capex risk remains extreme', linkage: 84, linkageLabel: 'Strong', truth: 94, impact: '−18.6', side: 'con' },
+      { id: 'c2', title: 'No SMR has reached commercial scale as of 2026', linkage: 79, linkageLabel: 'Strong', truth: 97, impact: '−12.0', side: 'con' },
+    ],
+    evidence: [
+      { id: 'e1', title: 'Lazard LCOE Analysis 2024', source: 'Lazard 2024', quality: 80, tier: 'T2', finding: 'Nuclear LCOE $141/MWh vs gas peaker $165–230/MWh under carbon pricing.', side: 'pro' },
+      { id: 'e2', title: 'Vogtle 3&4 Post-Mortem', source: 'Georgia Power Filing 2024', quality: 91, tier: 'T2', finding: 'Final cost $35B vs $14B estimate; 7-year schedule overrun.', side: 'con' },
+    ],
+  },
+  {
+    slug: 'ranked-choice-voting-reduces-polarization',
+    statement: 'Ranked-choice voting reduces political polarization',
+    reasonRank: 54.3,
+    marketPrice: 32.0,
+    volume: 9214,
+    contributors: 7,
+    argCount: 22,
+    lastEvaluated: '3 May 2026',
+    spectrums: { positivity: 30, specificity: 0.5, claimStrength: 0.35 },
+    proArgs: [
+      { id: 'p1', title: 'RCV incentivizes candidates to appeal beyond their base', linkage: 74, linkageLabel: 'Moderate', truth: 62, impact: '+10.8', side: 'pro' },
+      { id: 'p2', title: 'Alaska 2022 results: moderate candidates outperformed extremes', linkage: 66, linkageLabel: 'Moderate', truth: 78, impact: '+7.3', side: 'pro' },
+    ],
+    conArgs: [
+      { id: 'c1', title: 'No causal study isolates RCV from other electoral reforms', linkage: 58, linkageLabel: 'Moderate', truth: 82, impact: '−9.4', side: 'con' },
+      { id: 'c2', title: 'Polarization is driven by media/social dynamics, not ballot structure', linkage: 52, linkageLabel: 'Moderate', truth: 68, impact: '−7.1', side: 'con' },
+    ],
+    evidence: [
+      { id: 'e1', title: 'Blessing et al — Does RCV Reduce Polarization?', source: 'Electoral Studies 2022', quality: 72, tier: 'T2', finding: 'Weak positive correlation; no causal identification.', side: 'pro' },
+      { id: 'e2', title: 'Brunell & Grofman — RCV and Extremism',          source: 'PS: Political Science 2023', quality: 68, tier: 'T2', finding: 'No significant effect on ideological extremity of winners.', side: 'con' },
+    ],
+  },
+  {
+    slug: 'rent-control-increases-supply',
+    statement: 'Rent control increases housing supply long-term',
+    reasonRank: 18.0,
+    marketPrice: 41.2,
+    volume: 6402,
+    contributors: 6,
+    argCount: 19,
+    lastEvaluated: '1 May 2026',
+    spectrums: { positivity: -70, specificity: 0.7, claimStrength: 0.88 },
+    proArgs: [
+      { id: 'p1', title: 'Stabilized tenants stay longer, improving neighborhood investment', linkage: 42, linkageLabel: 'Weak', truth: 58, impact: '+3.2', side: 'pro' },
+    ],
+    conArgs: [
+      { id: 'c1', title: 'Diamond et al (2019): SF rent control reduced rental supply 15%', linkage: 92, linkageLabel: 'Strong', truth: 94, impact: '−24.1', side: 'con' },
+      { id: 'c2', title: 'Landlords convert units to condos or let them decay under ceilings', linkage: 86, linkageLabel: 'Strong', truth: 88, impact: '−16.4', side: 'con' },
+      { id: 'c3', title: 'Price ceilings reduce developer ROI; new construction collapses',   linkage: 79, linkageLabel: 'Strong', truth: 84, impact: '−12.8', side: 'con' },
+    ],
+    evidence: [
+      { id: 'e1', title: 'Diamond, McQuade, Qian — Effects of Rent Control', source: 'American Economic Review 2019', quality: 96, tier: 'T1', finding: 'SF rent control protected tenants but reduced supply 15%; equilibrium rents rose 5–7%.', side: 'con' },
+      { id: 'e2', title: 'Sims — Out of Control: What Can We Learn from the End of Massachusetts Rent Control', source: 'Journal of Urban Economics 2007', quality: 82, tier: 'T1', finding: 'Rent control removal increased housing supply and quality.', side: 'con' },
+    ],
+  },
+];
+
+export function getBelief(slug: string): Belief | undefined {
+  return beliefs.find(b => b.slug === slug);
+}
+
+// ─── Arbitrage ─────────────────────────────────────────────────────────────────
+
+export const arbitrageRows: ArbitrageRow[] = beliefs.map(b => ({
+  id: b.slug,
+  title: b.statement.length > 55 ? b.statement.slice(0, 55) + '…' : b.statement,
+  category: getCategoryForBelief(b.slug),
+  reasonRank: b.reasonRank,
+  marketPrice: b.marketPrice,
+  volume: b.volume,
+  signal: b.reasonRank > b.marketPrice ? 'UNDER' : 'OVER',
+}));
+
+function getCategoryForBelief(slug: string): string {
+  const map: Record<string, string> = {
+    'carbon-tax-reduces-emissions':           'Climate',
+    'fifteen-dollar-minimum-wage':            'Labor',
+    'new-nuclear-cheaper-than-gas':           'Energy',
+    'ranked-choice-voting-reduces-polarization': 'Politics',
+    'rent-control-increases-supply':          'Housing',
+  };
+  return map[slug] ?? 'Policy';
+}
+
+// ─── CBA ───────────────────────────────────────────────────────────────────────
+
+export const carbonTaxCBA: CBAItem[] = [
+  { id: 'b1', label: 'Emissions reduction (social cost of carbon)', impact: '+$8.2B / yr',  impactValue:  8.2, likelihood: 72, evidence: 78, side: 'benefit' },
+  { id: 'b2', label: 'Public health improvement (PM2.5 ↓ 6%)',      impact: '+$1.4B / yr',  impactValue:  1.4, likelihood: 64, evidence: 71, side: 'benefit' },
+  { id: 'b3', label: 'Revenue rebated to households',               impact: '+$12B / yr',   impactValue: 12.0, likelihood: 92, evidence: 88, side: 'benefit' },
+  { id: 'c1', label: 'Higher fuel costs at the pump',               impact: '−$10.2B / yr', impactValue: -10.2, likelihood: 95, evidence: 92, side: 'cost' },
+  { id: 'c2', label: 'Industry compliance & administration',        impact: '−$0.8B / yr',  impactValue:  -0.8, likelihood: 78, evidence: 64, side: 'cost' },
+  { id: 'c3', label: 'Carbon leakage through imports',              impact: '−$1.6B / yr',  impactValue:  -1.6, likelihood: 41, evidence: 68, side: 'cost' },
+];
+
+// ─── Users (in-memory store) ────────────────────────────────────────────────────
+// Pre-computed bcrypt hash for "password" (rounds=10)
+const DEMO_PASSWORD_HASH = '$2a$10$EYtGItvh1ju9oBs7ADzdA.Ijv8UqOWdgMVOCKNnl7ex3DZocvTH1a';
+
+export const users: User[] = [
+  { id: 'u1', email: 'demo@ise.io', name: 'Demo User', credits: 1250, passwordHash: DEMO_PASSWORD_HASH },
+];
+
+export function getUserByEmail(email: string): User | undefined {
+  return users.find(u => u.email === email);
+}
+
+// ─── Trades (in-memory store) ───────────────────────────────────────────────────
+
+export const trades: Trade[] = [];
+
+export function addTrade(trade: Omit<Trade, 'id' | 'createdAt'>): Trade {
+  const newTrade: Trade = {
+    ...trade,
+    id: `t${trades.length + 1}`,
+    createdAt: new Date().toISOString(),
+  };
+  trades.push(newTrade);
+
+  // Adjust the belief market price slightly
+  const belief = beliefs.find(b => b.slug === trade.beliefSlug);
+  if (belief) {
+    const priceDelta = (trade.side === 'YES' ? 1 : -1) * 0.001 * trade.amount;
+    belief.marketPrice = Math.max(1, Math.min(99, belief.marketPrice + priceDelta));
+    belief.volume += trade.amount;
+  }
+
+  return newTrade;
+}
+
+export function getTradesByUser(userId: string): Trade[] {
+  return trades.filter(t => t.userId === userId);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,84 @@
+export type EvidenceTier = 'T1' | 'T2' | 'T3' | 'T4';
+export type ValenceSide = 'pro' | 'con';
+export type ArbitrageSignal = 'UNDER' | 'OVER';
+export type ScoreTone = 'excellent' | 'good' | 'moderate' | 'weak';
+
+export interface Argument {
+  id: string;
+  title: string;
+  linkage: number;
+  linkageLabel: string;
+  truth: number;
+  impact: string;
+  side: ValenceSide;
+}
+
+export interface Evidence {
+  id: string;
+  title: string;
+  source: string;
+  quality: number;
+  tier: EvidenceTier;
+  finding: string;
+  side: ValenceSide;
+}
+
+export interface Spectrums {
+  positivity: number;   // -100 to +100
+  specificity: number;  // 0 to 1
+  claimStrength: number; // 0 to 1
+}
+
+export interface Belief {
+  slug: string;
+  statement: string;
+  reasonRank: number;
+  marketPrice: number;
+  volume: number;
+  contributors: number;
+  argCount: number;
+  lastEvaluated: string;
+  spectrums: Spectrums;
+  proArgs: Argument[];
+  conArgs: Argument[];
+  evidence: Evidence[];
+}
+
+export interface ArbitrageRow {
+  id: string;
+  title: string;
+  category: string;
+  reasonRank: number;
+  marketPrice: number;
+  volume: number;
+  signal: ArbitrageSignal;
+}
+
+export interface CBAItem {
+  id: string;
+  label: string;
+  impact: string;        // e.g. "+$8.2B / yr"
+  impactValue: number;   // numeric (positive = benefit, negative = cost)
+  likelihood: number;    // 0–100
+  evidence: number;      // quality score 0–100
+  side: 'benefit' | 'cost';
+}
+
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  credits: number;
+  passwordHash: string;
+}
+
+export interface Trade {
+  id: string;
+  userId: string;
+  beliefSlug: string;
+  side: 'YES' | 'NO';
+  amount: number;        // credits invested
+  price: number;         // price at time of trade
+  shares: number;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

- Full Next.js 14 App Router implementation with `app/` directory structure
- Two route groups: `(document)` (white/light) for belief pages, `arbitrage` (dark) for trader surfaces
- Three-spectrum belief pages (Valence, Specificity, Intensity) with `SpectrumsHeader` component
- 5-column argument trees matching source `ArgumentTreesSection` (Truth Score, Linkage Score, Contribution, Impact)
- Beliefs index with valence/specificity/intensity/sort filter UI
- Arbitrage dashboard with 7-column grid including Potential Return column
- `lib/claim-strength.ts` scoring module ported from source (`STRENGTH_BANDS`, `applyStrengthPenalty`, `getStrengthBand`)
- CSS variables and Tailwind tokens aligned with source repo (`--profit`, `--loss`, `--accent`, `--foreground`)
- NextAuth credentials provider with in-memory mock data and trade API
- Full Tailwind conversion with CSS vars and hover transitions throughout

## Test plan

- [ ] `npm install && npm run dev` — dev server starts on port 3000
- [ ] `/` homepage renders hero, three pillars, feature grid, CTA
- [ ] `/beliefs` renders filter dropdowns and belief cards
- [ ] `/beliefs/carbon-tax-reduces-emissions` renders Three Spectrums, Score Dashboard, Argument Trees, Evidence Ledger
- [ ] `/arbitrage` renders dark 7-column grid with Potential Return column
- [ ] `npm run build` completes without errors