### PR TITLE
Source argument Importance from a sub-belief and auto-propagate Truth/Importance/Linkage

### DIFF
--- a/prisma/migrations/20260530034251_add_argument_importance_belief/migration.sql
+++ b/prisma/migrations/20260530034251_add_argument_importance_belief/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: source an argument's Importance Score from a dedicated sub-belief.
+ALTER TABLE "Argument" ADD COLUMN "importanceBeliefId" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "Argument_importanceBeliefId_idx" ON "Argument"("importanceBeliefId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -210,6 +210,9 @@ model Belief {
   // Arguments where this belief IS the reason (child)
   asArgument Argument[] @relation("ArgumentBelief")
 
+  // Arguments whose Importance Score is sourced from this belief's net score
+  asImportanceArgument Argument[] @relation("ArgumentImportanceBelief")
+
   // Arguments attached TO this belief (parent)
   arguments Argument[] @relation("ParentBelief")
 
@@ -267,6 +270,13 @@ model Argument {
   beliefId Int
   belief   Belief @relation("ArgumentBelief", fields: [beliefId], references: [id])
 
+  /// Optional third edge: a dedicated "importance" sub-belief whose net score
+  /// SOURCES this argument's importanceScore (e.g. "The spoiler effect is a
+  /// major, solvable problem"). When set, importanceScore is derived from that
+  /// belief and auto-propagates; when null, importanceScore is the manual value.
+  importanceBeliefId Int?
+  importanceBelief   Belief? @relation("ArgumentImportanceBelief", fields: [importanceBeliefId], references: [id])
+
   side         String // "agree" or "disagree"
   linkageScore Float  @default(0.1)
   impactScore  Float  @default(0)
@@ -274,6 +284,7 @@ model Argument {
   /// Importance Score (0-1): how much this argument moves the probability needle.
   /// 1.0 = decisive, 0.5 = moderate, 0.1 = minor. Weights the argument's contribution
   /// to the parent belief's ReasonRank. Analogous to PageRank's link weight.
+  /// Derived from importanceBelief's net score when importanceBeliefId is set.
   importanceScore Float @default(1.0)
 
   linkageType      LinkageClassification @default(ANECDOTAL)
@@ -288,6 +299,8 @@ model Argument {
 
   linkageArguments LinkageArgument[]
   linkageVotes     LinkageVote[]
+
+  @@index([importanceBeliefId])
 }
 
 model LinkageArgument {

--- a/src/app/api/arguments/[id]/linkage/route.ts
+++ b/src/app/api/arguments/[id]/linkage/route.ts
@@ -25,7 +25,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { calculateLinkageFromArguments, applyDepthAttenuation } from '@/core/scoring/scoring-engine'
-import { propagateFromArgumentChange } from '@/lib/propagate-belief-scores'
+import { propagateFromLinkageChange } from '@/lib/propagate-belief-scores'
 
 // ─── GET ───────────────────────────────────────────────────────────────────
 
@@ -137,22 +137,16 @@ export async function POST(
     },
   })
 
-  // Recompute linkage score and persist it back to the Argument
-  const allLinkageArgs = await prisma.linkageArgument.findMany({
-    where: { argumentId },
-  })
-  const newScore = calculateLinkageFromArguments(
-    allLinkageArgs.map(la => ({ side: la.side, strength: la.strength }))
-  )
-  await prisma.argument.update({
+  // Recompute the linkage score from the full sub-debate and propagate it
+  // upward through the belief graph. This implements "when you strengthen an
+  // underlying fact, the algorithm automatically updates every conclusion
+  // connected to it." propagateFromLinkageChange persists the new linkage too.
+  const propagation = await propagateFromLinkageChange(argumentId)
+  const refreshed = await prisma.argument.findUnique({
     where: { id: argumentId },
-    data: { linkageScore: newScore },
+    select: { linkageScore: true },
   })
-
-  // Propagate the updated linkage score upward through the belief graph.
-  // This implements "when you strengthen an underlying fact, the algorithm
-  // automatically updates every conclusion connected to it."
-  const propagation = await propagateFromArgumentChange(argumentId)
+  const newScore = refreshed?.linkageScore ?? arg.linkageScore
 
   return NextResponse.json(
     {
@@ -183,28 +177,23 @@ export async function PATCH(
 
   const arg = await prisma.argument.findUnique({
     where: { id: argumentId },
-    include: { linkageArguments: true },
+    select: { id: true },
   })
   if (!arg) {
     return NextResponse.json({ error: 'Argument not found' }, { status: 404 })
   }
 
-  const newScore = calculateLinkageFromArguments(
-    arg.linkageArguments.map(la => ({ side: la.side, strength: la.strength }))
-  )
-
-  const updated = await prisma.argument.update({
+  // Recompute the linkage score from the sub-debate and propagate upward.
+  const propagation = await propagateFromLinkageChange(argumentId)
+  const updated = await prisma.argument.findUnique({
     where: { id: argumentId },
-    data: { linkageScore: newScore },
     select: { id: true, linkageScore: true, linkageType: true, depth: true },
   })
-
-  // Propagate the recomputed linkage score upward through the belief graph.
-  const propagation = await propagateFromArgumentChange(argumentId)
+  const newScore = updated?.linkageScore ?? 0
 
   return NextResponse.json({
     updated,
-    attenuatedScore: applyDepthAttenuation(newScore, updated.depth),
+    attenuatedScore: applyDepthAttenuation(newScore, updated?.depth ?? 0),
     propagation: {
       updatedArgumentIds: propagation.updatedArgumentIds,
       updatedBeliefIds: propagation.updatedBeliefIds,

--- a/src/core/scoring/all-scores.ts
+++ b/src/core/scoring/all-scores.ts
@@ -37,6 +37,7 @@ export {
   scoreArgument,              // Truth + Linkage + Importance composite
   getEvidenceTypeWeight,      // Evidence tier weights
 } from './scoring-engine'
+import { mechanicalSimilarity } from './duplication-scoring'
 
 // ─── Score interfaces ─────────────────────────────────────────────────────
 
@@ -630,10 +631,6 @@ export function aggregateMediaScores(
 export function calculateTopicOverlapScore(
   items: Array<{ id: string; text: string }>,
 ): TopicOverlapResult {
-  const { mechanicalSimilarity } = require('./duplication-scoring') as {
-    mechanicalSimilarity: (a: string, b: string) => number
-  }
-
   const MECHANICAL_THRESHOLD = 0.85
 
   const contributionFactors: Record<string, number> = {}
@@ -690,13 +687,9 @@ export function calculateBeliefEquivalencyScore(
   statementB: string,
   semanticSimilarity: number | null = null,
 ): BeliefEquivalencyResult {
-  const { mechanicalSimilarity: mSim } = require('./duplication-scoring') as {
-    mechanicalSimilarity: (a: string, b: string) => number
-  }
-
   const MECHANICAL_THRESHOLD = 0.85
 
-  const mechanicalSim = mSim(statementA, statementB)
+  const mechanicalSim = mechanicalSimilarity(statementA, statementB)
   const isMechanicalEquivalent = mechanicalSim >= MECHANICAL_THRESHOLD
 
   let equivalencyScore: number

--- a/src/core/scoring/scoring-engine.ts
+++ b/src/core/scoring/scoring-engine.ts
@@ -758,6 +758,30 @@ export function computeArgumentImpactScore(
 }
 
 /**
+ * Derive an argument's Importance Score (0–1) from the net score of a
+ * dedicated "importance" sub-belief (e.g. "The spoiler effect is a major,
+ * solvable problem").
+ *
+ * A belief's net score (`computeBeliefScores().overallScore`) lives on the
+ * [-100, +100] valence axis. Importance, by contrast, is a [0, 1] weight on
+ * how much an argument moves the parent's probability needle. We map the
+ * belief's net score linearly onto that range:
+ *
+ *   importance = (overallScore + 100) / 200   clamped to [0, 1]
+ *
+ * - A fully-supported importance belief (+100) → importance 1.0 (decisive).
+ * - A neutral / unargued importance belief (0) → importance 0.5 (moderate).
+ * - A refuted importance belief (-100)         → importance 0.0 (negligible).
+ *
+ * This keeps Importance on the same "how true is the claim that this matters"
+ * footing as Truth, so an argument's weight tracks the live debate about its
+ * own significance instead of a hand-entered constant.
+ */
+export function deriveImportanceFromBeliefScore(overallScore: number): number {
+  return Math.max(0, Math.min(1, (overallScore + 100) / 200))
+}
+
+/**
  * Get score breakdown for a likelihood estimate.
  */
 export function scoreLikelihoodEstimate(estimate: LikelihoodEstimate): {

--- a/src/features/belief-analysis/components/ArgumentTreesSection.tsx
+++ b/src/features/belief-analysis/components/ArgumentTreesSection.tsx
@@ -81,6 +81,30 @@ function ContributionBadge({ arg }: { arg: ArgumentWithBelief }) {
   )
 }
 
+/**
+ * Importance Score cell. When the argument sources its importance from a
+ * dedicated sub-belief, the score links to that belief's page (where the
+ * "does this matter?" debate lives). Otherwise it renders as plain text —
+ * never a broken link (Rule 5).
+ */
+function ImportanceCell({ arg }: { arg: ArgumentWithBelief }) {
+  const pct = `${(arg.importanceScore * 100).toFixed(0)}%`
+
+  if (arg.importanceBelief) {
+    return (
+      <Link
+        href={`/beliefs/${arg.importanceBelief.slug}`}
+        title="Importance is sourced from this belief — click to debate whether it matters"
+        className="text-[var(--accent)] hover:underline text-sm font-mono"
+      >
+        {pct}
+      </Link>
+    )
+  }
+
+  return <span className="text-sm font-mono text-[var(--muted-foreground)]">{pct}</span>
+}
+
 function ArgumentRow({ arg }: { arg: ArgumentWithBelief }) {
   const argScore = (arg.belief.positivity).toFixed(1)
   const impact = arg.impactScore.toFixed(1)
@@ -98,11 +122,14 @@ function ArgumentRow({ arg }: { arg: ArgumentWithBelief }) {
       <td className="px-3 py-3 text-center text-sm font-mono">
         <Link
           href={`/beliefs/${arg.belief.slug}`}
-          title="Click to see full score breakdown"
+          title="Truth — click to see the child belief's full score breakdown"
           className="text-[var(--accent)] hover:underline"
         >
           {Number(argScore) >= 0 ? '+' : ''}{argScore}
         </Link>
+      </td>
+      <td className="px-3 py-3 text-center">
+        <ImportanceCell arg={arg} />
       </td>
       <td className="px-3 py-3 text-center">
         <LinkageBadge arg={arg} />
@@ -145,15 +172,16 @@ export default function ArgumentTreesSection({ arguments: args, totalPro, totalC
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-green-50">
-              <th className="px-3 py-2 text-left w-[52%] font-semibold">
+              <th className="px-3 py-2 text-left w-[44%] font-semibold">
                 Top <Link href="/Scoring" className="text-[var(--accent)] hover:underline">Scoring</Link> Reasons to Agree
               </th>
-              <th className="px-3 py-2 text-center w-[12%] font-semibold">Argument Score</th>
-              <th className="px-3 py-2 text-center w-[12%] font-semibold">
+              <th className="px-3 py-2 text-center w-[11%] font-semibold" title="Truth — the child belief's net score">Truth</th>
+              <th className="px-3 py-2 text-center w-[11%] font-semibold" title="Importance — how much this argument moves the needle">Importance</th>
+              <th className="px-3 py-2 text-center w-[11%] font-semibold">
                 <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Linkage Score</Link>
               </th>
               <th
-                className="px-3 py-2 text-center w-[12%] font-semibold"
+                className="px-3 py-2 text-center w-[11%] font-semibold"
                 title="Linkage Score × Truth Score"
               >
                 Contribution
@@ -168,7 +196,7 @@ export default function ArgumentTreesSection({ arguments: args, totalPro, totalC
               <EmptyRow />
             )}
             <tr className="bg-gray-100 font-semibold">
-              <td colSpan={4} className="px-3 py-2 text-right text-sm">Total Pro:</td>
+              <td colSpan={5} className="px-3 py-2 text-right text-sm">Total Pro:</td>
               <td className="px-3 py-2 text-center text-sm font-mono text-green-700">
                 +{totalPro.toFixed(1)}
               </td>
@@ -182,15 +210,16 @@ export default function ArgumentTreesSection({ arguments: args, totalPro, totalC
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-red-50">
-              <th className="px-3 py-2 text-left w-[52%] font-semibold">
+              <th className="px-3 py-2 text-left w-[44%] font-semibold">
                 Top <Link href="/Scoring" className="text-[var(--accent)] hover:underline">Scoring</Link> Reasons to Disagree
               </th>
-              <th className="px-3 py-2 text-center w-[12%] font-semibold">Argument Score</th>
-              <th className="px-3 py-2 text-center w-[12%] font-semibold">
+              <th className="px-3 py-2 text-center w-[11%] font-semibold" title="Truth — the child belief's net score">Truth</th>
+              <th className="px-3 py-2 text-center w-[11%] font-semibold" title="Importance — how much this argument moves the needle">Importance</th>
+              <th className="px-3 py-2 text-center w-[11%] font-semibold">
                 <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Linkage Score</Link>
               </th>
               <th
-                className="px-3 py-2 text-center w-[12%] font-semibold"
+                className="px-3 py-2 text-center w-[11%] font-semibold"
                 title="Linkage Score × Truth Score"
               >
                 Contribution
@@ -205,7 +234,7 @@ export default function ArgumentTreesSection({ arguments: args, totalPro, totalC
               <EmptyRow />
             )}
             <tr className="bg-gray-100 font-semibold">
-              <td colSpan={4} className="px-3 py-2 text-right text-sm">Total Con:</td>
+              <td colSpan={5} className="px-3 py-2 text-right text-sm">Total Con:</td>
               <td className="px-3 py-2 text-center text-sm font-mono text-red-700">
                 -{totalCon.toFixed(1)}
               </td>

--- a/src/features/belief-analysis/data/fetch-belief.ts
+++ b/src/features/belief-analysis/data/fetch-belief.ts
@@ -20,6 +20,9 @@ const BELIEF_INCLUDE = {
       belief: {
         select: { id: true, slug: true, statement: true, positivity: true },
       },
+      importanceBelief: {
+        select: { id: true, slug: true, statement: true, positivity: true },
+      },
     },
     orderBy: { impactScore: 'desc' as const },
   },

--- a/src/features/belief-analysis/types.ts
+++ b/src/features/belief-analysis/types.ts
@@ -82,6 +82,14 @@ export interface ArgumentWithBelief {
     statement: string
     positivity: number
   }
+  /** The belief sourcing this argument's Importance Score, if any. */
+  importanceBeliefId: number | null
+  importanceBelief: {
+    id: number
+    slug: string
+    statement: string
+    positivity: number
+  } | null
 }
 
 export interface EvidenceItem {

--- a/src/lib/propagate-belief-scores.ts
+++ b/src/lib/propagate-belief-scores.ts
@@ -26,7 +26,11 @@
 
 import { prisma } from '@/lib/prisma'
 import { fetchBeliefById, computeBeliefScores } from '@/features/belief-analysis/data/fetch-belief'
-import { computeArgumentImpactScore } from '@/core/scoring/scoring-engine'
+import {
+  computeArgumentImpactScore,
+  deriveImportanceFromBeliefScore,
+  calculateLinkageFromArguments,
+} from '@/core/scoring/scoring-engine'
 
 // Re-export so callers can import from one place
 export { computeArgumentImpactScore }
@@ -40,6 +44,64 @@ export interface PropagationResult {
   updatedBeliefIds: number[]
   /** Number of recursive levels traversed */
   depth: number
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────
+
+/** Columns needed to recompute an argument edge's impact. */
+const ARGUMENT_EDGE_SELECT = {
+  id: true,
+  parentBeliefId: true,
+  beliefId: true,
+  importanceBeliefId: true,
+  side: true,
+  linkageScore: true,
+  importanceScore: true,
+} as const
+
+interface ArgumentEdge {
+  id: number
+  parentBeliefId: number
+  beliefId: number
+  importanceBeliefId: number | null
+  side: string
+  linkageScore: number
+  importanceScore: number
+}
+
+/**
+ * Resolve a belief's truth score (0–1), memoized per propagation pass so a
+ * belief feeding many arguments is only scored once.
+ */
+async function truthScoreFor(beliefId: number, cache: Map<number, number>): Promise<number> {
+  const cached = cache.get(beliefId)
+  if (cached !== undefined) return cached
+
+  const belief = await fetchBeliefById(beliefId)
+  const score = belief ? computeBeliefScores(belief).importanceWeightedScore : 0
+  cache.set(beliefId, score)
+  return score
+}
+
+/**
+ * Resolve an argument's effective Importance Score (0–1).
+ *
+ * When `importanceBeliefId` is set, importance is DERIVED from that belief's
+ * net score (normalized to 0–1) so it tracks the live sub-debate about whether
+ * the argument matters. When null, the manually-entered `importanceScore` is
+ * used unchanged — keeping every pre-existing argument backward compatible.
+ */
+async function resolveEffectiveImportance(arg: {
+  importanceBeliefId: number | null
+  importanceScore: number
+}): Promise<number> {
+  if (arg.importanceBeliefId == null) return arg.importanceScore
+
+  const importanceBelief = await fetchBeliefById(arg.importanceBeliefId)
+  if (!importanceBelief) return arg.importanceScore
+
+  const { overallScore } = computeBeliefScores(importanceBelief)
+  return deriveImportanceFromBeliefScore(overallScore)
 }
 
 /**
@@ -87,39 +149,58 @@ export async function propagateBeliefScores(
     data: { positivity: childScores.overallScore },
   })
 
-  // ── Step 2: Find all arguments where this belief is the child ───
-  // An argument links: parentBelief (the conclusion) ← belief (the reason).
-  // When the reason's truth changes, the argument's impact changes too.
-  const argumentsAsChild = await prisma.argument.findMany({
+  // ── Step 2: Find every argument edge that draws on this belief ──
+  // A belief can feed a parent argument through THREE distinct edges:
+  //   • Truth edge      (Argument.beliefId)           — the reason itself.
+  //   • Importance edge (Argument.importanceBeliefId) — how much it matters.
+  //   • Linkage edge    (linkage sub-debate)          — handled separately,
+  //     via propagateFromLinkageChange, since it lives below the argument.
+  // When this belief changes we must refresh every argument on the truth OR
+  // importance edge, because both feed impactScore = Truth × Importance × Linkage.
+  const truthEdges = await prisma.argument.findMany({
     where: { beliefId },
-    select: {
-      id: true,
-      parentBeliefId: true,
-      side: true,
-      linkageScore: true,
-      importanceScore: true,
-    },
+    select: ARGUMENT_EDGE_SELECT,
+  })
+  const importanceEdges = await prisma.argument.findMany({
+    where: { importanceBeliefId: beliefId },
+    select: ARGUMENT_EDGE_SELECT,
   })
 
-  if (argumentsAsChild.length === 0) {
+  // Merge by id so an argument that uses this belief as BOTH its truth and
+  // importance source is only recomputed once.
+  const affectedArguments = new Map<number, ArgumentEdge>()
+  for (const arg of [...truthEdges, ...importanceEdges]) {
+    affectedArguments.set(arg.id, arg)
+  }
+
+  if (affectedArguments.size === 0) {
     // This belief is not a child of any other belief — propagation stops here.
     return result
   }
 
-  // ── Step 3: Recompute impactScore for each argument edge ────────
+  // ── Step 3: Recompute impactScore for each affected argument ────
+  // Each argument is recomputed from its OWN three inputs, not from the
+  // triggering belief alone: an importance-edge argument keeps its separate
+  // truth child, and vice versa. truthScoreFor memoizes per-belief lookups.
+  const truthScoreCache = new Map<number, number>([[beliefId, childTruthScore]])
   const parentBeliefIds = new Set<number>()
 
-  for (const arg of argumentsAsChild) {
+  for (const arg of affectedArguments.values()) {
+    const truth = await truthScoreFor(arg.beliefId, truthScoreCache)
+    const importance = await resolveEffectiveImportance(arg)
+
     const newImpactScore = computeArgumentImpactScore(
       arg.side,
-      childTruthScore,
+      truth,
       arg.linkageScore,
-      arg.importanceScore,
+      importance,
     )
 
     await prisma.argument.update({
       where: { id: arg.id },
-      data: { impactScore: newImpactScore },
+      // Persist the derived importance too, so rendered tables and later
+      // truth-edge recomputes read a value consistent with the live debate.
+      data: { impactScore: newImpactScore, importanceScore: importance },
     })
 
     result.updatedArgumentIds.push(arg.id)
@@ -176,5 +257,39 @@ export async function propagateFromArgumentChange(argumentId: number): Promise<P
   }
 
   // Propagate from the child belief upward through this argument to all ancestors.
+  return propagateBeliefScores(arg.beliefId)
+}
+
+/**
+ * Trigger propagation from a change in an argument's LINKAGE sub-debate.
+ *
+ * Mirrors {@link propagateFromArgumentChange}, but for the third score channel:
+ * it first recomputes the argument's `linkageScore` from its current
+ * LinkageArguments (the (A−D)/(A+D)-style sub-debate), persists it, then
+ * propagates from the argument's child belief upward — which recomputes this
+ * argument's impactScore with the fresh linkage and ripples to every ancestor.
+ *
+ * Call this whenever a LinkageArgument is added, edited, or removed.
+ *
+ * @param argumentId - The argument whose linkage sub-debate just changed.
+ */
+export async function propagateFromLinkageChange(argumentId: number): Promise<PropagationResult> {
+  const arg = await prisma.argument.findUnique({
+    where: { id: argumentId },
+    select: { beliefId: true, linkageArguments: { select: { side: true, strength: true } } },
+  })
+
+  if (!arg) {
+    return { updatedArgumentIds: [], updatedBeliefIds: [], depth: 0 }
+  }
+
+  // Recompute linkage from the sub-debate and persist it before propagating,
+  // so the upward recomputation of impactScore reads the up-to-date linkage.
+  const newLinkageScore = calculateLinkageFromArguments(arg.linkageArguments)
+  await prisma.argument.update({
+    where: { id: argumentId },
+    data: { linkageScore: newLinkageScore },
+  })
+
   return propagateBeliefScores(arg.beliefId)
 }

--- a/tests/integration/propagate-three-way.test.ts
+++ b/tests/integration/propagate-three-way.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Integration tests for three-way (Truth / Importance / Linkage) score
+ * propagation through a live SQLite database.
+ *
+ * Builds an isolated temp database from the committed migration chain, points
+ * the Prisma singleton at it (via DATABASE_URL set before any import that pulls
+ * `@/lib/prisma`), seeds a small belief graph, and asserts that editing each of
+ * the three child-score sources ripples up to the parent argument's impact and
+ * the parent belief's net score.
+ *
+ * Covers acceptance criteria 1–3 and the cycle-safety requirement of Task 6.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import Database from 'better-sqlite3'
+import fs from 'fs'
+import path from 'path'
+
+const DB_PATH = path.resolve(__dirname, 'tmp-propagation.test.db')
+
+// Module-level handles populated in beforeAll after DATABASE_URL is set, so the
+// Prisma singleton binds to the temp database rather than the default dev.db.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let prisma: any
+let propagateBeliefScores: any
+let propagateFromLinkageChange: any
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// Seeded ids, filled during setup.
+let gpId: number          // parent conclusion
+let truthChildId: number  // the reason (Truth edge)
+let impChildId: number    // the importance sub-belief (Importance edge)
+let mainArgId: number     // gp ← truthChild, importance from impChild
+
+function applyMigrations(file: string) {
+  const db = new Database(file)
+  const root = path.resolve(__dirname, '../../prisma/migrations')
+  const dirs = fs
+    .readdirSync(root)
+    .filter(d => fs.existsSync(path.join(root, d, 'migration.sql')))
+    .sort()
+  for (const d of dirs) {
+    db.exec(fs.readFileSync(path.join(root, d, 'migration.sql'), 'utf8'))
+  }
+  db.close()
+}
+
+beforeAll(async () => {
+  if (fs.existsSync(DB_PATH)) fs.unlinkSync(DB_PATH)
+  applyMigrations(DB_PATH)
+
+  process.env.DATABASE_URL = `file:${DB_PATH}`
+
+  // Dynamic imports AFTER DATABASE_URL is set so the singleton binds correctly.
+  ;({ prisma } = await import('@/lib/prisma'))
+  ;({ propagateBeliefScores, propagateFromLinkageChange } = await import(
+    '@/lib/propagate-belief-scores'
+  ))
+
+  const belief = (statement: string, slug: string) =>
+    prisma.belief.create({ data: { slug, statement } })
+
+  const gp = await belief('Adopt ranked-choice voting', 'rcv-gp')
+  const truthChild = await belief('RCV eliminates the spoiler effect', 'rcv-truth')
+  const impChild = await belief('The spoiler effect is a major, solvable problem', 'rcv-importance')
+  const grand = await belief('Supporting sub-point', 'rcv-grand')
+  gpId = gp.id
+  truthChildId = truthChild.id
+  impChildId = impChild.id
+
+  // Give truthChild a net truth of 1.0 (single agree argument, full impact).
+  await prisma.argument.create({
+    data: {
+      parentBeliefId: truthChild.id,
+      beliefId: grand.id,
+      side: 'agree',
+      linkageScore: 1.0,
+      importanceScore: 1.0,
+      impactScore: 60,
+    },
+  })
+
+  // Give impChild a net score of +50 → derived importance 0.75.
+  // pro 30, con 10 → overall = (30 - 10) / 40 * 100 = 50.
+  await prisma.argument.create({
+    data: {
+      parentBeliefId: impChild.id,
+      beliefId: grand.id,
+      side: 'agree',
+      linkageScore: 1.0,
+      importanceScore: 1.0,
+      impactScore: 30,
+    },
+  })
+  await prisma.argument.create({
+    data: {
+      parentBeliefId: impChild.id,
+      beliefId: grand.id,
+      side: 'disagree',
+      linkageScore: 1.0,
+      importanceScore: 1.0,
+      impactScore: -10,
+    },
+  })
+
+  // The main argument under test: gp ← truthChild, importance sourced from impChild.
+  const mainArg = await prisma.argument.create({
+    data: {
+      parentBeliefId: gp.id,
+      beliefId: truthChild.id,
+      importanceBeliefId: impChild.id,
+      side: 'agree',
+      linkageScore: 0.8,
+      importanceScore: 1.0, // stale manual value; derivation should overwrite it
+      impactScore: 0,
+    },
+  })
+  mainArgId = mainArg.id
+}, 60_000)
+
+afterAll(async () => {
+  if (prisma) await prisma.$disconnect()
+  if (fs.existsSync(DB_PATH)) fs.unlinkSync(DB_PATH)
+})
+
+describe('Importance edge: editing the importance sub-belief', () => {
+  it('derives importanceScore from the sub-belief and recomputes impact', async () => {
+    await propagateBeliefScores(impChildId)
+
+    const arg = await prisma.argument.findUnique({ where: { id: mainArgId } })
+    // impChild net score +50 → importance 0.75 (overwrites the stale 1.0).
+    expect(arg.importanceScore).toBeCloseTo(0.75, 5)
+    // impact = +1.0(truth) × 0.8(linkage) × 0.75(importance) × 100 = 60.
+    expect(arg.impactScore).toBeCloseTo(60, 5)
+  })
+
+  it('updates the parent belief net score with no manual entry', async () => {
+    const gp = await prisma.belief.findUnique({ where: { id: gpId } })
+    // gp has a single agree argument (impact 60) → net score +100.
+    expect(gp.positivity).toBeCloseTo(100, 5)
+  })
+
+  it('reacts when the importance sub-belief is weakened', async () => {
+    // Flip the importance debate negative: net score becomes -50 → importance 0.25.
+    await prisma.argument.updateMany({
+      where: { parentBeliefId: impChildId, side: 'agree' },
+      data: { impactScore: 10 },
+    })
+    await prisma.argument.updateMany({
+      where: { parentBeliefId: impChildId, side: 'disagree' },
+      data: { impactScore: -30 },
+    })
+
+    await propagateBeliefScores(impChildId)
+
+    const arg = await prisma.argument.findUnique({ where: { id: mainArgId } })
+    expect(arg.importanceScore).toBeCloseTo(0.25, 5)
+    // impact = 1.0 × 0.8 × 0.25 × 100 = 20.
+    expect(arg.impactScore).toBeCloseTo(20, 5)
+  })
+})
+
+describe('Truth edge: editing the reason belief', () => {
+  it('re-derives importance and recomputes impact from the truth child', async () => {
+    // Restore importance belief to +50 (importance 0.75) for a clean assertion.
+    await prisma.argument.updateMany({
+      where: { parentBeliefId: impChildId, side: 'agree' },
+      data: { impactScore: 30 },
+    })
+    await prisma.argument.updateMany({
+      where: { parentBeliefId: impChildId, side: 'disagree' },
+      data: { impactScore: -10 },
+    })
+    // Re-derive importance via the importance edge first.
+    await propagateBeliefScores(impChildId)
+
+    // Now propagate from the Truth child. truthChild truth stays 1.0.
+    await propagateBeliefScores(truthChildId)
+
+    const arg = await prisma.argument.findUnique({ where: { id: mainArgId } })
+    expect(arg.importanceScore).toBeCloseTo(0.75, 5)
+    expect(arg.impactScore).toBeCloseTo(60, 5)
+  })
+})
+
+describe('Linkage edge: editing the linkage sub-debate', () => {
+  it('recomputes linkage from the sub-debate and ripples to impact', async () => {
+    // Two "agree" linkage arguments, no opposition → linkage A/(A+D) = 1.0.
+    await prisma.linkageArgument.create({
+      data: { argumentId: mainArgId, side: 'agree', statement: 'Direct causal mechanism', strength: 1.0 },
+    })
+    await prisma.linkageArgument.create({
+      data: { argumentId: mainArgId, side: 'agree', statement: 'Corroborated by data', strength: 1.0 },
+    })
+
+    await propagateFromLinkageChange(mainArgId)
+
+    const arg = await prisma.argument.findUnique({ where: { id: mainArgId } })
+    expect(arg.linkageScore).toBeCloseTo(1.0, 5)
+    // impact = 1.0(truth) × 1.0(linkage) × 0.75(importance) × 100 = 75.
+    expect(arg.impactScore).toBeCloseTo(75, 5)
+  })
+})
+
+describe('Cycle safety', () => {
+  it('terminates when beliefs reference each other in a cycle', async () => {
+    const a = await prisma.belief.create({ data: { slug: 'cycle-a', statement: 'Belief A' } })
+    const b = await prisma.belief.create({ data: { slug: 'cycle-b', statement: 'Belief B' } })
+
+    // A ← B and B ← A : a directed cycle in the argument graph.
+    await prisma.argument.create({
+      data: { parentBeliefId: a.id, beliefId: b.id, side: 'agree', linkageScore: 0.5, importanceScore: 1.0, impactScore: 0 },
+    })
+    await prisma.argument.create({
+      data: { parentBeliefId: b.id, beliefId: a.id, side: 'agree', linkageScore: 0.5, importanceScore: 1.0, impactScore: 0 },
+    })
+
+    // Should return (the visited-set breaks the cycle) rather than hang.
+    const result = await propagateBeliefScores(a.id)
+    expect(result).toHaveProperty('updatedBeliefIds')
+    expect(Array.isArray(result.updatedArgumentIds)).toBe(true)
+  }, 20_000)
+})

--- a/tests/unit/core/scoring/derive-importance.test.ts
+++ b/tests/unit/core/scoring/derive-importance.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for sourcing an argument's Importance Score from a sub-belief.
+ *
+ * `deriveImportanceFromBeliefScore` maps a belief's net score (the [-100, +100]
+ * valence axis returned by computeBeliefScores().overallScore) onto the [0, 1]
+ * importance weight that feeds impact = Truth × Importance × Linkage.
+ *
+ * These are pure-function tests; the end-to-end DB propagation of the same
+ * derivation is covered in tests/integration/propagate-three-way.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  deriveImportanceFromBeliefScore,
+  computeArgumentImpactScore,
+} from '../../../../src/core/scoring/scoring-engine'
+
+describe('deriveImportanceFromBeliefScore', () => {
+  it('maps a fully-supported importance belief (+100) to importance 1.0', () => {
+    expect(deriveImportanceFromBeliefScore(100)).toBe(1.0)
+  })
+
+  it('maps a neutral / unargued importance belief (0) to importance 0.5', () => {
+    expect(deriveImportanceFromBeliefScore(0)).toBe(0.5)
+  })
+
+  it('maps a refuted importance belief (-100) to importance 0.0', () => {
+    expect(deriveImportanceFromBeliefScore(-100)).toBe(0.0)
+  })
+
+  it('is linear across the valence axis', () => {
+    expect(deriveImportanceFromBeliefScore(50)).toBe(0.75)
+    expect(deriveImportanceFromBeliefScore(-50)).toBe(0.25)
+  })
+
+  it('is monotonic: a better-argued importance belief yields more importance', () => {
+    const weak = deriveImportanceFromBeliefScore(-20)
+    const strong = deriveImportanceFromBeliefScore(60)
+    expect(strong).toBeGreaterThan(weak)
+  })
+
+  it('clamps out-of-range scores to [0, 1]', () => {
+    expect(deriveImportanceFromBeliefScore(250)).toBe(1.0)
+    expect(deriveImportanceFromBeliefScore(-250)).toBe(0.0)
+  })
+})
+
+describe('impact = Truth × Importance × Linkage with derived importance', () => {
+  it('feeds a derived importance straight into the impact formula', () => {
+    // Importance belief sits at +50 → importance 0.75.
+    const importance = deriveImportanceFromBeliefScore(50)
+    expect(importance).toBe(0.75)
+
+    // Truth 0.8, linkage 0.5, derived importance 0.75 → 0.8 × 0.5 × 0.75 × 100 = 30.
+    const impact = computeArgumentImpactScore('agree', 0.8, 0.5, importance)
+    expect(impact).toBe(30.0)
+  })
+
+  it('a stronger importance belief raises the argument impact', () => {
+    const truth = 0.7
+    const linkage = 0.6
+    const weakImportance = deriveImportanceFromBeliefScore(-40) // 0.3
+    const strongImportance = deriveImportanceFromBeliefScore(80) // 0.9
+
+    const weakImpact = computeArgumentImpactScore('agree', truth, linkage, weakImportance)
+    const strongImpact = computeArgumentImpactScore('agree', truth, linkage, strongImportance)
+
+    expect(strongImpact).toBeGreaterThan(weakImpact)
+  })
+
+  it('a refuted importance belief zeroes the argument impact', () => {
+    const importance = deriveImportanceFromBeliefScore(-100) // 0.0
+    const impact = computeArgumentImpactScore('agree', 0.9, 0.9, importance)
+    expect(impact).toBe(0)
+  })
+
+  it('the three channels multiply: doubling none changes nothing, importance scales linearly', () => {
+    const base = computeArgumentImpactScore('agree', 0.5, 0.5, deriveImportanceFromBeliefScore(0)) // imp 0.5
+    const doubled = computeArgumentImpactScore('agree', 0.5, 0.5, deriveImportanceFromBeliefScore(100)) // imp 1.0
+    expect(doubled).toBeCloseTo(base * 2, 5)
+  })
+})


### PR DESCRIPTION
## What & why

Makes a parent argument's **Truth**, **Importance**, and **Linkage** scores update automatically when work is done on the child pages that source them, then recomputes the parent belief's net score and propagates up the graph. This is an **extension** of the existing scoring/propagation machinery, not a rebuild.

The core gap was **Importance**: Truth already auto-propagates (it's the child belief's net score) and Linkage is already computed from the linkage sub-debate, but Importance was a flat hand-entered field. This PR sources it from a dedicated sub-belief so it tracks the live debate about whether an argument actually matters.

## Changes

**Task 1 — Importance from a sub-belief**
- Schema: new optional `Argument.importanceBeliefId` edge (third edge alongside the `beliefId` truth edge) + `Belief.asImportanceArgument` back-relation + index + migration `add_argument_importance_belief`.
- `deriveImportanceFromBeliefScore(overallScore)` in `scoring-engine.ts` maps a belief's net score (−100..+100) onto the 0..1 importance weight. When `importanceBeliefId` is null the manual `importanceScore` is kept → **backward compatible**.
- `impactScore = computeArgumentImpactScore(side, truth, linkage, importance)` is unchanged; it already multiplies the three.

**Task 2 — Three-way propagation**
- `propagateBeliefScores(childId)` now refreshes both **Truth edges** (`beliefId == childId`) and **Importance edges** (`importanceBeliefId == childId`), re-deriving each argument's importance and recomputing impact, parent net score, and recursing up.
- New `propagateFromLinkageChange(argumentId)` mirrors `propagateFromArgumentChange`: recomputes linkage from the sub-debate, persists it, propagates up. The linkage API route is consolidated onto it (no parallel implementation).
- Existing `visited`-set cycle guard and depth attenuation preserved.

**Task 3 — Render the three scores as links**
- Argument rows render **Truth** (→ child belief), **Importance** (→ importance sub-belief when present, plain text otherwise — never a broken link), and **Linkage** (→ `/arguments/[id]/linkage`). `importanceBelief` is exposed through the fetch include and types.

**Drive-by fix**
- Replaced a latent dynamic `require('./duplication-scoring')` in `all-scores.ts` (two sites) with a static import. It threw `Cannot find module` under Node/ESM whenever a belief with >1 arguments was scored, which blocked `computeBeliefScores` in any non-webpack context.

**Task 6 — Tests**
- `tests/unit/core/scoring/derive-importance.test.ts`: importance-from-sub-belief mapping + impact = Truth × Importance × Linkage.
- `tests/integration/propagate-three-way.test.ts`: DB-backed (temp SQLite built from the migration chain) verification that editing a Truth child, an Importance child, or a Linkage sub-debate each ripples to the parent argument's impact and the parent belief's net score, plus cycle safety.

## Verification
- `npx vitest run` → **181 passed** (+16 new). The only failing suite is the pre-existing `_archive/backend` mongoose test, unrelated to this change.
- `npx tsc --noEmit` clean for all touched files.
- `eslint` clean for touched files (the 1 pre-existing `prefer-const` + 2 unused-import warnings in `scoring-engine.ts` are in untouched code).

## Not included (blocked)
- **Task 4 (HTML generator)** and **Task 5 (corpus importer)** target worked-example files under `Debate Reform/...` (e.g. `Template_CANONICAL.html`, `belief_ranked-choice-voting.html`) that are **not present in this repository** — this repo is the Next.js app whose canonical assets are `templates/belief-analysis-template.html` and `docs/BELIEF_PAGE_RULES.md`. Reproducing those pages "byte-for-structure" isn't possible without the reference files, so they're deferred. Happy to pick them up if the assets are added or pointed to.

https://claude.ai/code/session_01VLKmVjiyr7QxdUT8rBSZCa

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLKmVjiyr7QxdUT8rBSZCa)_