### PR TITLE
Add AI provider configuration and improve belief page links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,15 @@ RECENCY_WEIGHT=0.10
 # ─── API Configuration ──────────────────────────────────────────
 MAX_RESULTS_PER_PAGE=20
 API_PREFIX="/api/v1"
+
+# ─── AI Provider (for debate topic generation) ──────────────────
+# Provider: "anthropic" | "openai" | "ollama"
+AI_PROVIDER="anthropic"
+AI_API_KEY="your-api-key-here"
+# Model to use (e.g. "claude-sonnet-4-6", "gpt-4o", "llama3")
+AI_MODEL="claude-sonnet-4-6"
+# Base URL override (leave blank for default; required for Ollama: http://localhost:11434)
+AI_API_BASE=""
+AI_TEMPERATURE=0.7
+AI_MAX_TOKENS=4000
+AI_TIMEOUT=60

--- a/src/app/beliefs/[slug]/page.tsx
+++ b/src/app/beliefs/[slug]/page.tsx
@@ -67,20 +67,13 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
         </h1>
         <p className="text-sm mb-4 leading-7">
           <strong>Score:</strong>{' '}
-          <Link
-            href="/Argument%20scores%20from%20sub-argument%20scores"
-            className="text-[var(--accent)] hover:underline"
-          >
-            +{proPart} pro / -{conPart} con
-          </Link>{' '}
+          <span>+{proPart} pro / -{conPart} con</span>{' '}
           <span className="text-xs text-[var(--muted-foreground)]">
             (computed from sub-argument scores)
           </span>
           <br />
           <strong>Topic:</strong>{' '}
-          <Link href="/One%20Page%20Per%20Topic" className="text-[var(--accent)] hover:underline">
-            {belief.category || 'Uncategorized'}
-          </Link>
+          <span>{belief.category || 'Uncategorized'}</span>
           {belief.subcategory && <> &gt; {belief.subcategory}</>}
         </p>
 

--- a/src/features/debate-topics/ai-generator.ts
+++ b/src/features/debate-topics/ai-generator.ts
@@ -64,7 +64,7 @@ Return a single valid JSON object matching this exact structure (all fields requ
   "categoryPath": ${JSON.stringify(catPath.length ? catPath : ['Society & Culture'])},
   "external": {
     "wikipediaUrl": "https://en.wikipedia.org/wiki/...",
-    "deweyDecimal": "XXX.XX (Category)",
+    "deweyDecimal": "Use the accurate Dewey Decimal number and category for ${topicName}.",
     "locSubjectHeading": "Subject Heading (Call Number range)",
     "locUrl": "https://id.loc.gov/authorities/subjects/...",
     "stanfordUrl": "https://plato.stanford.edu/entries/.../"


### PR DESCRIPTION
## Summary
This PR adds AI provider configuration for debate topic generation and removes broken wiki-style links from the belief analysis page.

## Key Changes

- **AI Provider Configuration** (`.env.example`): Added environment variables to support multiple AI providers (Anthropic, OpenAI, Ollama) for debate topic generation, including API key, model selection, base URL override, temperature, max tokens, and timeout settings.

- **Belief Page Link Cleanup** (`src/app/beliefs/[slug]/page.tsx`): Removed two broken internal wiki-style links:
  - Removed link to non-existent "/Argument%20scores%20from%20sub-argument%20scores" page from the Score display
  - Removed link to non-existent "/One%20Page%20Per%20Topic" page from the Topic/Category display
  - Converted both to plain `<span>` elements per BELIEF_PAGE_RULES.md Rule 5 (no broken links)

- **AI Generator Improvement** (`src/features/debate-topics/ai-generator.ts`): Enhanced the Dewey Decimal prompt instruction to request accurate classification for the specific topic being generated, replacing the generic placeholder format.

## Implementation Details

The AI configuration follows a provider-agnostic pattern, allowing users to choose between Anthropic, OpenAI, or local Ollama deployments. The Ollama base URL defaults to `http://localhost:11434` when configured.

The belief page changes align with the canonical rules documented in `docs/BELIEF_PAGE_RULES.md`, specifically Rule 5 which prohibits broken links on the belief page.

https://claude.ai/code/session_0113QLDBdA2hPRTj5sUbbHZ2