### PR TITLE
Restructure debate topic page: rename spectrums to continuums, add specificity ladder

### DIFF
--- a/prisma/migrations/20260606000000_add_common_ground_value_conflicts/migration.sql
+++ b/prisma/migrations/20260606000000_add_common_ground_value_conflicts/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+-- Add the "Real Value Conflicts" column to the Common Ground & Compromise section.
+ALTER TABLE "DebateCommonGround" ADD COLUMN "valueConflicts" TEXT NOT NULL DEFAULT '[]';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1132,8 +1132,9 @@ model DebateCommonGround {
   topic   DebateTopic @relation(fields: [topicId], references: [id], onDelete: Cascade)
 
   /// JSON arrays
-  agreements   String @default("[]")
-  compromises  String @default("[]")
+  agreements     String @default("[]")
+  valueConflicts String @default("[]")
+  compromises    String @default("[]")
 }
 
 /// One row in the Evidence Ledger (supporting or weakening).

--- a/prisma/seed-debate-topics.ts
+++ b/prisma/seed-debate-topics.ts
@@ -266,6 +266,11 @@ async function main() {
             'Relationship skills and conflict resolution improve outcomes regardless of legal structure',
             'High-conflict marriages are worse for children than stable single-parent households',
           ]),
+          valueConflicts: JSON.stringify([
+            'Individual autonomy to define family vs. the state privileging one family form for child welfare',
+            'Equal treatment of all household types vs. preserving marriage as a distinct cultural and legal category',
+            'Tradition and continuity vs. adapting institutions to how people actually live now',
+          ]),
           compromises: JSON.stringify([
             'Extend marriage legal benefits to all registered domestic partnerships while maintaining marriage as a distinct cultural category',
             'Focus public investment on relationship quality programs rather than marriage promotion per se',

--- a/src/app/debate-topics/[slug]/page.tsx
+++ b/src/app/debate-topics/[slug]/page.tsx
@@ -67,9 +67,24 @@ export default async function DebateTopicPage({ params }: Props) {
           controversyRating={topic.controversyRating}
         />
 
+        {/*
+          How this page deduplicates a debate. Every belief gets a coordinate on three
+          independent matching continuums — valence, magnitude, specificity. Engagement and
+          the assumption stack are deliberately NOT matching coordinates.
+        */}
+        <div className="bg-[#f4f9ff] border-l-4 border-[#0055a4] p-3 my-4 text-sm">
+          <strong>How this page deduplicates a debate.</strong> Every belief about this topic gets a coordinate on
+          three independent continuums: <strong>valence</strong> (which direction it runs), <strong>magnitude</strong>{' '}
+          (how absolute the claim is), and <strong>specificity</strong> (how general or concrete it is). Two beliefs
+          that land on the same coordinate are the <em>same claim</em> in different words and get merged. Two that land
+          nearly on top of each other get the redundancy discount: the second one contributes only its non-overlapping
+          fraction, because saying a thing five ways is not five reasons. That is the whole point of one page per topic.
+          The argument gets built once, here, instead of restarting from scratch on every forum.
+        </div>
+
         <hr className="my-6" />
 
-        {/* Spectrum 1: Debate Landscape */}
+        {/* Continuum 1: Valence */}
         {topic.positions.length > 0 && (
           <>
             <Spectrum1Positions positions={topic.positions} />
@@ -77,36 +92,28 @@ export default async function DebateTopicPage({ params }: Props) {
           </>
         )}
 
-        {/* Spectrum 2: Claim Magnitude */}
+        {/* Continuum 2: Claim Magnitude */}
         <Spectrum2Magnitude
           topicTitle={topic.title}
           claimMagnitudeLevels={topic.claimMagnitudeLevels}
         />
         <hr className="my-6" />
 
-        {/* Spectrum 3: Civic Engagement Level */}
-        {topic.escalationLevels.length > 0 && (
+        {/* Continuum 3: Specificity — the Abstraction Ladder */}
+        {topic.abstractionRungs.length > 0 && (
           <>
-            <Spectrum3Escalation escalationLevels={topic.escalationLevels} topicTitle={topic.title} />
+            <Spectrum4AbstractionLadder rungs={topic.abstractionRungs} topicTitle={topic.title} />
             <hr className="my-6" />
           </>
         )}
 
-        {/* Foundational Assumptions */}
+        {/* Assumption Stack Behind Each Position (a dependency map, not a continuum) */}
         {topic.assumptions.length > 0 && (
           <>
             <FoundationalAssumptions
               assumptions={topic.assumptions}
               keyInsight={topic.assumptionKeyInsight}
             />
-            <hr className="my-6" />
-          </>
-        )}
-
-        {/* Spectrum 4: Abstraction Ladder */}
-        {topic.abstractionRungs.length > 0 && (
-          <>
-            <Spectrum4AbstractionLadder rungs={topic.abstractionRungs} topicTitle={topic.title} />
             <hr className="my-6" />
           </>
         )}
@@ -119,7 +126,15 @@ export default async function DebateTopicPage({ params }: Props) {
           </>
         )}
 
-        {/* Common Ground */}
+        {/* The Engagement Landscape (a stakeholder map, not a matching continuum) */}
+        {topic.escalationLevels.length > 0 && (
+          <>
+            <Spectrum3Escalation escalationLevels={topic.escalationLevels} topicTitle={topic.title} />
+            <hr className="my-6" />
+          </>
+        )}
+
+        {/* Common Ground and Compromise */}
         {topic.commonGround && (
           <>
             <CommonGround commonGround={topic.commonGround} />

--- a/src/components/debate-topic/CommonGround.tsx
+++ b/src/components/debate-topic/CommonGround.tsx
@@ -5,17 +5,41 @@ interface Props {
 }
 
 export default function CommonGround({ commonGround }: Props) {
+  const valueConflicts = commonGround.valueConflicts ?? [];
+
   return (
     <div className="mb-8">
-      <h2 className="text-xl font-bold mb-3">
-        🤝 Common Ground &amp; Compromise
+      <h2 className="text-xl font-bold mb-1">
+        🤝 Common Ground and Compromise
       </h2>
+      <p className="text-sm text-gray-600 mb-3">
+        Once both sides&apos; costs and benefits are scored under Cost-Benefit Analysis, the same scored trees read
+        sideways and three things fall out automatically. This is the conflict readout, not an editor&apos;s guess at
+        where people might get along.
+      </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 w-1/2">What Both Sides Might Agree On</th>
-              <th className="border border-gray-300 px-3 py-2 w-1/2">Possible Compromise Positions</th>
+            <tr className="bg-gray-100 align-top">
+              <th className="border border-gray-300 px-3 py-2 w-1/3">
+                Shared Interests
+                <br />
+                <span className="text-xs font-normal text-gray-500">Impacts both sides actually want</span>
+              </th>
+              <th className="border border-gray-300 px-3 py-2 w-1/3">
+                Real Value Conflicts
+                <br />
+                <span className="text-xs font-normal text-gray-500">
+                  Where one side prices freedom and the other prices safety
+                </span>
+              </th>
+              <th className="border border-gray-300 px-3 py-2 w-1/3">
+                Compromise Candidates
+                <br />
+                <span className="text-xs font-normal text-gray-500">
+                  A small, achievable likelihood shift would flip a category&apos;s net
+                </span>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -28,6 +52,17 @@ export default function CommonGround({ commonGround }: Props) {
                 </ol>
               </td>
               <td className="border border-gray-300 px-3 py-3 align-top">
+                {valueConflicts.length > 0 ? (
+                  <ol className="list-decimal list-inside space-y-1">
+                    {valueConflicts.map((v, i) => (
+                      <li key={i}>{v}</li>
+                    ))}
+                  </ol>
+                ) : (
+                  <span className="text-gray-400 text-xs">None listed</span>
+                )}
+              </td>
+              <td className="border border-gray-300 px-3 py-3 align-top">
                 <ol className="list-decimal list-inside space-y-1">
                   {commonGround.compromises.map((c, i) => (
                     <li key={i}>{c}</li>
@@ -37,6 +72,12 @@ export default function CommonGround({ commonGround }: Props) {
             </tr>
           </tbody>
         </table>
+      </div>
+      <div className="bg-blue-50 p-3 border-l-4 border-blue-700 mt-3 text-xs">
+        <strong>Why this column matters:</strong> The Compromise Candidates are the winnable disagreements — the ones a
+        small shift in likelihood can actually flip — as opposed to the symbolic value conflicts that no negotiation
+        resolves. Pointing people at the tractable fights instead of the eternal ones is the payoff of scoring both
+        sides with equal rigor.
       </div>
     </div>
   );

--- a/src/components/debate-topic/CoreValuesConflict.tsx
+++ b/src/components/debate-topic/CoreValuesConflict.tsx
@@ -5,7 +5,7 @@ interface Props {
   topicTitle: string;
 }
 
-export default function CoreValuesConflict({ coreValues, topicTitle }: Props) {
+export default function CoreValuesConflict({ coreValues }: Props) {
   return (
     <div className="mb-8">
       <h2 className="text-xl font-bold mb-3">
@@ -16,10 +16,10 @@ export default function CoreValuesConflict({ coreValues, topicTitle }: Props) {
           <thead>
             <tr className="bg-gray-100">
               <th className="border border-gray-300 px-3 py-2 w-1/2">
-                Values Supporting {topicTitle} as a Privileged Institution
+                Values Supporting This Topic
               </th>
               <th className="border border-gray-300 px-3 py-2 w-1/2">
-                Values Opposing Legal/Policy Privilege for {topicTitle}
+                Values Opposing This Topic
               </th>
             </tr>
           </thead>
@@ -35,7 +35,7 @@ export default function CoreValuesConflict({ coreValues, topicTitle }: Props) {
                 {coreValues.supportingActual.length > 0 && (
                   <>
                     <br />
-                    <strong>Actual (critics say):</strong>
+                    <strong>Critics say the actual motivation is:</strong>
                     <ol className="list-decimal list-inside mt-1 space-y-1">
                       {coreValues.supportingActual.map((v, i) => (
                         <li key={i}>{v}</li>
@@ -54,7 +54,7 @@ export default function CoreValuesConflict({ coreValues, topicTitle }: Props) {
                 {coreValues.opposingActual.length > 0 && (
                   <>
                     <br />
-                    <strong>Actual (critics say):</strong>
+                    <strong>Critics say the actual motivation is:</strong>
                     <ol className="list-decimal list-inside mt-1 space-y-1">
                       {coreValues.opposingActual.map((v, i) => (
                         <li key={i}>{v}</li>

--- a/src/components/debate-topic/EvidenceLedger.tsx
+++ b/src/components/debate-topic/EvidenceLedger.tsx
@@ -19,7 +19,10 @@ export default function EvidenceLedger({ evidenceItems }: Props) {
     <div className="mb-8">
       <h2 className="text-xl font-bold mb-1">⚖️ The Evidence Ledger</h2>
       <p className="text-xs text-gray-600 mb-3">
-        Weighing the raw data. Quality scores based on methodology, sample size, and reproducibility.
+        Evidence formally attaches to specific beliefs, not to the topic as a whole, and is scored on its own page per
+        study. This ledger is the cross-topic highlight reel: the highest-impact evidence appearing anywhere under this
+        topic, so a reader sees the empirical state of play before diving into individual belief pages. Quality scores
+        reflect methodology, sample size, and reproducibility.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">

--- a/src/components/debate-topic/FoundationalAssumptions.tsx
+++ b/src/components/debate-topic/FoundationalAssumptions.tsx
@@ -17,19 +17,25 @@ export default function FoundationalAssumptions({ assumptions, keyInsight }: Pro
   return (
     <div className="mb-8">
       <h2 className="text-xl font-bold mb-1">
-        📜 Foundational Assumptions: What You Must Believe at Each Position
+        📜 Assumption Stack Behind Each Position
       </h2>
+      <p className="text-sm text-gray-600 mb-3">
+        This is not a fourth continuum. It is the dependency map sitting under the Continuum 1 positions above. It
+        answers a different question: to land at a given valence, what chain of assumptions do you have to accept, from
+        broadest worldview down to the narrowest topic-specific claim? Surfacing the stack is how a disagreement at the
+        bottom gets traced to its real root higher up, which is usually where the actual fight is.
+      </p>
       {keyInsight && (
         <p className="mb-3 text-sm">
-          <strong>Key Insight:</strong> {keyInsight}
+          <strong>Core split:</strong> {keyInsight}
         </p>
       )}
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 w-[18%]">To Hold Position</th>
-              <th className="border border-gray-300 px-3 py-2">You Must Believe These Assumptions (Ordered General → Specific)</th>
+              <th className="border border-gray-300 px-3 py-2 w-[15%]">To Hold Position</th>
+              <th className="border border-gray-300 px-3 py-2">You Must Accept These Assumptions (General to Specific)</th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/debate-topic/ObjectiveCriteriaTable.tsx
+++ b/src/components/debate-topic/ObjectiveCriteriaTable.tsx
@@ -30,11 +30,11 @@ export default function ObjectiveCriteriaTable({ criteria, topicTitle }: Props) 
         📏 Best Objective Criteria for Measuring Beliefs on {topicTitle}
       </h2>
       <p className="text-xs text-gray-600 mb-3">
-        Before debating whether {topicTitle.toLowerCase()} is good or bad, the ISE asks users to agree on <em>what good measurement looks like</em>. Each criterion below is itself a belief with its own page. Users submit reasons to agree or disagree that it is valid, reliable, and actually linked to the core question. Scores are calculated recursively — no editorial judgment required.
+        Before arguments about this topic can be scored, users first agree on <em>what good measurement looks like</em>. This section lists proposed criteria sorted by their community-assigned Objective Criteria Score. Each criterion is itself a belief with its own page: users submit reasons to agree or disagree that it is a valid, reliable, independent, and relevant measure. The scores below are calculated recursively from those sub-arguments — without manual ranking or editorial judgment.
       </p>
 
       <div className="bg-blue-50 border-l-4 border-blue-600 p-3 mb-3 text-xs">
-        <strong>How each criterion is scored:</strong>
+        <strong>How each criterion is scored across four dimensions:</strong>
         <ul className="mt-1 ml-4 list-disc space-y-1">
           <li><strong>Validity:</strong> Does this measure actually capture what we claim it captures?</li>
           <li><strong>Reliability:</strong> Can different observers measure it consistently?</li>

--- a/src/components/debate-topic/Spectrum1Positions.tsx
+++ b/src/components/debate-topic/Spectrum1Positions.tsx
@@ -18,15 +18,18 @@ function scoreColor(score: number): string {
 
 export default function Spectrum1Positions({ positions }: Props) {
   return (
-    <div className="mb-8">
+    <div id="valence" className="mb-8">
       <h2 className="text-xl font-bold mb-1">
-        📊 Spectrum 1: The Debate Landscape{' '}
-        <span className="text-base font-normal text-gray-600">(Negative ↔ Positive)</span>
+        📊 Continuum 1: Valence{' '}
+        <a href="/positive-to-negative" className="text-base font-normal text-blue-600 hover:underline">
+          (Negative ↔ Positive)
+        </a>
       </h2>
       <p className="text-sm text-gray-600 mb-4">
-        Maps the overall direction of a belief toward this topic, from total opposition (−100%) to total support (+100%).
-        This spectrum captures <em>direction only</em>. How extreme the phrasing is, and how many principles someone is
-        willing to violate to advance it, are separate dimensions measured in Spectrums 2 and 3.
+        Direction only, from total opposition (−100%) to total support (+100%). How extreme the phrasing is and how
+        concrete the claim is are separate dimensions, handled in Continuums 2 and 3. The <strong>Belief Score</strong>{' '}
+        in the last column is calculated from the linked pro and con sub-arguments. It is not the same thing as the
+        valence. A claim can sit at +100% (maximally supportive) and still score badly if its arguments are weak.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
@@ -67,7 +70,7 @@ export default function Spectrum1Positions({ positions }: Props) {
       <p className="text-right text-xs mt-2 text-gray-500">
         See: <a href="/positive-to-negative" className="text-blue-600 hover:underline">Full Positivity Framework</a>
         {' | '}
-        <a href="/positive-to-negative" className="text-blue-600 hover:underline">Why We Need This Spectrum</a>
+        <a href="/positive-to-negative" className="text-blue-600 hover:underline">Why We Need This Continuum</a>
       </p>
     </div>
   );

--- a/src/components/debate-topic/Spectrum2Magnitude.tsx
+++ b/src/components/debate-topic/Spectrum2Magnitude.tsx
@@ -1,50 +1,52 @@
 import type { DebateClaimMagnitude } from '@/core/types/debate-topic';
 
-// Generic fallback rows used when no DB-backed data is available for a topic
+// Generic fallback rows used when no DB-backed data is available for a topic.
+// Each row describes what a belief *sounds like* at that strength, on either side,
+// plus the telltale words that place it there.
 const GENERIC_MAGNITUDE_ROWS = [
   {
     sortOrder: 0,
     magnitudeLevel: 'Weak (20%)',
     magnitudePercent: 20,
-    sublabel: 'Modest Assertion',
+    sublabel: 'Modest',
     proExample: (topic: string) =>
-      `"${topic} has some advantages, though it has real flaws that need addressing."`,
+      `${topic} is somewhat good, openly admitting real flaws and exceptions.`,
     antiExample: (topic: string) =>
-      `"${topic} has some structural inefficiencies that make it less effective than alternatives in certain contexts."`,
-    scopeDescription: 'Narrow scope. Leaves room for exceptions and context-dependence.',
+      `${topic} is somewhat bad, while conceding it works acceptably much of the time.`,
+    scopeDescription: 'Narrow. Hedged with “some,” “tends to,” “in certain cases.”',
   },
   {
     sortOrder: 1,
     magnitudeLevel: 'Moderate (50%)',
     magnitudePercent: 50,
-    sublabel: 'Standard Assertion',
+    sublabel: 'Standard',
     proExample: (topic: string) =>
-      `"${topic}, when functioning well, produces significantly better outcomes than the available alternatives."`,
+      `${topic} is clearly better than the alternatives in most cases.`,
     antiExample: (topic: string) =>
-      `"${topic} is significantly compromised by specific structural flaws, producing reliably suboptimal outcomes."`,
-    scopeDescription: 'Clear claim without overstating. The level at which most serious academic arguments operate.',
+      `${topic} is clearly worse than the alternatives in most cases.`,
+    scopeDescription: 'Definite but bounded. “Clearly,” “generally,” “in most cases.” Where most serious arguments live.',
   },
   {
     sortOrder: 2,
     magnitudeLevel: 'Strong (80%)',
     magnitudePercent: 80,
-    sublabel: 'Broad Assertion',
+    sublabel: 'Broad',
     proExample: (topic: string) =>
-      `"${topic} is the only approach that provides the key benefits in question, and any alternative is fundamentally unjust or ineffective."`,
+      `${topic} is right across the board and the alternatives reliably fail.`,
     antiExample: (topic: string) =>
-      `"${topic} is fundamentally broken and cannot produce good outcomes without changes so drastic it would cease to be recognizable."`,
-    scopeDescription: 'Wide scope, absolute framing. Leaves little room for alternatives or incremental improvement.',
+      `${topic} is wrong across the board and fails wherever it is tried.`,
+    scopeDescription: 'Near-universal. “Across the board,” “fundamentally.” Little room for exceptions.',
   },
   {
     sortOrder: 3,
     magnitudeLevel: 'Extreme (100%)',
     magnitudePercent: 100,
-    sublabel: 'Maximal Assertion',
-    proExample: () =>
-      '"This is the pinnacle of human achievement in this domain and any deviation from it, however small, must be resisted by any means necessary."',
-    antiExample: () =>
-      '"This is a total fraud — a permanent mechanism of harm — that has never served its intended beneficiaries and never will."',
-    scopeDescription: 'Catastrophic framing with no limiting conditions. The hardest to defend and the easiest to dismiss without engaging the moderate arguments.',
+    sublabel: 'Maximal',
+    proExample: (topic: string) =>
+      `${topic} is always right, everywhere, with no legitimate exception.`,
+    antiExample: (topic: string) =>
+      `${topic} is always wrong, has never once worked and never will.`,
+    scopeDescription: 'Total, zero limiting conditions. “Always,” “never,” “no exception.” One counterexample sinks it.',
   },
 ];
 
@@ -60,29 +62,31 @@ export default function Spectrum2Magnitude({ topicTitle, claimMagnitudeLevels }:
   const hasDbData = claimMagnitudeLevels && claimMagnitudeLevels.length > 0;
 
   return (
-    <div className="mb-8">
+    <div id="magnitude" className="mb-8">
       <h2 className="text-xl font-bold mb-1">
-        💪 Spectrum 2: Claim Magnitude{' '}
+        💪 Continuum 2: Claim Magnitude{' '}
         <a href="/strong-to-weak" className="text-base font-normal text-blue-600 hover:underline">
           (Weak ↔ Strong)
         </a>
       </h2>
       <p className="text-sm text-gray-600 mb-4">
-        This spectrum captures how extreme or absolute the phrasing of a claim is, independent of whether it is true and
-        independent of which direction the claim runs. A weak pro-topic claim and a weak anti-topic claim are both modest
-        assertions — they just point in opposite directions. The <strong>Belief Score</strong>, calculated dynamically
-        from linked pro and con sub-arguments, separately indicates how well-supported any given claim actually is.
-        Spectrum 2 just identifies the structural magnitude of the assertion so that equivalent claims can be matched
-        and grouped correctly.
+        How absolute a belief is, independent of its truth and independent of which direction it runs. Magnitude is not
+        a new list of beliefs — it is a property carried by each belief already sitting in Continuum 1. This table
+        defines the strength scale and shows what a belief <em>sounds like</em> at each level, so any belief on the page
+        can be placed and so two beliefs at the same strength can be matched. A weak pro belief and a weak anti belief
+        are both modest; they just point in opposite directions. This axis measures the extremity of the{' '}
+        <em>claim</em>, not the extremity of anyone&apos;s commitment to acting on it — that is the{' '}
+        <a href="#engagement" className="text-blue-600 hover:underline">Engagement Landscape</a>, kept off the matching
+        coordinates. The <strong>Belief Score</strong> separately tells you how well-supported any given belief actually is.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 w-[18%]">Claim Magnitude</th>
-              <th className="border border-gray-300 px-3 py-2 w-[35%]">Pro-Topic Example</th>
-              <th className="border border-gray-300 px-3 py-2 w-[35%]">Anti-Topic Example</th>
-              <th className="border border-gray-300 px-3 py-2 w-[12%]">Scope</th>
+              <th className="border border-gray-300 px-3 py-2 w-[16%]">Claim Magnitude</th>
+              <th className="border border-gray-300 px-3 py-2 w-[32%]">Pro Belief at This Strength</th>
+              <th className="border border-gray-300 px-3 py-2 w-[32%]">Anti Belief at This Strength</th>
+              <th className="border border-gray-300 px-3 py-2 w-[20%]">Scope &amp; Telltale Words</th>
             </tr>
           </thead>
           <tbody>
@@ -112,10 +116,10 @@ export default function Spectrum2Magnitude({ topicTitle, claimMagnitudeLevels }:
                       <br />
                       <span className="text-xs font-normal text-gray-600">{row.sublabel}</span>
                     </td>
-                    <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">
+                    <td className="border border-gray-300 px-3 py-2 text-gray-700">
                       {row.proExample(lower)}
                     </td>
-                    <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">
+                    <td className="border border-gray-300 px-3 py-2 text-gray-700">
                       {row.antiExample(lower)}
                     </td>
                     <td className="border border-gray-300 px-3 py-2 text-gray-600 text-xs">
@@ -132,7 +136,7 @@ export default function Spectrum2Magnitude({ topicTitle, claimMagnitudeLevels }:
         man. The ISE requires engaging with the best version of the opposing argument, not the loudest one.
       </div>
       <p className="text-right text-xs mt-2 text-gray-500">
-        See: <a href="/strong-to-weak" className="text-blue-600 hover:underline">Why We Need This Spectrum</a>
+        See: <a href="/strong-to-weak" className="text-blue-600 hover:underline">Why We Need This Continuum</a>
       </p>
     </div>
   );

--- a/src/components/debate-topic/Spectrum3Escalation.tsx
+++ b/src/components/debate-topic/Spectrum3Escalation.tsx
@@ -21,19 +21,22 @@ export default function Spectrum3Escalation({ escalationLevels, topicTitle }: Pr
   );
 
   return (
-    <div className="mb-8">
+    <div id="engagement" className="mb-8">
       <h2 className="text-xl font-bold mb-1">
-        ⚡ Spectrum 3: Civic Engagement Level{' '}
+        ⚡ The Engagement Landscape{' '}
         <a href="/escalation-spectrum" className="text-base font-normal text-blue-600 hover:underline">
           (Passive ↔ Active)
         </a>
       </h2>
       <p className="text-sm text-gray-600 mb-4">
-        This captures how actively someone is willing to act on their position — not how extreme their
-        belief is (Spectrum 2) or which direction it runs (Spectrum 1). Two people can hold identical
-        beliefs at identical magnitudes and still differ enormously in how much they are willing to
-        sacrifice to advance them. Mapping this dimension separately prevents the ISE from conflating
-        conviction with action, and action with extremism.
+        <strong>This is a stakeholder map, not a matching continuum.</strong> It answers the second half of &ldquo;how
+        extreme is this?&rdquo;: not how absolute the belief is (that is{' '}
+        <a href="#magnitude" className="text-blue-600 hover:underline">Claim Magnitude</a>) but how far a person will go
+        to act on it. That is a fact about the person, not about the belief. A casual supporter and someone willing to
+        go to prison hold the <em>same belief</em> about this topic, so engagement deliberately does <em>not</em> feed
+        the belief-matching coordinates above. Two identical beliefs at different engagement levels stay one belief on
+        this page. Keeping this axis separate is what stops the system from confusing a loud claim with a committed
+        person, or commitment with extremism.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
@@ -102,20 +105,13 @@ export default function Spectrum3Escalation({ escalationLevels, topicTitle }: Pr
         </table>
       </div>
       <p className="text-sm text-gray-600 mt-3">
-        <strong>Key insight:</strong> The three spectrums are fully independent. Someone can hold a
-        moderate-magnitude claim (Spectrum 2 = 50%) about a cause they feel lukewarm about
-        (Spectrum 1 = +40%) and still be willing to go to prison for it (Spectrum 3 = Level 4).
-        Plotting a coordinate on each spectrum is what lets the system match beliefs accurately rather
-        than bundling very different positions together.{' '}
-        {escalationLevels.length > 4 && (
-          <>
-            For engagement beyond Level 4, see:{' '}
-            <a href="/escalation-spectrum" className="text-blue-600 hover:underline">Escalation Spectrum</a>.
-          </>
-        )}
+        <strong>Key insight:</strong> Engagement is fully independent of the three matching continuums. Someone can hold
+        a moderate-magnitude claim (Continuum 2 = 50%) about a cause they feel lukewarm toward (Continuum 1 = +40%) and
+        still be willing to go to prison for it (Engagement Level 4). For engagement beyond Level 4, see:{' '}
+        <a href="/escalation-spectrum" className="text-blue-600 hover:underline">Escalation Spectrum</a>.
       </p>
       <p className="text-right text-xs mt-2 text-gray-500">
-        See: <a href="/escalation-spectrum" className="text-blue-600 hover:underline">Escalation Spectrum Full Explanation</a>
+        <a href="/w/page/21956745/American%20values" className="text-blue-600 hover:underline">Core Values Framework</a>
       </p>
     </div>
   );

--- a/src/components/debate-topic/Spectrum4AbstractionLadder.tsx
+++ b/src/components/debate-topic/Spectrum4AbstractionLadder.tsx
@@ -7,21 +7,27 @@ interface Props {
 
 export default function Spectrum4AbstractionLadder({ rungs, topicTitle }: Props) {
   return (
-    <div className="mb-8">
+    <div id="specificity" className="mb-8">
       <h2 className="text-xl font-bold mb-1">
-        🪜 Spectrum 4: The Abstraction Ladder{' '}
-        <span className="text-base font-normal text-gray-600">(General ↔ Specific)</span>
+        🧩 Continuum 3: Specificity, the Abstraction Ladder{' '}
+        <a href="/general-to-specific" className="text-base font-normal text-blue-600 hover:underline">
+          (General ↔ Specific)
+        </a>
       </h2>
       <p className="text-sm text-gray-600 mb-4">
-        Shows how general worldviews cascade into specific positions on {topicTitle.toLowerCase()} policy.
+        How concrete a claim is. The same topic supports claims at very different altitudes, from a sweeping worldview
+        down to a single line-item policy, and these are genuinely different claims that need separate scoring. Two
+        people can agree at the top of the ladder and split at the bottom, or disagree about first principles and still
+        converge on the same specific reform. Mapping the rungs is what lets the engine match a broad principle to a
+        broad principle without falsely merging it with a narrow policy that happens to lean the same direction.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 w-[18%]">Level</th>
-              <th className="border border-gray-300 px-3 py-2 w-[41%]">Pro-{topicTitle} Assumption Chain</th>
-              <th className="border border-gray-300 px-3 py-2 w-[41%]">Skeptical/Anti-{topicTitle} Assumption Chain</th>
+              <th className="border border-gray-300 px-3 py-2 w-[15%]">Rung</th>
+              <th className="border border-gray-300 px-3 py-2 w-[42%]">Pro-{topicTitle} Chain</th>
+              <th className="border border-gray-300 px-3 py-2 w-[43%]">Anti-{topicTitle} Chain</th>
             </tr>
           </thead>
           <tbody>

--- a/src/core/types/debate-topic.ts
+++ b/src/core/types/debate-topic.ts
@@ -67,7 +67,12 @@ export interface DebateCoreValues {
 }
 
 export interface DebateCommonGround {
+  /// "Shared Interests" — impacts both sides actually want
   agreements: string[];
+  /// "Real Value Conflicts" — where one side prices freedom and the other prices safety.
+  /// Optional so topics seeded before this column existed still render.
+  valueConflicts?: string[];
+  /// "Compromise Candidates" — a small likelihood shift would flip a category's net
   compromises: string[];
 }
 

--- a/src/features/debate-topics/ai-generator.ts
+++ b/src/features/debate-topics/ai-generator.ts
@@ -236,8 +236,9 @@ Return a single valid JSON object matching this exact structure (all fields requ
     "opposingActual": ["1. Value name — what critics say", "2. ..."]
   },
   "commonGround": {
-    "agreements": ["1. ...", "2. ...", "3. ...", "4. ..."],
-    "compromises": ["1. ...", "2. ...", "3. ...", "4. ..."]
+    "agreements": ["1. shared interest both sides want", "2. ...", "3. ..."],
+    "valueConflicts": ["1. genuine value tradeoff no negotiation resolves", "2. ...", "3. ..."],
+    "compromises": ["1. winnable change that flips a category's net", "2. ...", "3. ..."]
   },
   "evidenceItems": [
     {

--- a/src/features/debate-topics/db.ts
+++ b/src/features/debate-topics/db.ts
@@ -109,6 +109,7 @@ function mapTopicFromDb(row: any): DebateTopic {
     const cg = row.commonGround;
     commonGround = {
       agreements: parseJson<string[]>(cg.agreements, []),
+      valueConflicts: parseJson<string[]>(cg.valueConflicts, []),
       compromises: parseJson<string[]>(cg.compromises, []),
     };
   }
@@ -311,6 +312,7 @@ export async function createDebateTopic(data: DebateTopic): Promise<DebateTopic>
             commonGround: {
               create: {
                 agreements: JSON.stringify(data.commonGround.agreements),
+                valueConflicts: JSON.stringify(data.commonGround.valueConflicts ?? []),
                 compromises: JSON.stringify(data.commonGround.compromises),
               },
             },

--- a/templates/topic-template.html
+++ b/templates/topic-template.html
@@ -96,203 +96,396 @@
     <div id="wikipage" class="box wikistyle">
 
     <div style="" id="wikipage-inner">
-    <h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;text-align:right;"><a style="font-size:13px;" href="/w/page/21957696/Colorado%20Should">Home</a><span style="font-size:13px;"> › </span><a style="font-size:13px;" href="/w/page/159323433/One%20Page%20Per%20Topic">Topics</a><span style="font-size:13px;"> › </span><strong style="font-family:inherit;font-style:inherit;">[Category] &gt; [Topic Name]</strong></h2>
-<div style="font-family:'Segoe UI', Arial, sans-serif;line-height:1.6;color:#333;">
+<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold; text-align: right;"><a style="font-size: 13px;" href="/w/page/21957696/Colorado%20Should">Home</a><span style="font-size: 13px;"> &rsaquo; </span><a style="font-size: 13px;" href="/w/page/159323433/One%20Page%20Per%20Topic">Topics</a><span style="font-size: 13px;"> &rsaquo; </span><strong style="font-family: inherit; font-style: inherit;">[Category] &gt; [Topic Name]</strong></h2>
+<div style="font-family: 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #333;">
 <h1>Topic: [Topic Name]</h1>
-<p style="font-size:13px;"><strong>Definition:</strong> [Neutral, objective definition of the topic].<br /><strong>Scope:</strong> [What is included in this topic vs. what belongs in related topics].</p>
-<div style="border:1px solid #ccc;padding:10px;background-color:#f9f9f9;">
-<p style="text-align:center;margin:0;"><strong>Topic Metrics</strong><br /><a href="/w/page/162731388/Importance%20Score">Importance</a>: <strong>[0-100]</strong> | <a href="/w/page/159353568/Evidence%20Scores">Evidence Depth</a>: <strong>[Low/Med/High]</strong> | <a href="/w/page/159300543/ReasonRank">Controversy Rating</a>: <strong>[0-100]</strong></p>
+<p style="font-size: 13px;"><strong>Definition:</strong> [Neutral, objective definition of the topic].<br /><strong>Scope:</strong> [What is included in this topic vs. what belongs in related topics].</p>
+<div style="border: 1px solid #ccc; padding: 10px; background-color: #f9f9f9;">
+<p style="text-align: center; margin: 0;"><strong>Topic Metrics</strong><br /><a href="/w/page/162731388/Importance%20Score">Importance</a>: <strong>[0-100]</strong> | <a href="/w/page/159353568/Evidence%20Scores">Evidence Depth</a>: <strong>[Low/Med/High]</strong> | <a href="/w/page/159300543/ReasonRank">Controversy</a>: <strong>[0-100]</strong></p>
 </div>
-<hr /><h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;">📊 Spectrum 1: The Debate Landscape (<a href="/positive%20to%20negative">Negative ↔ Positive</a>)</h2>
-<p style="font-size:13px;">Maps the overall direction of a belief toward the topic, from total opposition (-100%) to total support (+100%). This spectrum captures <em>direction only</em>. How extreme the phrasing of the claim is, and how many principles someone is willing to violate to advance it, are separate dimensions measured in Spectrums 2 and 3. By plotting a percentage on each of the three spectrums, we can accurately match and organize beliefs that are saying the same thing.</p>
-<table style="border-collapse:collapse;width:100%;margin-bottom:2em;" border="1" cellpadding="8"><thead><tr style="background-color:#f0f3f6;"><th width="12%">Position</th> <th width="55%">Core Belief / Claim</th> <th width="25%">Top Underlying Argument</th> <th width="8%">Belief Score</th>
-</tr></thead><tbody><tr><td style="background-color:#ffcccc;text-align:center;"><strong>-100%</strong><br />(Strongly Oppose)</td>
+<hr />
+
+<div style="background-color: #f4f9ff; padding: 12px; border-left: 4px solid #0055a4; margin: 15px 0; font-size: 13px;"><strong>How this page deduplicates a debate.</strong> Every belief about this topic gets a coordinate on three independent continuums: <strong>valence</strong> (which direction it runs), <strong>magnitude</strong> (how absolute the claim is), and <strong>specificity</strong> (how general or concrete it is). Two beliefs that land on the same coordinate are the <em>same claim</em> in different words and get merged. Two that land nearly on top of each other get the <a href="/w/page/159300543/ReasonRank">redundancy discount</a>: the second one contributes only its non-overlapping fraction, because saying a thing five ways is not five reasons. That is the whole point of one page per topic. The argument gets built once, here, instead of restarting from scratch on every forum.</div>
+
+<h2 id="valence" style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#128202; Continuum 1: Valence (<a href="/positive%20to%20negative">Negative &harr; Positive</a>)</h2>
+<p style="font-size: 13px;">Direction only, from total opposition (-100%) to total support (+100%). How extreme the phrasing is and how concrete the claim is are separate dimensions, handled in Continuums 2 and 3. The <strong>Belief Score</strong> in the last column is calculated from the linked pro and con sub-arguments. It is not the same thing as the valence. A claim can sit at +100% (maximally supportive) and still score badly if its arguments are weak.</p>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="12%">Position</th> <th width="55%">Core Belief / Claim</th> <th width="25%">Top Underlying Argument</th> <th width="8%">Belief Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="background-color: #ffcccc; text-align: center;"><strong>-100%</strong><br />(Strongly Oppose)</td>
 <td>[Belief that the topic is fundamentally harmful or false]</td>
 <td>[Primary reason, e.g., "Violates human rights"]</td>
-<td align="center"><span style="color:#d32f2f;font-weight:bold;">[-XX]</span></td>
-</tr><tr><td style="background-color:#ffe6e6;text-align:center;"><strong>-50%</strong><br />(Skeptical)</td>
+<td align="center"><span style="color: #d32f2f; font-weight: bold;">[-XX]</span></td>
+</tr>
+<tr>
+<td style="background-color: #ffe6e6; text-align: center;"><strong>-50%</strong><br />(Skeptical)</td>
 <td>[Belief that the topic has significant flaws or costs]</td>
 <td>[Primary reason, e.g., "Too expensive"]</td>
-<td align="center"><span style="color:#d32f2f;font-weight:bold;">[-XX]</span></td>
-</tr><tr><td style="background-color:#ffffcc;text-align:center;"><strong>0%</strong><br />(Neutral/Nuanced)</td>
+<td align="center"><span style="color: #d32f2f; font-weight: bold;">[-XX]</span></td>
+</tr>
+<tr>
+<td style="background-color: #ffffcc; text-align: center;"><strong>0%</strong><br />(Neutral/Nuanced)</td>
 <td>[Belief that the topic is complex or context-dependent]</td>
 <td>[Primary reason, e.g., "Depends on implementation"]</td>
 <td align="center"><strong>[0]</strong></td>
-</tr><tr><td style="background-color:#e6ffe6;text-align:center;"><strong>+50%</strong><br />(Supportive)</td>
+</tr>
+<tr>
+<td style="background-color: #e6ffe6; text-align: center;"><strong>+50%</strong><br />(Supportive)</td>
 <td>[Belief that the topic is generally beneficial]</td>
 <td>[Primary reason, e.g., "Solves specific problem"]</td>
-<td align="center"><span style="color:#2e7d32;font-weight:bold;">[+XX]</span></td>
-</tr><tr><td style="background-color:#ccffcc;text-align:center;"><strong>+100%</strong><br />(Strongly Support)</td>
+<td align="center"><span style="color: #2e7d32; font-weight: bold;">[+XX]</span></td>
+</tr>
+<tr>
+<td style="background-color: #ccffcc; text-align: center;"><strong>+100%</strong><br />(Strongly Support)</td>
 <td>[Belief that the topic is essential or a moral imperative]</td>
 <td>[Primary reason, e.g., "Saves lives"]</td>
-<td align="center"><span style="color:#2e7d32;font-weight:bold;">[+XX]</span></td>
-</tr></tbody></table><p style="text-align:right;font-style:italic;">See: <a href="/w/page/162417909/beliefs%20grouped">Full Positivity Framework</a> | <a href="/positive%20to%20negative">Why We Need This Spectrum</a></p>
-<hr /><h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;">💪 Spectrum 2: Claim Magnitude (<a href="/strong%20to%20weak">Weak ↔ Strong</a>)</h2>
-<p style="font-size:13px;">This spectrum captures how extreme or absolute the phrasing of a claim is, independent of whether it is true and independent of which direction the claim runs. A weak pro-topic claim and a weak anti-topic claim are both modest assertions -- they just point in opposite directions. The <strong>Belief Score</strong>, calculated dynamically from linked pro and con sub-arguments, separately indicates how well-supported any given claim actually is. Spectrum 2 just identifies the structural magnitude of the assertion so that equivalent claims can be matched and grouped correctly.</p>
-<table style="border-collapse:collapse;width:100%;margin-bottom:2em;" border="1" cellpadding="8"><thead><tr style="background-color:#f0f3f6;"><th width="18%">Claim Magnitude</th> <th width="35%">Pro-Topic Example</th> <th width="35%">Anti-Topic Example</th> <th width="12%">Scope</th>
-</tr></thead><tbody><tr><td align="center"><strong>Weak (20%)</strong><br />Modest Assertion</td>
-<td>"[Topic] has some advantages, though it has real flaws that need addressing."</td>
-<td>"[Topic] has some structural inefficiencies that make it less effective than alternatives in certain contexts."</td>
-<td>Narrow scope. Leaves room for exceptions and context-dependence.</td>
-</tr><tr><td align="center"><strong>Moderate (50%)</strong><br />Standard Assertion</td>
-<td>"[Topic], when functioning well, produces significantly better outcomes than the available alternatives."</td>
-<td>"[Topic] is significantly compromised by [specific flaw], producing reliably suboptimal outcomes."</td>
-<td>Clear claim without overstating. The level at which most serious academic arguments operate.</td>
-</tr><tr><td align="center"><strong>Strong (80%)</strong><br />Broad Assertion</td>
-<td>"[Topic] is the only approach that provides [key benefit], and any alternative is fundamentally unjust or ineffective."</td>
-<td>"[Topic] is fundamentally broken and cannot produce good outcomes without changes so drastic it would cease to be recognizable."</td>
-<td>Wide scope, absolute framing. Leaves little room for alternatives or incremental improvement.</td>
-</tr><tr><td align="center"><strong>Extreme (100%)</strong><br />Maximal Assertion</td>
-<td>"[Topic] is the pinnacle of human achievement in this domain and any deviation from it, however small, must be resisted by any means necessary."</td>
-<td>"[Topic] is a total fraud, a permanent mechanism of [harm], that has never served [intended beneficiaries] and never will."</td>
-<td>Catastrophic framing with no limiting conditions. The hardest to defend and the easiest to dismiss without engaging the moderate arguments that deserve serious responses.</td>
-</tr></tbody></table><p style="font-size:13px;background-color:#f4f9ff;padding:10px;border-left:4px solid #0055a4;"><strong>Key insight:</strong> The strongest arguments on either side typically operate at Moderate (50%) magnitude, not Extreme (100%). Dismissing opposition by attacking only the Extreme (100%) versions is a straw man. The ISE requires engaging with the best version of the opposing argument, not the loudest one.</p>
-<p style="text-align:right;font-style:italic;">See: <a href="/strong%20to%20weak">Why We Need This Spectrum</a></p>
-<hr /><h2>⚡ Spectrum 3: Civic Engagement Level (<a href="/escalation%20spectrum">Passive ↔ Active</a>)</h2>
-<p>This captures how actively someone is willing to act on their position -- not how extreme their belief is (Spectrum 2) or which direction it runs (Spectrum 1). Two people can hold identical beliefs at identical magnitudes and still differ enormously in how much they are willing to sacrifice to advance them. Mapping this dimension separately prevents the ISE from conflating conviction with action, and action with extremism.</p>
-<table style="width:1597px;" border="1" cellpadding="8"><thead><tr><th width="18%">Engagement Level</th><th width="27%">Pro-Topic: What It Looks Like</th><th width="27%">Anti-Topic: What It Looks Like</th><th width="14%">Pro-Topic Example</th><th width="14%">Anti-Topic Example</th>
-</tr></thead><tbody><tr><td style="background-color:#e8f5e9;"><strong>1. Preference</strong><br />Passive lean</td>
+<td align="center"><span style="color: #2e7d32; font-weight: bold;">[+XX]</span></td>
+</tr>
+</tbody>
+</table>
+<p style="text-align: right; font-style: italic;">See: <a href="/w/page/162417909/beliefs%20grouped">Full Positivity Framework</a> | <a href="/positive%20to%20negative">Why We Need This Continuum</a></p>
+<hr />
+
+<h2 id="magnitude" style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#128170; Continuum 2: Claim Magnitude (<a href="/strong%20to%20weak">Weak &harr; Strong</a>)</h2>
+<p style="font-size: 13px;">How absolute a belief is, independent of its truth and independent of which direction it runs. Magnitude is not a new list of beliefs. It is a property carried by each belief already sitting in <a href="#valence">Continuum 1</a>. This table defines the strength scale and shows what a belief <em>sounds like</em> at each level, so any belief on the page can be placed and so two beliefs at the same strength can be matched. A weak pro belief and a weak anti belief are both modest, they just point in opposite directions. This axis measures the extremity of the <em>claim</em>, not the extremity of anyone's commitment to acting on it. Those are two different questions: how absolute is the belief (here) versus how hard will a person fight for it (the <a href="#engagement">Engagement Landscape</a>, further down, which is a fact about the person and is kept off the matching coordinates). The <strong>Belief Score</strong> separately tells you how well-supported any given belief actually is.</p>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="16%">Claim Magnitude</th> <th width="32%">Pro Belief at This Strength</th> <th width="32%">Anti Belief at This Strength</th> <th width="20%">Scope &amp; Telltale Words</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center"><strong>Weak (20%)</strong><br />Modest</td>
+<td>[A belief that the topic is somewhat good, that openly admits real flaws and exceptions]</td>
+<td>[A belief that the topic is somewhat bad, that concedes it works acceptably much of the time]</td>
+<td>Narrow. Hedged with <em>"some," "tends to," "in certain cases."</em></td>
+</tr>
+<tr>
+<td align="center"><strong>Moderate (50%)</strong><br />Standard</td>
+<td>[A belief that the topic is clearly better than the alternatives in most cases]</td>
+<td>[A belief that the topic is clearly worse than the alternatives in most cases]</td>
+<td>Definite but bounded. <em>"Clearly," "generally," "in most cases."</em> Where most serious arguments live.</td>
+</tr>
+<tr>
+<td align="center"><strong>Strong (80%)</strong><br />Broad</td>
+<td>[A belief that the topic is right across the board and the alternatives reliably fail]</td>
+<td>[A belief that the topic is wrong across the board and fails wherever it is tried]</td>
+<td>Near-universal. <em>"Across the board," "fundamentally."</em> Little room for exceptions.</td>
+</tr>
+<tr>
+<td align="center"><strong>Extreme (100%)</strong><br />Maximal</td>
+<td>[A belief that the topic is always right, everywhere, with no legitimate exception]</td>
+<td>[A belief that the topic is always wrong, has never once worked and never will]</td>
+<td>Total, zero limiting conditions. <em>"Always," "never," "no exception."</em> One counterexample sinks it.</td>
+</tr>
+</tbody>
+</table>
+<p style="font-size: 13px; background-color: #f4f9ff; padding: 10px; border-left: 4px solid #0055a4;"><strong>Key insight:</strong> The strongest arguments on either side typically operate at Moderate (50%) magnitude, not Extreme (100%). Dismissing opposition by attacking only the Extreme (100%) versions is a straw man. The ISE requires engaging with the best version of the opposing argument, not the loudest one.</p>
+<p style="text-align: right; font-style: italic;">See: <a href="/strong%20to%20weak">Why We Need This Continuum</a></p>
+<hr />
+
+<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#129513; Continuum 3: Specificity, the Abstraction Ladder (<a href="/w/page/21957696/General%20to%20Specific">General &harr; Specific</a>)</h2>
+<p style="font-size: 13px;">How concrete a claim is. The same topic supports claims at very different altitudes, from a sweeping worldview down to a single line-item policy, and these are genuinely different claims that need separate scoring. Two people can agree at the top of the ladder and split at the bottom, or disagree about first principles and still converge on the same specific reform. Mapping the rungs is what lets the engine match "[broad principle]" to "[broad principle]" without falsely merging it with "[narrow policy]" that happens to lean the same direction.</p>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="15%">Rung</th> <th width="42%">Pro-Topic Chain</th> <th width="43%">Anti-Topic Chain</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center"><strong>Most General</strong><br />(Worldview)</td>
+<td>"[Fundamental belief about human nature, society, or reality that supports this topic]"</td>
+<td>"[Fundamental belief about human nature, society, or reality that opposes this topic]"</td>
+</tr>
+<tr>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+</tr>
+<tr>
+<td align="center"><strong>Political / Ethical Philosophy</strong></td>
+<td>"[Political principle that follows from the worldview]"</td>
+<td>"[Political principle that follows from the worldview]"</td>
+</tr>
+<tr>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+</tr>
+<tr>
+<td align="center"><strong>This Topic</strong></td>
+<td>"[Position on this specific topic: +50% to +100%]"</td>
+<td>"[Position on this specific topic: -50% to -100%]"</td>
+</tr>
+<tr>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+</tr>
+<tr>
+<td align="center"><strong>Most Specific</strong><br />(Policy / Action)</td>
+<td>"[Specific policy or action that follows from supporting this topic]"</td>
+<td>"[Specific policy or action that follows from opposing this topic]"</td>
+</tr>
+</tbody>
+</table>
+<p style="text-align: right; font-style: italic;">See: <a href="/w/page/21957696/General%20to%20Specific">General to Specific Framework</a></p>
+<hr />
+
+<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#128220; <a href="/Assumptions">Assumption Stack Behind Each Position</a></h2>
+<p style="font-size: 13px;">This is not a fourth continuum. It is the dependency map sitting under the <strong>Continuum 1</strong> positions above. It answers a different question: to land at a given valence, what chain of assumptions do you have to accept, from broadest worldview down to the narrowest topic-specific claim? Surfacing the stack is how a disagreement at the bottom gets traced to its real root higher up, which is usually where the actual fight is.</p>
+<p style="font-size: 13px;"><strong>Core split:</strong> [State the single assumption that most cleanly divides the two sides.]</p>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="15%">To Hold Position</th> <th width="85%">You Must Accept These Assumptions (General to Specific)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="background-color: #ffcccc; text-align: center;"><strong>-100% to -50%</strong><br />(Strongly Oppose)</td>
+<td style="font-size: 13px;"><strong>1. [Worldview]:</strong> [Description]<br /><strong>2. [Political/philosophical]:</strong> [Description]<br /><strong>3. [Causal claim about this domain]:</strong> [Description]<br /><strong>4. [Topic-specific]:</strong> [Description]<br /><strong>5. [Most specific claim]:</strong> [Description]</td>
+</tr>
+<tr>
+<td style="background-color: #ffe6e6; text-align: center;"><strong>-50% to -20%</strong><br />(Skeptical)</td>
+<td style="font-size: 13px;"><strong>1. [Worldview]:</strong> [Description]<br /><strong>2. [Values]:</strong> [Description]<br /><strong>3. [Causal beliefs]:</strong> [Description]<br /><strong>4. [Topic-specific]:</strong> [Description]</td>
+</tr>
+<tr>
+<td style="background-color: #ffffcc; text-align: center;"><strong>-20% to +20%</strong><br />(Nuanced/Mixed)</td>
+<td style="font-size: 13px;"><strong>1. [Acknowledges complexity]:</strong> [Description]<br /><strong>2. [Both sides have valid points]:</strong> [Description]<br /><strong>3. [Context matters]:</strong> [Description]<br /><strong>4. [Implementation determines outcome]:</strong> [Description]</td>
+</tr>
+<tr>
+<td style="background-color: #e6ffe6; text-align: center;"><strong>+20% to +50%</strong><br />(Supportive)</td>
+<td style="font-size: 13px;"><strong>1. [Worldview]:</strong> [Description]<br /><strong>2. [Values]:</strong> [Description]<br /><strong>3. [Causal beliefs]:</strong> [Description]<br /><strong>4. [Topic-specific]:</strong> [Description]</td>
+</tr>
+<tr>
+<td style="background-color: #ccffcc; text-align: center;"><strong>+50% to +100%</strong><br />(Strongly Support)</td>
+<td style="font-size: 13px;"><strong>1. [Worldview]:</strong> [Description]<br /><strong>2. [Political/philosophical]:</strong> [Description]<br /><strong>3. [Causal claim about this domain]:</strong> [Description]<br /><strong>4. [Topic-specific]:</strong> [Description]<br /><strong>5. [Most specific claim]:</strong> [Description]</td>
+</tr>
+</tbody>
+</table>
+<hr />
+
+<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#9878;&#65039; <a href="/Core%20Values%20Conflict" target="_blank">Core Values Conflict</a></h2>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="50%">Values Supporting This Topic</th> <th width="50%">Values Opposing This Topic</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="font-size: 13px;" valign="top"><strong>Advertised:</strong><br /> 1. [Value supporters claim to uphold]<br /> 2. [Value supporters claim to uphold]<br /> 3. [Value supporters claim to uphold]<br /><br /><strong>Critics say the actual motivation is:</strong><br /> 1. [Hidden motivation critics attribute]<br /> 2. [Hidden motivation critics attribute]</td>
+<td style="font-size: 13px;" valign="top"><strong>Advertised:</strong><br /> 1. [Value opponents claim to uphold]<br /> 2. [Value opponents claim to uphold]<br /> 3. [Value opponents claim to uphold]<br /><br /><strong>Critics say the actual motivation is:</strong><br /> 1. [Hidden motivation critics attribute]<br /> 2. [Hidden motivation critics attribute]</td>
+</tr>
+</tbody>
+</table>
+<hr />
+
+<h2 id="engagement" style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#9889; The Engagement Landscape (<a href="/escalation%20spectrum">Passive &harr; Active</a>)</h2>
+<p style="font-size: 13px;"><strong>This is a stakeholder map, not a matching continuum.</strong> It answers the second half of "how extreme is this?": not how absolute the belief is (that is <a href="#magnitude">Claim Magnitude</a>) but how far a person will go to act on it. That is a fact about the person, not about the belief. A casual supporter and someone willing to go to prison hold the <em>same belief</em> about this topic, so engagement deliberately does <em>not</em> feed the belief-matching coordinates above. Two identical beliefs at different engagement levels stay one belief on this page. Keeping this axis separate is what stops the system from confusing a loud claim with a committed person, or commitment with extremism.</p>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="18%">Engagement Level</th><th width="27%">Pro-Topic: What It Looks Like</th><th width="27%">Anti-Topic: What It Looks Like</th><th width="14%">Pro-Topic Example</th><th width="14%">Anti-Topic Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="background-color: #e8f5e9;"><strong>1. Preference</strong><br />Passive lean</td>
 <td>Would support the topic if convenient. Would not prioritize it over other concerns.</td>
 <td>Mildly skeptical. Would prefer alternatives in certain contexts. Would not act on this preference.</td>
 <td>[Pro example: typical casual supporter]</td>
 <td>[Anti example: typical casual skeptic]</td>
-</tr><tr><td style="background-color:#c8e6c9;"><strong>2. Active Advocacy</strong><br />Engaged participant</td>
+</tr>
+<tr>
+<td style="background-color: #c8e6c9;"><strong>2. Active Advocacy</strong><br />Engaged participant</td>
 <td>Votes, donates, signs petitions, argues publicly in favor of the topic.</td>
 <td>Votes, donates, lobbies, and argues publicly against the topic or for alternatives.</td>
 <td>[Pro example: standard civic participation in support]</td>
 <td>[Anti example: standard civic participation in opposition]</td>
-</tr><tr><td style="background-color:#fff9c4;"><strong>3. Principled Non-Compliance</strong><br />Conscientious objector</td>
+</tr>
+<tr>
+<td style="background-color: #fff9c4;"><strong>3. Principled Non-Compliance</strong><br />Conscientious objector</td>
 <td>Refuses personal participation in what they consider unjust opposition to this topic, even at personal cost. Does not obstruct others.</td>
 <td>Refuses to implement or participate in this topic even when required. Does not obstruct others.</td>
-<td>[Pro example: accepts personal cost rather than act against conscience -- Thomas More pattern]</td>
+<td>[Pro example: accepts personal cost rather than act against conscience, Thomas More pattern]</td>
 <td>[Anti example: official who resigns rather than implement a policy they consider unjust]</td>
-</tr><tr><td style="background-color:#ffe082;"><strong>4. Civil Disobedience</strong><br />Principled lawbreaking</td>
+</tr>
+<tr>
+<td style="background-color: #ffe082;"><strong>4. Civil Disobedience</strong><br />Principled lawbreaking</td>
 <td>Openly breaks specific unjust laws considered obstacles to this topic. Accepts legal consequences and uses prosecution as moral leverage.</td>
 <td>Openly defies specific laws or mandates related to this topic. Accepts legal consequences and uses prosecution as moral leverage.</td>
 <td>[Pro example: MLK / Gandhi equivalent for this topic's pro side]</td>
 <td>[Anti example: conscientious objectors who accepted imprisonment rather than comply]</td>
-</tr></tbody></table><p><strong>Key insight:</strong>&nbsp;The three spectrums are fully independent. Someone can hold a moderate-magnitude claim (Spectrum 2 = 50%) about a cause they feel lukewarm about (Spectrum 1 = +40%) and still be willing to go to prison for it (Spectrum 3 = Level 4). Plotting a coordinate on each spectrum is what lets the system match beliefs accurately rather than bundling very different positions together. For engagement beyond Level 4, see:&nbsp;<a href="/escalation%20spectrum">Escalation Spectrum</a>.</p>
-<p style="text-align:right;"><a href="/w/page/21956745/American%20values">Core Values Framework</a></p>
-<hr /><h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;">📜 <a href="/Assumptions">Foundational Assumptions</a>: What You Must Believe at Each Position</h2>
-<p style="font-size:13px;">Your position on Spectrum 1 depends on deeper assumptions about reality, values, and causation. This section maps those dependencies from most general (worldview) to most specific (this topic).</p>
-<p style="font-size:13px;"><strong>Key Insight:</strong> [State the core assumption that divides the two sides.]</p>
-<table style="border-collapse:collapse;width:100%;margin-bottom:2em;" border="1" cellpadding="8"><thead><tr style="background-color:#f0f3f6;"><th width="15%">To Hold Position</th> <th width="85%">You Must Believe These Assumptions (Ordered General to Specific)</th>
-</tr></thead><tbody><tr><td style="background-color:#ffcccc;text-align:center;"><strong>-100% to -50%</strong><br />(Strongly Oppose)</td>
-<td style="font-size:13px;"><strong>1. [Most general worldview assumption]:</strong> [Description]<br /><strong>2. [Political/philosophical assumption]:</strong> [Description]<br /><strong>3. [Causal assumption about this domain]:</strong> [Description]<br /><strong>4. [Specific assumption about this topic]:</strong> [Description]<br /><strong>5. [Most specific claim]:</strong> [Description]</td>
-</tr><tr><td style="background-color:#ffe6e6;text-align:center;"><strong>-50% to -20%</strong><br />(Skeptical)</td>
-<td style="font-size:13px;"><strong>1. [Worldview]:</strong> [Description]<br /><strong>2. [Values]:</strong> [Description]<br /><strong>3. [Causal beliefs]:</strong> [Description]<br /><strong>4. [Topic-specific]:</strong> [Description]</td>
-</tr><tr><td style="background-color:#ffffcc;text-align:center;"><strong>-20% to +20%</strong><br />(Nuanced/Mixed)</td>
-<td style="font-size:13px;"><strong>1. [Acknowledges complexity]:</strong> [Description]<br /><strong>2. [Both sides have valid points]:</strong> [Description]<br /><strong>3. [Context matters]:</strong> [Description]<br /><strong>4. [Implementation determines outcome]:</strong> [Description]</td>
-</tr><tr><td style="background-color:#e6ffe6;text-align:center;"><strong>+20% to +50%</strong><br />(Supportive)</td>
-<td style="font-size:13px;"><strong>1. [Worldview]:</strong> [Description]<br /><strong>2. [Values]:</strong> [Description]<br /><strong>3. [Causal beliefs]:</strong> [Description]<br /><strong>4. [Topic-specific]:</strong> [Description]</td>
-</tr><tr><td style="background-color:#ccffcc;text-align:center;"><strong>+50% to +100%</strong><br />(Strongly Support)</td>
-<td style="font-size:13px;"><strong>1. [Most general worldview assumption]:</strong> [Description]<br /><strong>2. [Political/philosophical assumption]:</strong> [Description]<br /><strong>3. [Causal assumption about this domain]:</strong> [Description]<br /><strong>4. [Specific assumption about this topic]:</strong> [Description]<br /><strong>5. [Most specific claim]:</strong> [Description]</td>
-</tr></tbody></table><hr /><h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;">🪜 Spectrum 4: The Abstraction Ladder (General ↔ Specific)</h2>
-<p style="font-size:13px;">Shows how general worldviews cascade down into specific positions on this topic. Two people can agree at the top level and still reach opposite conclusions at the bottom, or disagree at the top and still agree on specific reforms.</p>
-<table style="border-collapse:collapse;width:100%;margin-bottom:2em;" border="1" cellpadding="8"><thead><tr style="background-color:#f0f3f6;"><th width="15%">Level</th> <th width="42%">Pro-Topic Assumption Chain</th> <th width="43%">Anti-Topic Assumption Chain</th>
-</tr></thead><tbody><tr><td align="center"><strong>Most General</strong><br />(Worldview)</td>
-<td>"[Fundamental belief about human nature, society, or reality that supports this topic]"</td>
-<td>"[Fundamental belief about human nature, society, or reality that opposes this topic]"</td>
-</tr><tr><td align="center">↓</td>
-<td align="center">↓</td>
-<td align="center">↓</td>
-</tr><tr><td align="center"><strong>Political/Ethical Philosophy</strong></td>
-<td>"[Political principle that follows from the worldview]"</td>
-<td>"[Political principle that follows from the worldview]"</td>
-</tr><tr><td align="center">↓</td>
-<td align="center">↓</td>
-<td align="center">↓</td>
-</tr><tr><td align="center"><strong>This Topic</strong></td>
-<td>"[Position on this specific topic: +50% to +100%]"</td>
-<td>"[Position on this specific topic: -50% to -100%]"</td>
-</tr><tr><td align="center">↓</td>
-<td align="center">↓</td>
-<td align="center">↓</td>
-</tr><tr><td align="center"><strong>Most Specific</strong><br />(Policy/Action)</td>
-<td>"[Specific policy or action that follows from supporting this topic]"</td>
-<td>"[Specific policy or action that follows from opposing this topic]"</td>
-</tr></tbody></table><p style="text-align:right;font-style:italic;">See: <a href="/w/page/21957696/General%20to%20Specific">General to Specific Framework</a></p>
-<hr /><h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;">⚖️ <a href="/Core%20Values%20Conflict" target="_blank">Core Values Conflict</a></h2>
-<table style="border-collapse:collapse;width:100%;margin-bottom:2em;" border="1" cellpadding="8"><thead><tr style="background-color:#f0f3f6;"><th width="50%">Values Supporting This Topic</th> <th width="50%">Values Opposing This Topic</th>
-</tr></thead><tbody><tr><td style="font-size:13px;" valign="top"><strong>Advertised:</strong><br /> 1. [Value supporters claim to uphold]<br /> 2. [Value supporters claim to uphold]<br /> 3. [Value supporters claim to uphold]<br /><br /><strong>Critics say the actual motivation is:</strong><br /> 1. [Hidden motivation critics attribute]<br /> 2. [Hidden motivation critics attribute]</td>
-<td style="font-size:13px;" valign="top"><strong>Advertised:</strong><br /> 1. [Value opponents claim to uphold]<br /> 2. [Value opponents claim to uphold]<br /> 3. [Value opponents claim to uphold]<br /><br /><strong>Critics say the actual motivation is:</strong><br /> 1. [Hidden motivation critics attribute]<br /> 2. [Hidden motivation critics attribute]</td>
-</tr></tbody></table><hr /><h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;">🤝 <a href="/w/page/162560439/Compromise">Common Ground and Compromise</a></h2>
-<table style="border-collapse:collapse;width:100%;margin-bottom:2em;" border="1" cellpadding="8"><thead><tr style="background-color:#f0f3f6;"><th width="50%">What Both Sides Might Agree On</th> <th width="50%">Possible Compromise Positions</th>
-</tr></thead><tbody><tr><td style="font-size:13px;" valign="top">1. [Shared value or goal]<br />2. [Shared concern]<br />3. [Common enemy or problem]</td>
-<td style="font-size:13px;" valign="top">1. [Solution addressing both sides' concerns]<br />2. [Incremental approach]<br />3. [Pilot program or experiment]</td>
-</tr></tbody></table><hr /><h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;">⚖️ The Evidence Ledger</h2>
-<p style="font-size:13px;">Weighing the raw data. Quality scores based on methodology, sample size, and reproducibility.</p>
-<table style="border-collapse:collapse;width:100%;margin-bottom:2em;" border="1" cellpadding="8"><thead><tr style="background-color:#f0f3f6;"><th width="40%">Supporting Evidence (Pro)</th> <th width="10%">Quality</th> <th width="40%">Weakening Evidence (Con)</th> <th width="10%">Quality</th>
-</tr></thead><tbody><tr><td>[Study/Data Title]<br /><span style="font-size:85%;">Source: [Institution/Author] (Year)</span><br /><span style="font-size:85%;">Finding: [Brief summary]</span></td>
-<td align="center"><strong>[95%]</strong><br /><span style="font-size:75%;">(Peer Reviewed)</span></td>
-<td>[Study/Data Title]<br /><span style="font-size:85%;">Source: [Institution/Author] (Year)</span><br /><span style="font-size:85%;">Finding: [Brief summary]</span></td>
-<td align="center"><strong>[80%]</strong><br /><span style="font-size:75%;">(Meta-analysis)</span></td>
-</tr><tr><td>[Historical Precedent/Statistic]<br /><span style="font-size:85%;">Source: [Institution/Author] (Year)</span><br /><span style="font-size:85%;">Finding: [Brief summary]</span></td>
+</tr>
+</tbody>
+</table>
+<p style="font-size: 13px;"><strong>Key insight:</strong> Engagement is fully independent of the three matching continuums. Someone can hold a moderate-magnitude claim (Continuum 2 = 50%) about a cause they feel lukewarm toward (Continuum 1 = +40%) and still be willing to go to prison for it (Engagement Level 4). For engagement beyond Level 4, see: <a href="/escalation%20spectrum">Escalation Spectrum</a>.</p>
+<p style="text-align: right; font-style: italic;"><a href="/w/page/21956745/American%20values">Core Values Framework</a></p>
+<hr />
+
+<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#129309; <a href="/w/page/162560439/Compromise">Common Ground and Compromise</a></h2>
+<p style="font-size: 13px;">Once both sides' costs and benefits are scored under <a href="/w/page/156187122/cost-benefit%20analysis">Cost-Benefit Analysis</a>, the same scored trees read sideways and three things fall out automatically. This is the conflict readout, not an editor's guess at where people might get along.</p>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="33%">Shared Interests<br /><span style="font-size: 85%; font-weight: normal;">Impacts both sides actually want</span></th> <th width="33%">Real Value Conflicts<br /><span style="font-size: 85%; font-weight: normal;">Where one side prices freedom and the other prices safety</span></th> <th width="34%">Compromise Candidates<br /><span style="font-size: 85%; font-weight: normal;">A small, achievable likelihood shift would flip a category's net</span></th>
+</tr>
+</thead>
+<tbody>
+<tr style="font-size: 13px;" valign="top">
+<td>1. [Impact both sides score as a benefit]<br />2. [Shared concern or common problem]<br />3. [Goal neither side disputes]</td>
+<td>1. [Value A vs Value B, genuinely traded off]<br />2. [The irreducible disagreement]<br />3. [Where no likelihood shift resolves it]</td>
+<td>1. [Impact where a feasible change flips the sign]<br />2. [Pilot or scoped version that wins both columns]<br />3. [Incremental step with a tractable likelihood gap]</td>
+</tr>
+</tbody>
+</table>
+<p style="font-size: 13px; background-color: #f4f9ff; padding: 10px; border-left: 4px solid #0055a4;"><strong>Why this column matters:</strong> The Compromise Candidates are the winnable disagreements, the ones a small shift in likelihood can actually flip, as opposed to the symbolic value conflicts that no negotiation resolves. Pointing people at the tractable fights instead of the eternal ones is the payoff of scoring both sides with equal rigor.</p>
+<hr />
+
+<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#9878;&#65039; The Evidence Ledger</h2>
+<p style="font-size: 13px;">Evidence formally attaches to specific beliefs, not to the topic as a whole, and is scored on its own <a href="/w/page/159353568/Evidence%20Scores">page per study</a>. This ledger is the cross-topic highlight reel: the highest-impact evidence appearing anywhere under this topic, so a reader sees the empirical state of play before diving into individual belief pages. Quality scores reflect methodology, sample size, and reproducibility.</p>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="40%">Supporting Evidence (Pro)</th> <th width="10%">Quality</th> <th width="40%">Weakening Evidence (Con)</th> <th width="10%">Quality</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Study/Data Title]<br /><span style="font-size: 85%;">Source: [Institution/Author] (Year)</span><br /><span style="font-size: 85%;">Finding: [Brief summary]</span></td>
+<td align="center"><strong>[95%]</strong><br /><span style="font-size: 75%;">(Peer Reviewed)</span></td>
+<td>[Study/Data Title]<br /><span style="font-size: 85%;">Source: [Institution/Author] (Year)</span><br /><span style="font-size: 85%;">Finding: [Brief summary]</span></td>
+<td align="center"><strong>[80%]</strong><br /><span style="font-size: 75%;">(Meta-analysis)</span></td>
+</tr>
+<tr>
+<td>[Historical Precedent/Statistic]<br /><span style="font-size: 85%;">Source: [Institution/Author] (Year)</span><br /><span style="font-size: 85%;">Finding: [Brief summary]</span></td>
 <td align="center"><strong>[XX%]</strong></td>
-<td>[Logical Paradox/Counter-Statistic]<br /><span style="font-size:85%;">Source: [Institution/Author] (Year)</span><br /><span style="font-size:85%;">Finding: [Brief summary]</span></td>
+<td>[Counter-Statistic]<br /><span style="font-size: 85%;">Source: [Institution/Author] (Year)</span><br /><span style="font-size: 85%;">Finding: [Brief summary]</span></td>
 <td align="center"><strong>[XX%]</strong></td>
-</tr></tbody></table><p style="text-align:right;font-style:italic;">See: <a href="/w/page/159353568/Evidence%20Scores">Evidence Scoring Methodology</a></p>
-<hr /><h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;">📏 <a href="/w/page/159351732/Objective%20criteria%20scores">Best Objective Criteria</a> for Measuring Beliefs on This Topic</h2>
-<p style="font-size:13px;">Before arguments about this topic can be scored, users must first agree on <em>what good measurement looks like</em>. This section lists proposed criteria sorted by their community-assigned <a href="/w/page/159351732/Objective%20criteria%20scores">Objective Criteria Score</a>. Each criterion is itself a belief with its own page: users submit reasons to agree or disagree that it is a valid, reliable, independent, and relevant measure. The scores below are calculated recursively from those sub-arguments without manual ranking or editorial judgment.</p>
-<div style="background-color:#f4f9ff;padding:12px;border-left:4px solid #0055a4;margin-bottom:15px;font-size:13px;"><strong>How each criterion is scored across four dimensions:</strong> 
-<ul style="margin:8px 0 0 0;"><li><strong><a href="/w/page/21960078/truth">Validity</a>:</strong> Does this measure actually capture what we claim it captures?</li>
+</tr>
+</tbody>
+</table>
+<p style="text-align: right; font-style: italic;">See: <a href="/w/page/159353568/Evidence%20Scores">Evidence Scoring Methodology</a></p>
+<hr />
+
+<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#128207; <a href="/w/page/159351732/Objective%20criteria%20scores">Best Objective Criteria</a> for Measuring Beliefs on This Topic</h2>
+<p style="font-size: 13px;">Before arguments about this topic can be scored, users first agree on <em>what good measurement looks like</em>. This section lists proposed criteria sorted by their community-assigned <a href="/w/page/159351732/Objective%20criteria%20scores">Objective Criteria Score</a>. Each criterion is itself a belief with its own page: users submit reasons to agree or disagree that it is a valid, reliable, independent, and relevant measure. The scores below are calculated recursively from those sub-arguments without manual ranking or editorial judgment.</p>
+<div style="background-color: #f4f9ff; padding: 12px; border-left: 4px solid #0055a4; margin-bottom: 15px; font-size: 13px;"><strong>How each criterion is scored across four dimensions:</strong>
+<ul style="margin: 8px 0 0 0;">
+<li><strong><a href="/w/page/21960078/truth">Validity</a>:</strong> Does this measure actually capture what we claim it captures?</li>
 <li><strong>Reliability:</strong> Can different observers measure it consistently without subjective manipulation?</li>
 <li><strong><a href="/w/page/159338766/Linkage%20Scores">Linkage</a>:</strong> How directly does this metric connect to the core claim being evaluated?</li>
 <li><strong><a href="/w/page/162731388/Importance%20Score">Importance</a>:</strong> If valid and linked, how significant is this metric relative to others available?</li>
-</ul></div>
-<table style="border-collapse:collapse;width:100%;margin-bottom:2em;" border="1" cellpadding="8"><thead><tr style="background-color:#f0f3f6;"><th width="28%">Proposed Criterion</th> <th width="12%" align="center"><a href="/w/page/159351732/Objective%20criteria%20scores">Criteria Score</a></th> <th width="15%" align="center">Validity</th> <th width="15%" align="center">Reliability</th> <th width="15%" align="center"><a href="/w/page/159338766/Linkage%20Scores">Linkage</a></th> <th width="15%" align="center"><a href="/w/page/162731388/Importance%20Score">Importance</a></th>
-</tr></thead><tbody><tr><td>[Criterion 1]<br /><span style="font-size:85%;color:#666;">[One-line description of what it measures and how]</span></td>
-<td align="center"><strong><span style="color:#2e7d32;">[92%]</span></strong></td>
+</ul>
+</div>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="28%">Proposed Criterion</th> <th width="12%" align="center"><a href="/w/page/159351732/Objective%20criteria%20scores">Criteria Score</a></th> <th width="15%" align="center">Validity</th> <th width="15%" align="center">Reliability</th> <th width="15%" align="center"><a href="/w/page/159338766/Linkage%20Scores">Linkage</a></th> <th width="15%" align="center"><a href="/w/page/162731388/Importance%20Score">Importance</a></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Criterion 1]<br /><span style="font-size: 85%; color: #666;">[One-line description of what it measures and how]</span></td>
+<td align="center"><strong><span style="color: #2e7d32;">[92%]</span></strong></td>
 <td align="center">High</td>
 <td align="center">High</td>
 <td align="center">High</td>
 <td align="center">High</td>
-</tr><tr><td>[Criterion 2]<br /><span style="font-size:85%;color:#666;">[One-line description]</span></td>
-<td align="center"><strong><span style="color:#2e7d32;">[85%]</span></strong></td>
+</tr>
+<tr>
+<td>[Criterion 2]<br /><span style="font-size: 85%; color: #666;">[One-line description]</span></td>
+<td align="center"><strong><span style="color: #2e7d32;">[85%]</span></strong></td>
 <td align="center">High</td>
 <td align="center">High</td>
 <td align="center">High</td>
 <td align="center">Med</td>
-</tr><tr><td>[Criterion 3]<br /><span style="font-size:85%;color:#666;">[One-line description]</span></td>
-<td align="center"><strong><span style="color:#f57c00;">[60%]</span></strong></td>
+</tr>
+<tr>
+<td>[Criterion 3]<br /><span style="font-size: 85%; color: #666;">[One-line description]</span></td>
+<td align="center"><strong><span style="color: #f57c00;">[60%]</span></strong></td>
 <td align="center">Med</td>
 <td align="center">Low</td>
 <td align="center">Med</td>
 <td align="center">Med</td>
-</tr><tr><td>[Criterion 4]<br /><span style="font-size:85%;color:#666;">[One-line description]</span></td>
-<td align="center"><strong><span style="color:#d32f2f;">[15%]</span></strong></td>
+</tr>
+<tr>
+<td>[Criterion 4]<br /><span style="font-size: 85%; color: #666;">[One-line description]</span></td>
+<td align="center"><strong><span style="color: #d32f2f;">[15%]</span></strong></td>
 <td align="center">Low</td>
 <td align="center">Low</td>
 <td align="center">Low</td>
 <td align="center">Low</td>
-</tr><tr><td style="font-size:85%;font-style:italic;color:#555;" colspan="6">Don't see a criterion that belongs here? <a href="/w/page/160433328/Contact%20Me">Submit a proposal</a> with reasons to support its validity, reliability, linkage, and importance. The community will score it.</td>
-</tr></tbody></table><div style="background-color:#fff0f0;padding:10px;border-left:4px solid #cc0000;margin:15px 0;font-size:13px;"><strong>Why this matters:</strong> Arguments submitted anywhere on this topic page are automatically weighted by how well they connect to high-scoring criteria. A claim supported by a criterion scoring 92% carries far more evidential weight than one supported by a criterion scoring 15%, regardless of how confidently either claim is stated. The yardstick is agreed upon before the measurements begin.</div>
-<p style="text-align:right;font-style:italic;">See: <a href="/w/page/159351732/Objective%20criteria%20scores">Full Objective Criteria Scoring Methodology</a></p>
-<hr /><h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;">📚 Best Media and Resources</h2>
-<p style="font-size:13px;">Curated resources sorted by positivity score and informational value.</p>
-<table style="border-collapse:collapse;width:100%;margin-bottom:2em;" border="1" cellpadding="8"><thead><tr style="background-color:#f0f3f6;"><th width="28%">Title</th> <th width="12%">Medium</th> <th width="12%">Bias/Tone</th> <th width="10%">Positivity</th> <th width="10%">Magnitude</th> <th width="10%">Escalation</th> <th width="18%">Key Insight</th>
-</tr></thead><tbody><tr><td>[Title]</td>
+</tr>
+<tr>
+<td style="font-size: 85%; font-style: italic; color: #555;" colspan="6">Don't see a criterion that belongs here? <a href="/w/page/160433328/Contact%20Me">Submit a proposal</a> with reasons to support its validity, reliability, linkage, and importance. The community will score it.</td>
+</tr>
+</tbody>
+</table>
+<div style="background-color: #fff0f0; padding: 10px; border-left: 4px solid #cc0000; margin: 15px 0; font-size: 13px;"><strong>Why this matters:</strong> Arguments submitted anywhere on this topic page are automatically weighted by how well they connect to high-scoring criteria. A claim supported by a criterion scoring 92% carries far more evidential weight than one supported by a criterion scoring 15%, regardless of how confidently either claim is stated. The yardstick is agreed upon before the measurements begin.</div>
+<p style="text-align: right; font-style: italic;">See: <a href="/w/page/159351732/Objective%20criteria%20scores">Full Objective Criteria Scoring Methodology</a></p>
+<hr />
+
+<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#128218; Best Media and Resources</h2>
+<p style="font-size: 13px;">Curated resources sorted by positivity score and informational value.</p>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="28%">Title</th> <th width="12%">Medium</th> <th width="12%">Bias/Tone</th> <th width="10%">Positivity</th> <th width="10%">Magnitude</th> <th width="10%">Escalation</th> <th width="18%">Key Insight</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Title]</td>
 <td>[Book/Doc/Article]</td>
 <td>[Academic/Polemic]</td>
 <td align="center">[+XX%]</td>
 <td align="center">[XX%]</td>
 <td align="center">[1-6]</td>
 <td>[One sentence summary]</td>
-</tr><tr><td>[Title]</td>
+</tr>
+<tr>
+<td>[Title]</td>
 <td>[Book/Doc/Article]</td>
 <td>[Critical/Satire]</td>
 <td align="center">[-XX%]</td>
 <td align="center">[XX%]</td>
 <td align="center">[1-6]</td>
 <td>[One sentence summary]</td>
-</tr></tbody></table><p style="text-align:right;font-style:italic;">See: <a href="/w/page/21958666/media">Media Framework</a></p>
-<hr /><h2 style="font-family:'Segoe UI', 'Lucida Grande', Arial, sans-serif;font-size:20px;font-weight:bold;">🔗 Related Topics</h2>
-<table style="border-collapse:collapse;width:100%;margin-bottom:2em;" border="1" cellpadding="10"><thead><tr style="background-color:#f0f3f6;"><th width="25%">Broader Categories (Parents)</th> <th width="25%">Specific Sub-Issues (Children)</th> <th width="25%">Related Concepts (Siblings)</th> <th width="25%">Opposing / Critical Views</th>
-</tr></thead><tbody><tr style="font-size:13px;" valign="top"><td>[Link to Parent 1]<br />[Link to Parent 2]</td>
+</tr>
+</tbody>
+</table>
+<p style="text-align: right; font-style: italic;">See: <a href="/w/page/21958666/media">Media Framework</a></p>
+<hr />
+
+<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">&#128279; Related Topics</h2>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="10">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="25%">Broader Categories (Parents)</th> <th width="25%">Specific Sub-Issues (Children)</th> <th width="25%">Related Concepts (Siblings)</th> <th width="25%">Opposing / Critical Views</th>
+</tr>
+</thead>
+<tbody>
+<tr style="font-size: 13px;" valign="top">
+<td>[Link to Parent 1]<br />[Link to Parent 2]</td>
 <td>[Link to Child 1]<br />[Link to Child 2]</td>
 <td>[Link to Sibling 1]<br />[Link to Sibling 2]</td>
 <td>[Link to Opposing View 1]<br />[Link to Opposing View 2]</td>
-</tr></tbody></table><hr /><h2 style="font-size:20px;">📬 Contribute</h2>
+</tr>
+</tbody>
+</table>
+<hr />
+
+<h2 style="font-size: 20px;">&#128236; Contribute</h2>
 <p><a href="/w/page/160433328/Contact%20Me">Contact me</a> to add beliefs, strengthen arguments, link new evidence, or propose objective criteria.<br /><a href="https://github.com/myklob/ideastockexchange">GitHub</a> for technical implementation and scoring algorithms.</p>
 </div>
 <p>&nbsp;</p>


### PR DESCRIPTION
## Summary

Restructured the debate topic template and components to clarify the conceptual model: renamed "Spectrums" to "Continuums" for the three belief-matching dimensions (valence, magnitude, specificity), separated engagement as a non-matching stakeholder map, and added the Abstraction Ladder (Continuum 3: Specificity) as a core matching dimension. Also expanded Common Ground to surface real value conflicts alongside shared interests and compromise candidates.

## Key Changes

**Template & Conceptual Clarity**
- Renamed "Spectrum 1: The Debate Landscape" → "Continuum 1: Valence" with clearer explanation that it measures direction only
- Renamed "Spectrum 2: Claim Magnitude" → "Continuum 2: Claim Magnitude" with simplified examples and telltale-words guidance
- Renamed "Spectrum 3: Civic Engagement Level" → "The Engagement Landscape" and explicitly marked it as a **non-matching stakeholder map** (not a belief-matching coordinate)
- Renamed "Spectrum 4: The Abstraction Ladder" → "Continuum 3: Specificity, the Abstraction Ladder" and repositioned it as the third core matching dimension
- Added introductory blue box explaining how the three continuums deduplicate beliefs via coordinate matching and the redundancy discount

**Assumption Stack & Values**
- Retitled "Foundational Assumptions" → "Assumption Stack Behind Each Position" with explanation that it is a dependency map, not a continuum
- Added "Core Values Conflict" section with advertised vs. actual motivations for both sides
- Expanded "Common Ground & Compromise" to include a "Real Value Conflicts" column alongside shared interests and compromise candidates

**Component Updates**
- Updated `Spectrum1Positions.tsx`: renamed heading, added anchor `id="valence"`, clarified description
- Updated `Spectrum2Magnitude.tsx`: renamed heading to "Continuum 2", simplified example text, added anchor `id="magnitude"`, updated generic fallback rows with shorter sublabels and hedged language
- Updated `Spectrum3Escalation.tsx`: renamed to "The Engagement Landscape", added anchor `id="engagement"`, expanded explanation that engagement is not a matching coordinate
- Updated `Spectrum4AbstractionLadder.tsx`: renamed to "Continuum 3: Specificity", added anchor `id="specificity"`, updated description
- Updated `FoundationalAssumptions.tsx`: retitled and added explanation of dependency mapping
- Updated `CoreValuesConflict.tsx`: removed unused `topicTitle` prop
- Updated `CommonGround.tsx`: expanded table headers with subtext, added `valueConflicts` column, added explanatory paragraph

**Database & Types**
- Added `valueConflicts` field to `DebateCommonGround` in Prisma schema (JSON array, default `[]`)
- Updated `DebateCommonGround` interface to include `valueConflicts: string[]`
- Updated seed script and AI generator to populate `valueConflicts`
- Added migration file for the new column

**Page Integration**
- Updated `/debate-topics/[slug]/page.tsx` to render the new introductory deduplication box and pass `abstractionRungs` to the new Continuum 3 component
- Updated component imports and ordering to reflect the new structure

## Notable Implementation Details

- All three continuums now have anchor IDs (`id="valence"`, `id="magnitude"`, `id="specificity"`) for deep linking
- Engagement Landscape explicitly disclaims that it is not a matching coordinate, preventing confusion between belief strength and personal commitment
- Assumption Stack and Core Values Conflict are now clearly separated from the matching continuums
- Common Ground now surfaces real value conflicts as a distinct column, enabling readers to see where trade-offs are genuine rather than resolvable
- Generic magnitude examples simplified to be more concise and use hedged language ("some," "tends to," "in certain cases") to match the actual strength levels

https://claude.ai/code/session_01Cj9DcpBzzvN8dhUEjftwV6