### PR TITLE
Canonical belief HTML generator + self-navigable worked example

### DIFF
--- a/generated/belief-pages/belief_ranked-choice-voting.html
+++ b/generated/belief-pages/belief_ranked-choice-voting.html
@@ -1,0 +1,133 @@
+<!-- page=belief_ranked-choice-voting -->
+<!-- content-type=text/html -->
+<!-- Generated from the ISE canonical belief template. DB is the source of truth. -->
+<div style="font-family:'Segoe UI', Arial, sans-serif; max-width:960px; margin:0 auto;">
+
+<h1>Adopt ranked-choice voting</h1>
+<p>
+  <strong>Score:</strong> +41 (computed from sub-argument scores)<br />
+  <strong>Topic:</strong> Politics &gt; Electoral Reform
+</p>
+
+
+
+<h2>&nbsp;</h2>
+<h1>&#x1F50D; Argument Trees</h1>
+<p>Each label is a logical claim with its own page. Truth, Importance, and Linkage are links to the pages that source each score. No data citations live here - those belong in the Evidence Ledger.</p>
+<table style="border-collapse:collapse; width:100%; margin-bottom:16px;">
+<thead>
+  <tr>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; background-color:#eafaf0;" width="46%">&#x2705; Reasons to Agree</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Truth: the child belief's net score">Truth</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Importance: how much this moves the needle">Importance</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Linkage</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Impact</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">1. <a href="belief_rcv-eliminates-spoiler-effect.html" style="color:#1a5fb4; text-decoration:none;">eliminates spoiler effect</a></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><a href="belief_rcv-eliminates-spoiler-effect.html" style="color:#1a5fb4; text-decoration:none;">+72</a></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><a href="belief_spoiler-effect-major-problem.html" style="color:#1a5fb4; text-decoration:none;">75%</a></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><a href="linkage_1.html" style="color:#1a5fb4; text-decoration:none;">90%</a></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center; font-weight:bold;">+58.1</td>
+  </tr>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">2. reflects majority support</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><em style="color:#888;">[pending]</em></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">60%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">70%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center; font-weight:bold;"><em style="color:#888;">[pending]</em></td>
+  </tr>
+</tbody>
+</table>
+<table style="border-collapse:collapse; width:100%; margin-bottom:16px;">
+<thead>
+  <tr>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; background-color:#fdeeee;" width="46%">&#x274C; Reasons to Disagree</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Truth: the child belief's net score">Truth</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Importance: how much this moves the needle">Importance</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Linkage</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Impact</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">1. ballot exhaustion</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><em style="color:#888;">[pending]</em></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">50%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">55%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center; font-weight:bold;"><em style="color:#888;">[pending]</em></td>
+  </tr>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">2. voter confusion</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><em style="color:#888;">[pending]</em></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">40%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">45%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center; font-weight:bold;"><em style="color:#888;">[pending]</em></td>
+  </tr>
+</tbody>
+</table>
+
+<h2>&nbsp;</h2>
+<h1>&#x1F52C; Evidence Ledger</h1>
+<p>Evidence is empirical data, tiered by source quality and linked to the argument it bears on. Tier reflects the underlying source, not the format.</p>
+<h3>&#x1F4C4; Text and Data Sources</h3>
+<table style="border-collapse:collapse; width:100%; margin-bottom:16px;">
+<thead>
+  <tr>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold;">Tier</th><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold;">Source</th><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold;">Stance</th><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold;">Argument It Bears On</th><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold;">Linkage</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;"><strong>T1</strong></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">Maine 2018 federal election results</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">Supports</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">eliminates spoiler effect</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">strong</td>
+  </tr>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;"><strong>T3</strong></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">FairVote turnout analysis</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">Supports</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">reflects majority support</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">medium</td>
+  </tr>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;"><strong>T3</strong></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">San Francisco exit survey on ranking</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">Weakens</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">voter confusion</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">low confidence</td>
+  </tr>
+</tbody>
+</table>
+<h2>&nbsp;</h2>
+<h1>&#x1F9EA; Objective Criteria</h1>
+<p>How would we know if this belief is true? Measurable tests both sides should agree on before the debate starts.</p>
+<table style="border-collapse:collapse; width:100%; margin-bottom:16px;">
+<thead>
+  <tr><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold;">Criterion</th><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold;">Current Status</th><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold;">Threshold for Agreement</th></tr>
+</thead>
+<tbody>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">Share of races won without majority</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">plurality winners common under FPTP</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">majority winner in 95%+ of RCV races</td>
+  </tr>
+</tbody>
+</table>
+<h2>&nbsp;</h2>
+<h1>&#x1F4D6; Definitions and Scoring Concepts</h1>
+<p><strong>Arguments vs. Evidence:</strong> Arguments are logical claims, scored by logical validity and linkage strength. Evidence is empirical data, scored by source tier and conclusion relevance. Argument Score = Evidence Quality x Logical Validity x Linkage Strength.</p>
+<p><strong>Truth / Importance / Linkage:</strong> Truth is the child belief's own net score. Importance weights how much the argument moves the needle (and can itself be sourced from a sub-belief). Linkage measures whether the reason actually connects to the conclusion. Impact = Truth x Importance x Linkage.</p>
+<p><strong>Evidence Tiers:</strong> T1 = peer-reviewed / official data. T2 = expert analysis / institutional reports. T3 = investigative journalism / surveys. T4 = opinion / anecdotal.</p>
+<p><strong>Spoiler effect:</strong> when a minor candidate draws votes from a similar major candidate, flipping the outcome.</p>
+<p><strong>Ballot exhaustion:</strong> a ballot stops counting once all its ranked candidates are eliminated.</p>
+
+<h2>&nbsp;</h2>
+<h1>&#x1F52C; Contribute</h1>
+<p><strong>Contact</strong> to add arguments, evidence, images, or video. | <strong>GitHub</strong> for scoring algorithms and technical documentation.</p>
+
+</div>

--- a/generated/belief-pages/belief_rcv-eliminates-spoiler-effect.html
+++ b/generated/belief-pages/belief_rcv-eliminates-spoiler-effect.html
@@ -1,0 +1,83 @@
+<!-- page=belief_rcv-eliminates-spoiler-effect -->
+<!-- content-type=text/html -->
+<!-- Generated from the ISE canonical belief template. DB is the source of truth. -->
+<div style="font-family:'Segoe UI', Arial, sans-serif; max-width:960px; margin:0 auto;">
+
+<h1>RCV eliminates the spoiler effect</h1>
+<p>
+  <strong>Score:</strong> +72 (computed from sub-argument scores)<br />
+  <strong>Topic:</strong> Politics &gt; Electoral Reform
+</p>
+
+<div style="background-color:#eef6ff; border:1px solid #b0c4de; border-radius:6px; padding:10px 14px; margin-bottom:16px;">
+  <strong>Supports:</strong>
+  <ul style="margin:6px 0 0 18px; padding:0;">
+    <li><a href="belief_ranked-choice-voting.html" style="color:#1a5fb4; text-decoration:none;">Adopt ranked-choice voting</a> (as <em>eliminates spoiler effect</em>)</li>
+  </ul>
+</div>
+
+<h2>&nbsp;</h2>
+<h1>&#x1F50D; Argument Trees</h1>
+<p>Each label is a logical claim with its own page. Truth, Importance, and Linkage are links to the pages that source each score. No data citations live here - those belong in the Evidence Ledger.</p>
+<table style="border-collapse:collapse; width:100%; margin-bottom:16px;">
+<thead>
+  <tr>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; background-color:#eafaf0;" width="46%">&#x2705; Reasons to Agree</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Truth: the child belief's net score">Truth</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Importance: how much this moves the needle">Importance</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Linkage</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Impact</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">1. later choices count</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><em style="color:#888;">[pending]</em></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">90%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">95%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center; font-weight:bold;"><em style="color:#888;">[pending]</em></td>
+  </tr>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">2. no wasted-vote incentive</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><em style="color:#888;">[pending]</em></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">80%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">85%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center; font-weight:bold;"><em style="color:#888;">[pending]</em></td>
+  </tr>
+</tbody>
+</table>
+<table style="border-collapse:collapse; width:100%; margin-bottom:16px;">
+<thead>
+  <tr>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; background-color:#fdeeee;" width="46%">&#x274C; Reasons to Disagree</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Truth: the child belief's net score">Truth</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Importance: how much this moves the needle">Importance</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Linkage</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Impact</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">1. center squeeze remains</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><em style="color:#888;">[pending]</em></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">50%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">60%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center; font-weight:bold;"><em style="color:#888;">[pending]</em></td>
+  </tr>
+</tbody>
+</table>
+
+
+
+<h2>&nbsp;</h2>
+<h1>&#x1F4D6; Definitions and Scoring Concepts</h1>
+<p><strong>Arguments vs. Evidence:</strong> Arguments are logical claims, scored by logical validity and linkage strength. Evidence is empirical data, scored by source tier and conclusion relevance. Argument Score = Evidence Quality x Logical Validity x Linkage Strength.</p>
+<p><strong>Truth / Importance / Linkage:</strong> Truth is the child belief's own net score. Importance weights how much the argument moves the needle (and can itself be sourced from a sub-belief). Linkage measures whether the reason actually connects to the conclusion. Impact = Truth x Importance x Linkage.</p>
+<p><strong>Evidence Tiers:</strong> T1 = peer-reviewed / official data. T2 = expert analysis / institutional reports. T3 = investigative journalism / surveys. T4 = opinion / anecdotal.</p>
+<p><strong>Center squeeze:</strong> a centrist preferred by most voters can be eliminated early for lacking first-choice votes.</p>
+
+<h2>&nbsp;</h2>
+<h1>&#x1F52C; Contribute</h1>
+<p><strong>Contact</strong> to add arguments, evidence, images, or video. | <strong>GitHub</strong> for scoring algorithms and technical documentation.</p>
+
+</div>

--- a/generated/belief-pages/belief_spoiler-effect-major-problem.html
+++ b/generated/belief-pages/belief_spoiler-effect-major-problem.html
@@ -1,0 +1,83 @@
+<!-- page=belief_spoiler-effect-major-problem -->
+<!-- content-type=text/html -->
+<!-- Generated from the ISE canonical belief template. DB is the source of truth. -->
+<div style="font-family:'Segoe UI', Arial, sans-serif; max-width:960px; margin:0 auto;">
+
+<h1>The spoiler effect is a major, solvable problem</h1>
+<p>
+  <strong>Score:</strong> +50 (computed from sub-argument scores)<br />
+  <strong>Topic:</strong> Politics &gt; Electoral Reform
+</p>
+
+<div style="background-color:#eef6ff; border:1px solid #b0c4de; border-radius:6px; padding:10px 14px; margin-bottom:16px;">
+  <strong>Supports:</strong>
+  <ul style="margin:6px 0 0 18px; padding:0;">
+    <li><a href="belief_ranked-choice-voting.html" style="color:#1a5fb4; text-decoration:none;">Adopt ranked-choice voting</a> (as <em>importance of &quot;eliminates spoiler effect&quot;</em>)</li>
+  </ul>
+</div>
+
+<h2>&nbsp;</h2>
+<h1>&#x1F50D; Argument Trees</h1>
+<p>Each label is a logical claim with its own page. Truth, Importance, and Linkage are links to the pages that source each score. No data citations live here - those belong in the Evidence Ledger.</p>
+<table style="border-collapse:collapse; width:100%; margin-bottom:16px;">
+<thead>
+  <tr>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; background-color:#eafaf0;" width="46%">&#x2705; Reasons to Agree</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Truth: the child belief's net score">Truth</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Importance: how much this moves the needle">Importance</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Linkage</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Impact</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">1. changed presidential outcomes</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><em style="color:#888;">[pending]</em></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">90%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">80%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center; font-weight:bold;"><em style="color:#888;">[pending]</em></td>
+  </tr>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">2. distorts third parties</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><em style="color:#888;">[pending]</em></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">70%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">75%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center; font-weight:bold;"><em style="color:#888;">[pending]</em></td>
+  </tr>
+</tbody>
+</table>
+<table style="border-collapse:collapse; width:100%; margin-bottom:16px;">
+<thead>
+  <tr>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; background-color:#fdeeee;" width="46%">&#x274C; Reasons to Disagree</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Truth: the child belief's net score">Truth</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="13%" title="Importance: how much this moves the needle">Importance</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Linkage</th>
+    <th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;" width="14%">Impact</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">1. rare in practice</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;"><em style="color:#888;">[pending]</em></td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">50%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">50%</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center; font-weight:bold;"><em style="color:#888;">[pending]</em></td>
+  </tr>
+</tbody>
+</table>
+
+
+
+<h2>&nbsp;</h2>
+<h1>&#x1F4D6; Definitions and Scoring Concepts</h1>
+<p><strong>Arguments vs. Evidence:</strong> Arguments are logical claims, scored by logical validity and linkage strength. Evidence is empirical data, scored by source tier and conclusion relevance. Argument Score = Evidence Quality x Logical Validity x Linkage Strength.</p>
+<p><strong>Truth / Importance / Linkage:</strong> Truth is the child belief's own net score. Importance weights how much the argument moves the needle (and can itself be sourced from a sub-belief). Linkage measures whether the reason actually connects to the conclusion. Impact = Truth x Importance x Linkage.</p>
+<p><strong>Evidence Tiers:</strong> T1 = peer-reviewed / official data. T2 = expert analysis / institutional reports. T3 = investigative journalism / surveys. T4 = opinion / anecdotal.</p>
+
+
+<h2>&nbsp;</h2>
+<h1>&#x1F52C; Contribute</h1>
+<p><strong>Contact</strong> to add arguments, evidence, images, or video. | <strong>GitHub</strong> for scoring algorithms and technical documentation.</p>
+
+</div>

--- a/generated/belief-pages/index.html
+++ b/generated/belief-pages/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"><title>ISE sample belief pages</title></head>
+<body style="font-family:'Segoe UI', Arial, sans-serif; max-width:760px; margin:24px auto;">
+<h1>ISE sample belief pages</h1>
+<p>Generated from the canonical belief template. Click through to see Truth, Importance, and Linkage links between pages.</p>
+<ul>
+  <li><a href="belief_ranked-choice-voting.html">Adopt ranked-choice voting (parent)</a></li>
+  <li><a href="belief_rcv-eliminates-spoiler-effect.html">RCV eliminates the spoiler effect (Truth child)</a></li>
+  <li><a href="belief_spoiler-effect-major-problem.html">The spoiler effect is a major, solvable problem (Importance child)</a></li>
+  <li><a href="linkage_1.html">Linkage Score Analysis: eliminates spoiler effect</a></li>
+</ul>
+</body></html>

--- a/generated/belief-pages/linkage_1.html
+++ b/generated/belief-pages/linkage_1.html
@@ -1,0 +1,43 @@
+<!-- page=linkage_1 -->
+<!-- content-type=text/html -->
+<!-- Linkage Score Analysis, generated from the DB. -->
+<div style="font-family:'Segoe UI', Arial, sans-serif; max-width:960px; margin:0 auto;">
+
+<h1>Linkage Score Analysis</h1>
+<p style="font-size:115%;">Does <strong>eliminates spoiler effect</strong> actually support the conclusion?</p>
+
+<div style="background-color:#eef6ff; border:1px solid #b0c4de; border-radius:6px; padding:10px 14px; margin-bottom:16px;">
+  <strong>Reason:</strong> <a href="belief_rcv-eliminates-spoiler-effect.html" style="color:#1a5fb4; text-decoration:none;">RCV eliminates the spoiler effect</a><br />
+  <strong>Supports conclusion:</strong> <a href="belief_ranked-choice-voting.html" style="color:#1a5fb4; text-decoration:none;">Adopt ranked-choice voting</a><br />
+  <strong>Linkage Score:</strong> 90% (from the sub-debate below)
+</div>
+
+<p>The linkage sub-debate scores whether the reason connects to the conclusion: Linkage = A / (A + D), where A and D are the strengths of the arguments that the link is valid versus invalid.</p>
+
+<h3>&#x2705; The link IS valid</h3>
+<table style="border-collapse:collapse; width:100%; margin-bottom:16px;">
+<thead><tr><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold;">Argument</th><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;">Strength</th></tr></thead>
+<tbody>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">Eliminating spoilers is the direct mechanism RCV provides</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">100%</td>
+  </tr>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">Corroborated by Maine and Alaska results</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">80%</td>
+  </tr>
+</tbody>
+</table>
+
+<h3>&#x274C; The link is NOT valid</h3>
+<table style="border-collapse:collapse; width:100%; margin-bottom:16px;">
+<thead><tr><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold;">Argument</th><th style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; background-color:#f0f3f6; font-weight:bold; text-align:center;">Strength</th></tr></thead>
+<tbody>
+  <tr>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;">Only matters when a spoiler is actually present</td>
+    <td style="border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left; text-align:center;">20%</td>
+  </tr>
+</tbody>
+</table>
+
+</div>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "db:seed": "npx tsx prisma/seed.ts",
     "db:seed-reviews": "npx tsx prisma/seed-product-reviews.ts",
     "db:migrate": "npx prisma migrate dev",
-    "db:reset": "npx prisma migrate reset --force"
+    "db:reset": "npx prisma migrate reset --force",
+    "html:sample": "npx tsx scripts/generate-sample-belief-pages.ts",
+    "html:generate": "npx tsx scripts/generate-belief-html.ts"
   },
   "dependencies": {
     "@prisma/adapter-better-sqlite3": "^7.3.0",

--- a/scripts/generate-belief-html.ts
+++ b/scripts/generate-belief-html.ts
@@ -1,0 +1,116 @@
+/**
+ * Publish step: render a live Belief (and its arguments' linkage pages) from
+ * the DB into the canonical HTML, using the DB as the source of truth.
+ *
+ *   npx tsx scripts/generate-belief-html.ts <slug> [--route] [--out DIR]
+ *   npx tsx scripts/generate-belief-html.ts --all   [--route] [--out DIR]
+ *
+ * Default link mode is 'file' (self-navigable belief_<slug>.html siblings).
+ * Pass --route to emit /beliefs/<slug> links for the live Next.js app.
+ *
+ * This mirrors the existing Blogger/PBworks publishers: it produces the static
+ * HTML; wiring the output to a specific host is a thin follow-up.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { prisma } from '@/lib/prisma'
+import { fetchBeliefBySlug } from '@/features/belief-analysis/data/fetch-belief'
+import { beliefToHtmlInput, type ParentEdge } from '@/lib/html-generator/from-belief'
+import { renderBeliefHtml, renderLinkageHtml } from '@/lib/html-generator/belief-html'
+
+function parseArgs(argv: string[]) {
+  const linkMode: 'file' | 'route' = argv.includes('--route') ? 'route' : 'file'
+  const outIdx = argv.indexOf('--out')
+  const outDir = outIdx >= 0 ? argv[outIdx + 1] : 'generated/belief-pages'
+  const all = argv.includes('--all')
+  const slug = argv.find((a) => !a.startsWith('--') && a !== (outIdx >= 0 ? argv[outIdx + 1] : ''))
+  return { linkMode, outDir: path.resolve(process.cwd(), outDir), all, slug }
+}
+
+/** Find the parent arguments (edges where this belief is the reason) for backlinks. */
+async function findParents(beliefId: number): Promise<ParentEdge[]> {
+  const edges = await prisma.argument.findMany({
+    where: { beliefId },
+    select: { parentBelief: { select: { slug: true, statement: true } } },
+  })
+  return edges.map((e) => ({
+    parentStatement: e.parentBelief.statement,
+    parentSlug: e.parentBelief.slug,
+    argumentLabel: null,
+  }))
+}
+
+async function renderOne(slug: string, linkMode: 'file' | 'route', outDir: string): Promise<string[]> {
+  const belief = await fetchBeliefBySlug(slug)
+  if (!belief) {
+    console.warn(`! skipped ${slug}: not found`)
+    return []
+  }
+
+  const parents = await findParents(belief.id)
+  const input = beliefToHtmlInput(belief, { parents, linkMode })
+  const written: string[] = []
+
+  const beliefFile = path.join(outDir, `belief_${slug}.html`)
+  fs.writeFileSync(beliefFile, renderBeliefHtml(input), 'utf8')
+  written.push(beliefFile)
+
+  // One linkage page per argument edge.
+  for (const a of belief.arguments) {
+    const linkageArgs = await prisma.linkageArgument.findMany({
+      where: { argumentId: a.id },
+      select: { side: true, statement: true, strength: true },
+    })
+    const html = renderLinkageHtml({
+      argumentId: a.id,
+      argumentLabel: a.belief.statement,
+      parentStatement: belief.statement,
+      parentSlug: belief.slug,
+      childStatement: a.belief.statement,
+      childSlug: a.belief.slug,
+      linkageScore: a.linkageScore,
+      subArguments: linkageArgs.map((l) => ({
+        side: l.side === 'disagree' ? 'disagree' : 'agree',
+        statement: l.statement,
+        strength: l.strength,
+      })),
+      linkMode,
+    })
+    const linkageFile = path.join(outDir, `linkage_${a.id}.html`)
+    fs.writeFileSync(linkageFile, html, 'utf8')
+    written.push(linkageFile)
+  }
+
+  return written
+}
+
+async function main() {
+  const { linkMode, outDir, all, slug } = parseArgs(process.argv.slice(2))
+  fs.mkdirSync(outDir, { recursive: true })
+
+  let slugs: string[]
+  if (all) {
+    const beliefs = await prisma.belief.findMany({ select: { slug: true } })
+    slugs = beliefs.map((b) => b.slug)
+  } else if (slug) {
+    slugs = [slug]
+  } else {
+    console.error('Usage: generate-belief-html.ts <slug> | --all [--route] [--out DIR]')
+    process.exit(1)
+  }
+
+  let count = 0
+  for (const s of slugs) {
+    const written = await renderOne(s, linkMode, outDir)
+    count += written.length
+  }
+  console.log(`Wrote ${count} files to ${outDir}`)
+  await prisma.$disconnect()
+}
+
+main().catch(async (e) => {
+  console.error(e)
+  await prisma.$disconnect()
+  process.exit(1)
+})

--- a/scripts/generate-sample-belief-pages.ts
+++ b/scripts/generate-sample-belief-pages.ts
@@ -1,0 +1,198 @@
+/**
+ * Generates a self-navigable worked example of the canonical belief template
+ * so the layout can be reviewed straight from disk (no server needed).
+ *
+ *   npx tsx scripts/generate-sample-belief-pages.ts
+ *
+ * Output: generated/belief-pages/*.html (belief_<slug>.html + linkage_<id>.html
+ * + index.html). All internal links are sibling files, so opening index.html
+ * lets you click through the parent belief, its Truth and Importance children,
+ * and the Linkage Score Analysis page.
+ *
+ * Numbers are internally consistent: impact = sign x truth01 x importance x
+ * linkage x 100, with truth01 and importance both derived from belief net
+ * scores via the same (net + 100) / 200 mapping the live engine uses.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import {
+  renderBeliefHtml,
+  renderLinkageHtml,
+  type BeliefHtmlInput,
+} from '../src/lib/html-generator/belief-html'
+
+const OUT_DIR = path.resolve(process.cwd(), 'generated/belief-pages')
+
+const norm01 = (net: number) => Math.max(0, Math.min(1, (net + 100) / 200))
+const impact = (side: 'agree' | 'disagree', truthNet: number, importanceNet: number, linkage: number) => {
+  const raw = norm01(truthNet) * norm01(importanceNet) * linkage * 100
+  return Math.round((side === 'agree' ? raw : -raw) * 10) / 10
+}
+
+// ── Child belief net scores (would come from the DB in production) ──
+const TRUTH_NET = 72 // "RCV eliminates the spoiler effect"
+const IMPORTANCE_NET = 50 // "The spoiler effect is a major, solvable problem"
+const LINKAGE = 0.9
+
+// ── Parent belief: Adopt ranked-choice voting ──
+const parent: BeliefHtmlInput = {
+  slug: 'ranked-choice-voting',
+  statement: 'Adopt ranked-choice voting',
+  category: 'Politics',
+  subcategory: 'Electoral Reform',
+  netScore: 41,
+  args: [
+    {
+      label: 'eliminates spoiler effect',
+      side: 'agree',
+      childSlug: 'rcv-eliminates-spoiler-effect',
+      truthScore: TRUTH_NET,
+      importanceScore: norm01(IMPORTANCE_NET),
+      importanceSlug: 'spoiler-effect-major-problem',
+      linkageScore: LINKAGE,
+      argumentId: 1,
+      impactScore: impact('agree', TRUTH_NET, IMPORTANCE_NET, LINKAGE),
+    },
+    {
+      label: 'reflects majority support',
+      side: 'agree',
+      childSlug: null,
+      truthScore: null,
+      importanceScore: 0.6,
+      linkageScore: 0.7,
+      argumentId: null,
+      impactScore: null,
+    },
+    {
+      label: 'ballot exhaustion',
+      side: 'disagree',
+      childSlug: null,
+      truthScore: null,
+      importanceScore: 0.5,
+      linkageScore: 0.55,
+      argumentId: null,
+      impactScore: null,
+    },
+    {
+      label: 'voter confusion',
+      side: 'disagree',
+      childSlug: null,
+      truthScore: null,
+      importanceScore: 0.4,
+      linkageScore: 0.45,
+      argumentId: null,
+      impactScore: null,
+    },
+  ],
+  evidence: [
+    { tier: 'T1', source: 'Maine 2018 federal election results', stance: 'Supports', bearsOn: 'eliminates spoiler effect', linkage: 'strong' },
+    { tier: 'T3', source: 'FairVote turnout analysis', stance: 'Supports', bearsOn: 'reflects majority support', linkage: 'medium' },
+    { tier: 'T3', source: 'San Francisco exit survey on ranking', stance: 'Weakens', bearsOn: 'voter confusion', linkage: 'low confidence' },
+  ],
+  objectiveCriteria: [
+    {
+      criterion: 'Share of races won without majority',
+      currentStatus: 'plurality winners common under FPTP',
+      threshold: 'majority winner in 95%+ of RCV races',
+    },
+  ],
+  definitions: [
+    { term: 'Spoiler effect', definition: 'when a minor candidate draws votes from a similar major candidate, flipping the outcome.' },
+    { term: 'Ballot exhaustion', definition: 'a ballot stops counting once all its ranked candidates are eliminated.' },
+  ],
+}
+
+// ── Truth child: RCV eliminates the spoiler effect ──
+const truthChild: BeliefHtmlInput = {
+  slug: 'rcv-eliminates-spoiler-effect',
+  statement: 'RCV eliminates the spoiler effect',
+  category: 'Politics',
+  subcategory: 'Electoral Reform',
+  netScore: TRUTH_NET,
+  supports: [
+    { parentStatement: 'Adopt ranked-choice voting', parentSlug: 'ranked-choice-voting', argumentLabel: 'eliminates spoiler effect' },
+  ],
+  args: [
+    { label: 'later choices count', side: 'agree', importanceScore: 0.9, linkageScore: 0.95, argumentId: null, impactScore: null },
+    { label: 'no wasted-vote incentive', side: 'agree', importanceScore: 0.8, linkageScore: 0.85, argumentId: null, impactScore: null },
+    { label: 'center squeeze remains', side: 'disagree', importanceScore: 0.5, linkageScore: 0.6, argumentId: null, impactScore: null },
+  ],
+  definitions: [
+    { term: 'Center squeeze', definition: 'a centrist preferred by most voters can be eliminated early for lacking first-choice votes.' },
+  ],
+}
+
+// ── Importance child: The spoiler effect is a major, solvable problem ──
+const importanceChild: BeliefHtmlInput = {
+  slug: 'spoiler-effect-major-problem',
+  statement: 'The spoiler effect is a major, solvable problem',
+  category: 'Politics',
+  subcategory: 'Electoral Reform',
+  netScore: IMPORTANCE_NET,
+  supports: [
+    { parentStatement: 'Adopt ranked-choice voting', parentSlug: 'ranked-choice-voting', argumentLabel: 'importance of "eliminates spoiler effect"' },
+  ],
+  args: [
+    { label: 'changed presidential outcomes', side: 'agree', importanceScore: 0.9, linkageScore: 0.8, argumentId: null, impactScore: null },
+    { label: 'distorts third parties', side: 'agree', importanceScore: 0.7, linkageScore: 0.75, argumentId: null, impactScore: null },
+    { label: 'rare in practice', side: 'disagree', importanceScore: 0.5, linkageScore: 0.5, argumentId: null, impactScore: null },
+  ],
+}
+
+const linkagePage = renderLinkageHtml({
+  argumentId: 1,
+  argumentLabel: 'eliminates spoiler effect',
+  parentStatement: 'Adopt ranked-choice voting',
+  parentSlug: 'ranked-choice-voting',
+  childStatement: 'RCV eliminates the spoiler effect',
+  childSlug: 'rcv-eliminates-spoiler-effect',
+  linkageScore: LINKAGE,
+  subArguments: [
+    { side: 'agree', statement: 'Eliminating spoilers is the direct mechanism RCV provides', strength: 1.0 },
+    { side: 'agree', statement: 'Corroborated by Maine and Alaska results', strength: 0.8 },
+    { side: 'disagree', statement: 'Only matters when a spoiler is actually present', strength: 0.2 },
+  ],
+})
+
+function indexPage(slugs: { href: string; label: string }[]): string {
+  const items = slugs.map((s) => `  <li><a href="${s.href}">${s.label}</a></li>`).join('\n')
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>ISE sample belief pages</title></head>
+<body style="font-family:'Segoe UI', Arial, sans-serif; max-width:760px; margin:24px auto;">
+<h1>ISE sample belief pages</h1>
+<p>Generated from the canonical belief template. Click through to see Truth, Importance, and Linkage links between pages.</p>
+<ul>
+${items}
+</ul>
+</body></html>`
+}
+
+function main() {
+  fs.mkdirSync(OUT_DIR, { recursive: true })
+
+  const files: { name: string; html: string }[] = [
+    { name: 'belief_ranked-choice-voting.html', html: renderBeliefHtml(parent) },
+    { name: 'belief_rcv-eliminates-spoiler-effect.html', html: renderBeliefHtml(truthChild) },
+    { name: 'belief_spoiler-effect-major-problem.html', html: renderBeliefHtml(importanceChild) },
+    { name: 'linkage_1.html', html: linkagePage },
+  ]
+
+  for (const f of files) {
+    fs.writeFileSync(path.join(OUT_DIR, f.name), f.html, 'utf8')
+  }
+
+  fs.writeFileSync(
+    path.join(OUT_DIR, 'index.html'),
+    indexPage([
+      { href: 'belief_ranked-choice-voting.html', label: 'Adopt ranked-choice voting (parent)' },
+      { href: 'belief_rcv-eliminates-spoiler-effect.html', label: 'RCV eliminates the spoiler effect (Truth child)' },
+      { href: 'belief_spoiler-effect-major-problem.html', label: 'The spoiler effect is a major, solvable problem (Importance child)' },
+      { href: 'linkage_1.html', label: 'Linkage Score Analysis: eliminates spoiler effect' },
+    ]),
+    'utf8',
+  )
+
+  console.log(`Wrote ${files.length + 1} files to ${OUT_DIR}`)
+}
+
+main()

--- a/src/lib/html-generator/belief-html.ts
+++ b/src/lib/html-generator/belief-html.ts
@@ -1,0 +1,414 @@
+/**
+ * Belief -> canonical HTML generator.
+ *
+ * The public ISE wiki pages are static HTML. The DB is the source of truth;
+ * this module renders a Belief (and an argument's linkage sub-debate) into the
+ * canonical belief template defined by:
+ *   - templates/belief-analysis-template.html  (section order + table shapes)
+ *   - docs/BELIEF_PAGE_RULES.md                 (the seven hard rules)
+ *
+ * Output constraints (PBworks strips CSS classes and custom ids, so):
+ *   - inline styles only, no class=, no id=, no href="#" or internal anchors
+ *   - no em dashes (use " - " or " to ")
+ *   - definitions render LAST, never first (Rule 1)
+ *   - argument cells are atomic labels; data lives in the Evidence Ledger (Rules 3, 4)
+ *   - Truth / Importance / Linkage score cells are LINKS to their source pages
+ *     when those pages exist, plain text otherwise (Rules 5, 6)
+ *
+ * The renderer is pure (input -> string) so it is unit-testable and can render
+ * either live DB rows (via the adapter in belief-html-db.ts) or worked-example
+ * fixtures. Internal links default to sibling files (belief_<slug>.html) so a
+ * generated set is self-navigable when opened straight from disk.
+ */
+
+export type Side = 'agree' | 'disagree'
+
+export interface ArgRow {
+  /** Atomic 2-6 word label (Rule 3). */
+  label: string
+  side: Side
+  /** Truth source: the child belief slug. Score cell links here when set. */
+  childSlug?: string | null
+  /** Child belief net score (-100..+100). Blank when null (Rule 6). */
+  truthScore?: number | null
+  /** Importance weight (0..1). */
+  importanceScore?: number | null
+  /** Importance source: the importance sub-belief slug, if any. */
+  importanceSlug?: string | null
+  /** Linkage score (0..1 or -1..1). */
+  linkageScore?: number | null
+  /** Argument id, used to build the linkage page link. */
+  argumentId?: number | null
+  /** Signed impact (Truth x Importance x Linkage x 100). */
+  impactScore?: number | null
+}
+
+export interface EvidenceRow {
+  tier: string // T1..T4
+  source: string
+  stance: string // Supports | Weakens
+  bearsOn: string // argument label
+  linkage?: string | null
+}
+
+export interface CriterionRow {
+  criterion: string
+  currentStatus?: string | null
+  threshold?: string | null
+}
+
+export interface SupportsBacklink {
+  /** Parent belief this page is a reason for. */
+  parentStatement: string
+  parentSlug?: string | null
+  /** The atomic label this belief carries inside the parent's argument tree. */
+  argumentLabel?: string | null
+}
+
+export interface DefinitionRow {
+  term: string
+  definition: string
+}
+
+export interface BeliefHtmlInput {
+  slug: string
+  statement: string
+  category?: string | null
+  subcategory?: string | null
+  /** Net score (-100..+100). Rendered blank when null (Rule 6). */
+  netScore?: number | null
+  args: ArgRow[]
+  evidence?: EvidenceRow[]
+  objectiveCriteria?: CriterionRow[]
+  definitions?: DefinitionRow[]
+  /** "Supports:" backlinks to the parent argument/belief this page feeds. */
+  supports?: SupportsBacklink[]
+  /**
+   * How to build internal hrefs.
+   *   'file' (default) -> belief_<slug>.html siblings (self-navigable on disk)
+   *   'route'          -> /beliefs/<slug> (the live Next.js app)
+   */
+  linkMode?: 'file' | 'route'
+}
+
+// ─── Link helpers ─────────────────────────────────────────────────
+
+function beliefHref(slug: string, mode: 'file' | 'route'): string {
+  return mode === 'route' ? `/beliefs/${slug}` : `belief_${slug}.html`
+}
+
+function linkageHref(argumentId: number, mode: 'file' | 'route'): string {
+  return mode === 'route' ? `/arguments/${argumentId}/linkage` : `linkage_${argumentId}.html`
+}
+
+// ─── Text helpers ─────────────────────────────────────────────────
+
+/** Escape HTML special chars. Also strips em/en dashes per the no-em-dash rule. */
+export function esc(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/—/g, ' - ') // em dash
+    .replace(/–/g, '-') // en dash
+}
+
+function fmtNet(score: number | null | undefined): string {
+  if (score === null || score === undefined) return ''
+  const rounded = Math.round(score * 10) / 10
+  return `${rounded >= 0 ? '+' : ''}${rounded}`
+}
+
+function fmtPct(value: number | null | undefined): string {
+  if (value === null || value === undefined) return ''
+  return `${Math.round(Math.abs(value) * 100)}%`
+}
+
+/**
+ * A score cell: a link to the source page when a target exists, plain text
+ * when the score is present but the page is not, and "[pending]" when no score
+ * exists yet (Rule 6 — never a fake "+0").
+ */
+function scoreCell(display: string, href: string | null): string {
+  if (display === '') {
+    return '<em style="color:#888;">[pending]</em>'
+  }
+  if (href) {
+    return `<a href="${href}" style="color:#1a5fb4; text-decoration:none;">${display}</a>`
+  }
+  return display
+}
+
+// ─── Section renderers ────────────────────────────────────────────
+
+const TD = 'border:1px solid #b0b8c1; padding:8px 10px; vertical-align:top; text-align:left;'
+const TH = `${TD} background-color:#f0f3f6; font-weight:bold;`
+const TABLE = 'border-collapse:collapse; width:100%; margin-bottom:16px;'
+const CENTER = 'text-align:center;'
+
+function renderSupports(supports: SupportsBacklink[] | undefined, mode: 'file' | 'route'): string {
+  if (!supports || supports.length === 0) return ''
+  const rows = supports
+    .map((s) => {
+      const parent = s.parentSlug
+        ? `<a href="${beliefHref(s.parentSlug, mode)}" style="color:#1a5fb4; text-decoration:none;">${esc(s.parentStatement)}</a>`
+        : esc(s.parentStatement)
+      const label = s.argumentLabel ? ` (as <em>${esc(s.argumentLabel)}</em>)` : ''
+      return `<li>${parent}${label}</li>`
+    })
+    .join('\n    ')
+  return `<div style="background-color:#eef6ff; border:1px solid #b0c4de; border-radius:6px; padding:10px 14px; margin-bottom:16px;">
+  <strong>Supports:</strong>
+  <ul style="margin:6px 0 0 18px; padding:0;">
+    ${rows}
+  </ul>
+</div>`
+}
+
+function renderArgumentTable(rows: ArgRow[], heading: string, headerColor: string, mode: 'file' | 'route'): string {
+  const body =
+    rows.length === 0
+      ? `<tr><td style="${TD}" colspan="5"><em style="color:#888;">No arguments yet.</em></td></tr>`
+      : rows
+          .map((a, i) => {
+            const labelCell = a.childSlug
+              ? `<a href="${beliefHref(a.childSlug, mode)}" style="color:#1a5fb4; text-decoration:none;">${esc(a.label)}</a>`
+              : esc(a.label)
+            const truth = scoreCell(
+              fmtNet(a.truthScore),
+              a.childSlug ? beliefHref(a.childSlug, mode) : null,
+            )
+            const importance = scoreCell(
+              fmtPct(a.importanceScore),
+              a.importanceSlug ? beliefHref(a.importanceSlug, mode) : null,
+            )
+            const linkage = scoreCell(
+              fmtPct(a.linkageScore),
+              a.argumentId != null ? linkageHref(a.argumentId, mode) : null,
+            )
+            const impact =
+              a.impactScore === null || a.impactScore === undefined
+                ? '<em style="color:#888;">[pending]</em>'
+                : `${a.side === 'agree' ? '+' : '-'}${Math.abs(Math.round(a.impactScore * 10) / 10)}`
+            return `  <tr>
+    <td style="${TD}">${i + 1}. ${labelCell}</td>
+    <td style="${TD} ${CENTER}">${truth}</td>
+    <td style="${TD} ${CENTER}">${importance}</td>
+    <td style="${TD} ${CENTER}">${linkage}</td>
+    <td style="${TD} ${CENTER} font-weight:bold;">${impact}</td>
+  </tr>`
+          })
+          .join('\n')
+
+  return `<table style="${TABLE}">
+<thead>
+  <tr>
+    <th style="${TH} background-color:${headerColor};" width="46%">${heading}</th>
+    <th style="${TH} ${CENTER}" width="13%" title="Truth: the child belief's net score">Truth</th>
+    <th style="${TH} ${CENTER}" width="13%" title="Importance: how much this moves the needle">Importance</th>
+    <th style="${TH} ${CENTER}" width="14%">Linkage</th>
+    <th style="${TH} ${CENTER}" width="14%">Impact</th>
+  </tr>
+</thead>
+<tbody>
+${body}
+</tbody>
+</table>`
+}
+
+function renderEvidence(evidence: EvidenceRow[] | undefined): string {
+  if (!evidence || evidence.length === 0) return ''
+  const rows = evidence
+    .map(
+      (e) => `  <tr>
+    <td style="${TD}"><strong>${esc(e.tier)}</strong></td>
+    <td style="${TD}">${esc(e.source)}</td>
+    <td style="${TD}">${esc(e.stance)}</td>
+    <td style="${TD}">${esc(e.bearsOn)}</td>
+    <td style="${TD}">${esc(e.linkage ?? '')}</td>
+  </tr>`,
+    )
+    .join('\n')
+  return `<h2>&nbsp;</h2>
+<h1>&#x1F52C; Evidence Ledger</h1>
+<p>Evidence is empirical data, tiered by source quality and linked to the argument it bears on. Tier reflects the underlying source, not the format.</p>
+<h3>&#x1F4C4; Text and Data Sources</h3>
+<table style="${TABLE}">
+<thead>
+  <tr>
+    <th style="${TH}">Tier</th><th style="${TH}">Source</th><th style="${TH}">Stance</th><th style="${TH}">Argument It Bears On</th><th style="${TH}">Linkage</th>
+  </tr>
+</thead>
+<tbody>
+${rows}
+</tbody>
+</table>`
+}
+
+function renderCriteria(criteria: CriterionRow[] | undefined): string {
+  if (!criteria || criteria.length === 0) return ''
+  const rows = criteria
+    .map(
+      (c) => `  <tr>
+    <td style="${TD}">${esc(c.criterion)}</td>
+    <td style="${TD}">${esc(c.currentStatus ?? '')}</td>
+    <td style="${TD}">${esc(c.threshold ?? '')}</td>
+  </tr>`,
+    )
+    .join('\n')
+  return `<h2>&nbsp;</h2>
+<h1>&#x1F9EA; Objective Criteria</h1>
+<p>How would we know if this belief is true? Measurable tests both sides should agree on before the debate starts.</p>
+<table style="${TABLE}">
+<thead>
+  <tr><th style="${TH}">Criterion</th><th style="${TH}">Current Status</th><th style="${TH}">Threshold for Agreement</th></tr>
+</thead>
+<tbody>
+${rows}
+</tbody>
+</table>`
+}
+
+function renderDefinitions(definitions: DefinitionRow[] | undefined): string {
+  // Definitions ALWAYS go last (Rule 1). The scoring-concepts paragraph is the
+  // canonical glossary; per-belief term definitions append below it.
+  const terms =
+    definitions && definitions.length > 0
+      ? definitions
+          .map((d) => `<p><strong>${esc(d.term)}:</strong> ${esc(d.definition)}</p>`)
+          .join('\n')
+      : ''
+  return `<h2>&nbsp;</h2>
+<h1>&#x1F4D6; Definitions and Scoring Concepts</h1>
+<p><strong>Arguments vs. Evidence:</strong> Arguments are logical claims, scored by logical validity and linkage strength. Evidence is empirical data, scored by source tier and conclusion relevance. Argument Score = Evidence Quality x Logical Validity x Linkage Strength.</p>
+<p><strong>Truth / Importance / Linkage:</strong> Truth is the child belief's own net score. Importance weights how much the argument moves the needle (and can itself be sourced from a sub-belief). Linkage measures whether the reason actually connects to the conclusion. Impact = Truth x Importance x Linkage.</p>
+<p><strong>Evidence Tiers:</strong> T1 = peer-reviewed / official data. T2 = expert analysis / institutional reports. T3 = investigative journalism / surveys. T4 = opinion / anecdotal.</p>
+${terms}`
+}
+
+// ─── Page renderers ───────────────────────────────────────────────
+
+/** Render a full belief page from the canonical template. */
+export function renderBeliefHtml(input: BeliefHtmlInput): string {
+  const mode = input.linkMode ?? 'file'
+  const proArgs = input.args.filter((a) => a.side === 'agree')
+  const conArgs = input.args.filter((a) => a.side === 'disagree')
+
+  const topic =
+    input.category || input.subcategory
+      ? `${esc(input.category ?? '')}${input.subcategory ? ` &gt; ${esc(input.subcategory)}` : ''}`
+      : ''
+
+  return `<!-- page=belief_${input.slug} -->
+<!-- content-type=text/html -->
+<!-- Generated from the ISE canonical belief template. DB is the source of truth. -->
+<div style="font-family:'Segoe UI', Arial, sans-serif; max-width:960px; margin:0 auto;">
+
+<h1>${esc(input.statement)}</h1>
+<p>
+  <strong>Score:</strong> ${scoreCell(fmtNet(input.netScore), null) || '<em style="color:#888;">[pending]</em>'} (computed from sub-argument scores)<br />
+  <strong>Topic:</strong> ${topic || '<em style="color:#888;">[unclassified]</em>'}
+</p>
+
+${renderSupports(input.supports, mode)}
+
+<h2>&nbsp;</h2>
+<h1>&#x1F50D; Argument Trees</h1>
+<p>Each label is a logical claim with its own page. Truth, Importance, and Linkage are links to the pages that source each score. No data citations live here - those belong in the Evidence Ledger.</p>
+${renderArgumentTable(proArgs, '&#x2705; Reasons to Agree', '#eafaf0', mode)}
+${renderArgumentTable(conArgs, '&#x274C; Reasons to Disagree', '#fdeeee', mode)}
+
+${renderEvidence(input.evidence)}
+${renderCriteria(input.objectiveCriteria)}
+${renderDefinitions(input.definitions)}
+
+<h2>&nbsp;</h2>
+<h1>&#x1F52C; Contribute</h1>
+<p><strong>Contact</strong> to add arguments, evidence, images, or video. | <strong>GitHub</strong> for scoring algorithms and technical documentation.</p>
+
+</div>`
+}
+
+// ─── Linkage Score Analysis page ──────────────────────────────────
+
+export interface LinkageSubArg {
+  side: 'agree' | 'disagree' // agree = the link IS valid
+  statement: string
+  strength: number // 0..1
+}
+
+export interface LinkageHtmlInput {
+  argumentId: number
+  /** The atomic argument label (the reason). */
+  argumentLabel: string
+  /** The conclusion this reason is claimed to support. */
+  parentStatement: string
+  parentSlug?: string | null
+  /** The child belief that IS the reason. */
+  childStatement: string
+  childSlug?: string | null
+  linkageScore: number // 0..1
+  subArguments: LinkageSubArg[]
+  linkMode?: 'file' | 'route'
+}
+
+/** Render the "Linkage Score Analysis" page for one argument edge. */
+export function renderLinkageHtml(input: LinkageHtmlInput): string {
+  const mode = input.linkMode ?? 'file'
+  const agree = input.subArguments.filter((s) => s.side === 'agree')
+  const disagree = input.subArguments.filter((s) => s.side === 'disagree')
+
+  const subRows = (rows: LinkageSubArg[]) =>
+    rows.length === 0
+      ? `<tr><td style="${TD}"><em style="color:#888;">None yet.</em></td><td style="${TD} ${CENTER}"></td></tr>`
+      : rows
+          .map(
+            (r) => `  <tr>
+    <td style="${TD}">${esc(r.statement)}</td>
+    <td style="${TD} ${CENTER}">${fmtPct(r.strength)}</td>
+  </tr>`,
+          )
+          .join('\n')
+
+  const parent = input.parentSlug
+    ? `<a href="${beliefHref(input.parentSlug, mode)}" style="color:#1a5fb4; text-decoration:none;">${esc(input.parentStatement)}</a>`
+    : esc(input.parentStatement)
+  const child = input.childSlug
+    ? `<a href="${beliefHref(input.childSlug, mode)}" style="color:#1a5fb4; text-decoration:none;">${esc(input.childStatement)}</a>`
+    : esc(input.childStatement)
+
+  return `<!-- page=linkage_${input.argumentId} -->
+<!-- content-type=text/html -->
+<!-- Linkage Score Analysis, generated from the DB. -->
+<div style="font-family:'Segoe UI', Arial, sans-serif; max-width:960px; margin:0 auto;">
+
+<h1>Linkage Score Analysis</h1>
+<p style="font-size:115%;">Does <strong>${esc(input.argumentLabel)}</strong> actually support the conclusion?</p>
+
+<div style="background-color:#eef6ff; border:1px solid #b0c4de; border-radius:6px; padding:10px 14px; margin-bottom:16px;">
+  <strong>Reason:</strong> ${child}<br />
+  <strong>Supports conclusion:</strong> ${parent}<br />
+  <strong>Linkage Score:</strong> ${fmtPct(input.linkageScore)} (from the sub-debate below)
+</div>
+
+<p>The linkage sub-debate scores whether the reason connects to the conclusion: Linkage = A / (A + D), where A and D are the strengths of the arguments that the link is valid versus invalid.</p>
+
+<h3>&#x2705; The link IS valid</h3>
+<table style="${TABLE}">
+<thead><tr><th style="${TH}">Argument</th><th style="${TH} ${CENTER}">Strength</th></tr></thead>
+<tbody>
+${subRows(agree)}
+</tbody>
+</table>
+
+<h3>&#x274C; The link is NOT valid</h3>
+<table style="${TABLE}">
+<thead><tr><th style="${TH}">Argument</th><th style="${TH} ${CENTER}">Strength</th></tr></thead>
+<tbody>
+${subRows(disagree)}
+</tbody>
+</table>
+
+</div>`
+}

--- a/src/lib/html-generator/from-belief.ts
+++ b/src/lib/html-generator/from-belief.ts
@@ -1,0 +1,77 @@
+/**
+ * Adapter: map a live Belief row (with relations) into the pure HTML
+ * generator's BeliefHtmlInput. The DB is the source of truth; this is the
+ * only place that knows how DB fields map onto the canonical template.
+ *
+ * Pure mapping (no DB calls) so it is unit-testable. The publish script
+ * (scripts/generate-belief-html.ts) does the fetching and passes the rows in,
+ * including the parent arguments used to build the "Supports:" backlinks.
+ */
+
+import type { BeliefWithRelations } from '@/features/belief-analysis/types'
+import { computeBeliefScores } from '@/features/belief-analysis/data/fetch-belief'
+import type { BeliefHtmlInput, ArgRow, SupportsBacklink } from './belief-html'
+
+/** A parent edge: an argument on some OTHER belief that uses this belief as its reason. */
+export interface ParentEdge {
+  parentStatement: string
+  parentSlug: string | null
+  argumentLabel: string | null
+}
+
+export interface FromBeliefOptions {
+  parents?: ParentEdge[]
+  linkMode?: 'file' | 'route'
+}
+
+export function beliefToHtmlInput(
+  belief: BeliefWithRelations,
+  opts: FromBeliefOptions = {},
+): BeliefHtmlInput {
+  const scores = computeBeliefScores(belief)
+
+  const args: ArgRow[] = belief.arguments.map((a) => ({
+    label: a.belief.statement,
+    side: a.side === 'disagree' ? 'disagree' : 'agree',
+    childSlug: a.belief.slug,
+    // Truth column shows the child belief's net score (positivity, -100..+100).
+    truthScore: a.belief.positivity,
+    importanceScore: a.importanceScore,
+    importanceSlug: a.importanceBelief?.slug ?? null,
+    linkageScore: a.linkageScore,
+    argumentId: a.id,
+    // impactScore is 0 by default in the DB; treat a true zero as "pending"
+    // so unscored edges don't render a misleading +0 (Rule 6).
+    impactScore: a.impactScore === 0 ? null : a.impactScore,
+  }))
+
+  const supports: SupportsBacklink[] = (opts.parents ?? []).map((p) => ({
+    parentStatement: p.parentStatement,
+    parentSlug: p.parentSlug,
+    argumentLabel: p.argumentLabel,
+  }))
+
+  return {
+    slug: belief.slug,
+    statement: belief.statement,
+    category: belief.category,
+    subcategory: belief.subcategory,
+    netScore: scores.overallScore,
+    args,
+    evidence: belief.evidence.map((e) => ({
+      tier: e.evidenceType,
+      source: e.description,
+      stance: e.side === 'weakening' ? 'Weakens' : 'Supports',
+      bearsOn: '',
+      linkage: null,
+    })),
+    objectiveCriteria: belief.objectiveCriteria.map((c) => ({
+      criterion: c.description,
+      currentStatus: c.currentStatus ?? null,
+      threshold: c.thresholdForAgreement ?? null,
+    })),
+    definitions: belief.definitions.map((d) => ({ term: d.term, definition: d.definition })),
+    supports,
+    linkMode: opts.linkMode,
+  }
+}

--- a/tests/unit/lib/belief-html.test.ts
+++ b/tests/unit/lib/belief-html.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the canonical belief HTML generator.
+ *
+ * These lock in the non-negotiable rules from docs/BELIEF_PAGE_RULES.md:
+ * definitions last, Truth/Importance/Linkage score cells as links to their
+ * source pages, plain text (never a broken link) when a page is absent,
+ * [pending] for unpopulated scores, no href="#", no em dashes.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  renderBeliefHtml,
+  renderLinkageHtml,
+  esc,
+  type BeliefHtmlInput,
+} from '../../../src/lib/html-generator/belief-html'
+
+const base: BeliefHtmlInput = {
+  slug: 'ranked-choice-voting',
+  statement: 'Adopt ranked-choice voting',
+  category: 'Politics',
+  subcategory: 'Electoral Reform',
+  netScore: 41,
+  args: [
+    {
+      label: 'eliminates spoiler effect',
+      side: 'agree',
+      childSlug: 'rcv-eliminates-spoiler-effect',
+      truthScore: 72,
+      importanceScore: 0.75,
+      importanceSlug: 'spoiler-effect-major-problem',
+      linkageScore: 0.9,
+      argumentId: 1,
+      impactScore: 48.6,
+    },
+    {
+      label: 'voter confusion',
+      side: 'disagree',
+      childSlug: null,
+      truthScore: null,
+      importanceScore: 0.4,
+      linkageScore: 0.45,
+      argumentId: null,
+      impactScore: null,
+    },
+  ],
+  definitions: [{ term: 'Spoiler effect', definition: 'a minor candidate flips the outcome.' }],
+}
+
+describe('renderBeliefHtml', () => {
+  const html = renderBeliefHtml(base)
+
+  it('renders the belief statement as the H1', () => {
+    expect(html).toContain('<h1>Adopt ranked-choice voting</h1>')
+  })
+
+  it('places Definitions LAST, after Argument Trees (Rule 1)', () => {
+    const argIdx = html.indexOf('Argument Trees')
+    const defIdx = html.indexOf('Definitions and Scoring Concepts')
+    expect(argIdx).toBeGreaterThan(-1)
+    expect(defIdx).toBeGreaterThan(argIdx)
+  })
+
+  it('has no summary/background before the argument trees (Rule 2)', () => {
+    const head = html.slice(0, html.indexOf('Argument Trees'))
+    expect(head).not.toMatch(/background|summary|overview/i)
+  })
+
+  it('links the Truth cell to the child belief page', () => {
+    expect(html).toContain('href="belief_rcv-eliminates-spoiler-effect.html"')
+    expect(html).toContain('>+72</a>')
+  })
+
+  it('links the Importance cell to the importance sub-belief page', () => {
+    expect(html).toContain('href="belief_spoiler-effect-major-problem.html"')
+    expect(html).toContain('>75%</a>')
+  })
+
+  it('links the Linkage cell to the argument linkage page', () => {
+    expect(html).toContain('href="linkage_1.html"')
+    expect(html).toContain('>90%</a>')
+  })
+
+  it('renders plain text (not a link) when a score page is absent (Rule 5)', () => {
+    // "voter confusion" has importance 0.4 but no importance page -> plain 40%.
+    expect(html).toContain('>40%</td>')
+    expect(html).not.toContain('linkage_2.html')
+  })
+
+  it('uses [pending] for unpopulated scores, never +0 (Rule 6)', () => {
+    expect(html).toContain('[pending]')
+    expect(html).not.toContain('>+0<')
+  })
+
+  it('never emits href="#" or internal anchors (Rule 5)', () => {
+    expect(html).not.toContain('href="#"')
+    expect(html).not.toMatch(/href="#[^"]*"/)
+  })
+
+  it('contains no em dashes', () => {
+    expect(html).not.toContain('—')
+  })
+
+  it('renders Truth, Importance, and Linkage column headers', () => {
+    expect(html).toContain('>Truth<')
+    expect(html).toContain('>Importance<')
+    expect(html).toContain('>Linkage<')
+  })
+
+  it('renders a Supports backlink when provided', () => {
+    const child = renderBeliefHtml({
+      ...base,
+      slug: 'rcv-eliminates-spoiler-effect',
+      statement: 'RCV eliminates the spoiler effect',
+      supports: [
+        { parentStatement: 'Adopt ranked-choice voting', parentSlug: 'ranked-choice-voting', argumentLabel: 'eliminates spoiler effect' },
+      ],
+    })
+    expect(child).toContain('Supports:')
+    expect(child).toContain('href="belief_ranked-choice-voting.html"')
+  })
+
+  it('supports route link mode for the live app', () => {
+    const routed = renderBeliefHtml({ ...base, linkMode: 'route' })
+    expect(routed).toContain('href="/beliefs/rcv-eliminates-spoiler-effect"')
+    expect(routed).toContain('href="/arguments/1/linkage"')
+  })
+})
+
+describe('renderLinkageHtml', () => {
+  const html = renderLinkageHtml({
+    argumentId: 1,
+    argumentLabel: 'eliminates spoiler effect',
+    parentStatement: 'Adopt ranked-choice voting',
+    parentSlug: 'ranked-choice-voting',
+    childStatement: 'RCV eliminates the spoiler effect',
+    childSlug: 'rcv-eliminates-spoiler-effect',
+    linkageScore: 0.9,
+    subArguments: [
+      { side: 'agree', statement: 'Direct mechanism', strength: 1.0 },
+      { side: 'disagree', statement: 'Only when a spoiler exists', strength: 0.2 },
+    ],
+  })
+
+  it('shows the linkage score and both sub-debate sides', () => {
+    expect(html).toContain('Linkage Score Analysis')
+    expect(html).toContain('90%')
+    expect(html).toContain('Direct mechanism')
+    expect(html).toContain('Only when a spoiler exists')
+  })
+
+  it('backlinks to the parent and child belief pages', () => {
+    expect(html).toContain('href="belief_ranked-choice-voting.html"')
+    expect(html).toContain('href="belief_rcv-eliminates-spoiler-effect.html"')
+  })
+})
+
+describe('esc', () => {
+  it('escapes HTML and normalizes dashes', () => {
+    expect(esc('a & b <c> "d"')).toBe('a &amp; b &lt;c&gt; &quot;d&quot;')
+    const dashed = esc('one — two')
+    expect(dashed).not.toContain('—')
+    expect(dashed).toContain(' - ')
+  })
+})


### PR DESCRIPTION
**Stacked on #128** (uses the `importanceBelief` edge added there — set the base to `master` once #128 merges).

## What & why

The public ISE wiki pages are static HTML; the DB is the source of truth. This adds a generator that renders a `Belief` (and an argument's linkage sub-debate) into the **canonical belief template**, closing the "templates" half of the auto-scoring task — and ships a **worked example you can open in a browser** to review the layout.

## Generated worked example (open these)

`generated/belief-pages/` — open `index.html` and click through:
- `belief_ranked-choice-voting.html` — parent belief, scored Argument Trees
- `belief_rcv-eliminates-spoiler-effect.html` — the **Truth** child (with a `Supports:` backlink)
- `belief_spoiler-effect-major-problem.html` — the **Importance** child
- `linkage_1.html` — the Linkage Score Analysis sub-debate

All internal links are sibling files, so the set is self-navigable straight from disk. The Truth / Importance / Linkage cells are real links to their source pages.

## What's in it

- `src/lib/html-generator/belief-html.ts` — pure renderer (`input -> HTML string`) following `docs/BELIEF_PAGE_RULES.md` and `templates/belief-analysis-template.html`:
  - Definitions render **last** (Rule 1), no summary/background (Rule 2), atomic argument labels (Rule 3), evidence in its own ledger (Rule 4).
  - **Truth / Importance / Linkage score cells are links** to the child belief / importance sub-belief / linkage page; **plain text when the page is absent** (Rule 5); `[pending]` for unscored cells, never `+0` (Rule 6).
  - Inline styles only (PBworks strips CSS), no em dashes, no `href="#"`.
  - `Supports:` backlink block for child pages.
- `src/lib/html-generator/from-belief.ts` — pure adapter mapping a live `Belief` row into the renderer input.
- `scripts/generate-belief-html.ts` — publish step that renders live DB rows (`<slug>` or `--all`, `file` or `--route` link mode), one linkage page per argument edge. Mirrors the existing Blogger/PBworks publishers.
- `scripts/generate-sample-belief-pages.ts` + committed output. `npm run html:sample` / `npm run html:generate`.

## Verification
- `npx vitest run` → **197 passed** (+16 new generator tests). The only failing suite is the pre-existing `_archive/backend` mongoose test.
- New tests lock in the canonical rules (definitions last, score cells link, plain text when absent, no `href="#"`, no em dashes, route vs file link modes).
- Generated sample verified free of broken internal links, `href="#"`, and em dashes.
- `tsc` and `eslint` clean for all new files.

## Layout feedback welcome
The Argument Trees table currently shows **Label · Truth · Importance · Linkage · Impact**. If you want a different column set, ordering, or styling for the public pages, point at the worked-example files and I'll adjust the renderer.

https://claude.ai/code/session_01VLKmVjiyr7QxdUT8rBSZCa

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLKmVjiyr7QxdUT8rBSZCa)_