### PR TITLE
Add Interest Validity Debate section to belief analysis

### DIFF
--- a/docs/BELIEF_PAGE_RULES.md
+++ b/docs/BELIEF_PAGE_RULES.md
@@ -153,6 +153,7 @@ Every section with "Supporters" and "Opponents" (Values, Interests, Biases, Moti
    - 6a. Interest Priority Rankings (same column shape as Values)
    - 6b. Shared vs. Conflicting Interests (with "Why the Conflict Exists")
    - 6c. How Interests Drive Value Rankings (Interest at Stake / Side / Value Elevated / Value Deprioritized / Confidence)
+   - 6d. Interest Validity Debate (three scopes: valid at all / more-or-less valid in general / valid within a specific scenario). Expanded only when an interest's validity is itself contested; renders the template skeleton otherwise. Source of truth: `templates/interest-validity-debate-template.html`.
 7. Foundational Assumptions (Required to Accept vs. Required to Reject)
 8. Objective Criteria (Criterion / Current Status / Threshold for Agreement)
 9. Cost-Benefit Analysis (Benefits vs. Costs, then Short-Term vs. Long-Term)
@@ -183,7 +184,7 @@ Before outputting any ISE belief page, verify:
 - [ ] All evidence lives in the Evidence Ledger with tier assigned
 - [ ] Visual/video items live in the Visual and Video Evidence sub-table, not in a separate Media section
 - [ ] Values section has all four sub-tables: Priority Rankings, Shared Values, Cross-Context, Advertised vs. Actual
-- [ ] Interests section has all three sub-tables: Priority Rankings, Shared vs. Conflicting (with Why), Interest -> Value Linkage
+- [ ] Interests section has all four sub-tables: Priority Rankings, Shared vs. Conflicting (with Why), Interest -> Value Linkage, Interest Validity Debate (three scopes)
 - [ ] Resolution section bundles Compromise/Obstacles AND Biases together
 - [ ] Every link points to a page that exists OR is plain text
 - [ ] No `href="#"` anchors anywhere

--- a/src/features/belief-analysis/components/InterestValiditySection.tsx
+++ b/src/features/belief-analysis/components/InterestValiditySection.tsx
@@ -1,0 +1,342 @@
+import Link from 'next/link'
+import type {
+  InterestValidityDebate,
+  ValidityReasonItem,
+  InterestComparisonItem,
+  InterestScenarioItem,
+} from '../types'
+
+interface InterestValiditySectionProps {
+  debates: InterestValidityDebate[]
+}
+
+/** A single placeholder debate so the template skeleton renders when no data exists. */
+const PLACEHOLDER_DEBATE: InterestValidityDebate = { interest: '' }
+
+function scoreCell(score: number | null | undefined): React.ReactNode {
+  if (score == null) {
+    return <span className="text-[var(--muted-foreground)] italic">[±XX]</span>
+  }
+  const sign = score > 0 ? '+' : ''
+  return <span className="font-mono">{sign}{score}</span>
+}
+
+function validityCell(score: number | null | undefined): React.ReactNode {
+  if (score == null) {
+    return <span className="text-[var(--muted-foreground)] italic">[pending]</span>
+  }
+  return <span className="font-mono">{score}/100</span>
+}
+
+function ReasonRows({
+  rows,
+  positive,
+}: {
+  rows: ValidityReasonItem[]
+  positive: boolean
+}) {
+  const data: Array<ValidityReasonItem | null> = rows.length > 0 ? rows : [null, null]
+  return (
+    <>
+      {data.map((row, i) => (
+        <li key={i} className="py-1">
+          {row ? (
+            <>
+              <span className={positive ? 'text-green-700' : 'text-red-700'}>
+                {scoreCell(row.score)}
+              </span>{' '}
+              <span>{row.reason}</span>
+              {row.criterion && (
+                <span className="text-[var(--muted-foreground)] text-xs">
+                  {' '}(criterion: {row.criterion})
+                </span>
+              )}
+            </>
+          ) : (
+            <span className="text-[var(--muted-foreground)] italic text-sm">
+              {positive
+                ? '[reason it is valid, named by opening words] (criterion)'
+                : '[reason it is not valid] (criterion)'}
+            </span>
+          )}
+        </li>
+      ))}
+    </>
+  )
+}
+
+function TwoColumnReasons({
+  leftTitle,
+  rightTitle,
+  leftRows,
+  rightRows,
+}: {
+  leftTitle: string
+  rightTitle: string
+  leftRows: ValidityReasonItem[]
+  rightRows: ValidityReasonItem[]
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-3 py-2 text-left font-semibold w-1/2">{leftTitle}</th>
+            <th className="px-3 py-2 text-left font-semibold w-1/2">{rightTitle}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="px-3 py-2 align-top">
+              <ul className="list-none space-y-0">
+                <ReasonRows rows={leftRows} positive />
+              </ul>
+            </td>
+            <td className="px-3 py-2 align-top">
+              <ul className="list-none space-y-0">
+                <ReasonRows rows={rightRows} positive={false} />
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ComparisonTable({ rows }: { rows: InterestComparisonItem[] }) {
+  const data: Array<InterestComparisonItem | null> = rows.length > 0 ? rows : [null, null]
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-3 py-2 text-left font-semibold w-[40%]">Interest</th>
+            <th className="px-3 py-2 text-left font-semibold w-[35%]">Maslow prior (starting band)</th>
+            <th className="px-3 py-2 text-center font-semibold w-[25%]">Current validity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} className="border-b border-gray-200">
+              <td className="px-3 py-2 align-top">
+                {row ? (
+                  row.isThisInterest ? <strong>{row.interest}</strong> : row.interest
+                ) : (
+                  <span className="text-[var(--muted-foreground)] italic">
+                    {i === 0 ? '[this interest]' : '[competing interest]'}
+                  </span>
+                )}
+              </td>
+              <td className="px-3 py-2 align-top">
+                {row?.maslowPrior ?? (
+                  <span className="text-[var(--muted-foreground)] italic">[level, e.g. Safety 70-85]</span>
+                )}
+              </td>
+              <td className="px-3 py-2 align-top text-center">{validityCell(row?.currentValidity)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ScenarioBlock({ scenario, index }: { scenario: InterestScenarioItem | null; index: number }) {
+  return (
+    <div className="border border-gray-200 rounded p-4 space-y-3">
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="px-3 py-2 text-left font-semibold w-[30%]">Scenario</th>
+              <th className="px-3 py-2 text-left font-semibold w-[35%]">Competing interest</th>
+              <th className="px-3 py-2 text-left font-semibold w-[35%]">Scenario fact that moves the ranking</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="px-3 py-2 align-top">
+                {scenario?.scenario ?? (
+                  <span className="text-[var(--muted-foreground)] italic">[describe the specific conflict]</span>
+                )}
+              </td>
+              <td className="px-3 py-2 align-top">
+                {scenario?.competingInterest ?? (
+                  <span className="text-[var(--muted-foreground)] italic">[the interest it collides with here]</span>
+                )}
+              </td>
+              <td className="px-3 py-2 align-top">
+                {scenario?.scenarioFact ?? (
+                  <span className="text-[var(--muted-foreground)] italic">[e.g. the harm is imminent and irreversible]</span>
+                )}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-sm">
+        The scenario claim, &ldquo;in this conflict, this interest should outrank the competing
+        interest,&rdquo; gets its two columns:
+      </p>
+      <TwoColumnReasons
+        leftTitle="Reasons it should win here"
+        rightTitle="Reasons it should yield here"
+        leftRows={scenario?.winReasons ?? []}
+        rightRows={scenario?.yieldReasons ?? []}
+      />
+
+      <p className="text-sm">
+        <strong>In-scenario ranking:</strong>{' '}
+        {scenario?.inScenarioRanking ?? (
+          <span className="text-[var(--muted-foreground)] italic">
+            [this interest wins / yields here] — may differ from the general ranking; note why the
+            scenario facts caused it
+          </span>
+        )}
+      </p>
+      {index === 0 && (
+        <p className="text-xs text-[var(--muted-foreground)]">
+          A near-tie here often marks a compromise candidate: a place where a small, achievable
+          change to the scenario facts would flip which interest wins.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function DebateBlock({ debate }: { debate: InterestValidityDebate }) {
+  const scenarios: Array<InterestScenarioItem | null> =
+    debate.scenarios && debate.scenarios.length > 0 ? debate.scenarios : [null]
+  const objectiveCriteria = debate.objectiveCriteria ?? []
+
+  return (
+    <div className="space-y-6 border-l-2 border-gray-200 pl-4">
+      <div>
+        <p className="text-sm">
+          <strong>The interest:</strong>{' '}
+          {debate.interest ? (
+            debate.interest
+          ) : (
+            <span className="text-[var(--muted-foreground)] italic">
+              [state it as a need, fear, or desire, e.g. &ldquo;I need to feel my neighborhood is safe&rdquo;]
+            </span>
+          )}
+        </p>
+        <ul className="text-xs text-[var(--muted-foreground)] list-disc list-inside mt-2 space-y-1">
+          <li><strong>Default:</strong> treat the interest as valid until an argument lowers it. The burden is on the challenge.</li>
+          <li><strong>Both sides are rational:</strong> assume each side holds its interest for reasons tied to a real need.</li>
+          <li><strong>Arguments set the score:</strong> validity traces entirely to the scored reasons below, never to who holds the interest or how loudly they assert it.</li>
+          <li><strong>Maslow is a prior, not a verdict:</strong> the reasons below can move the starting band up or down.</li>
+        </ul>
+      </div>
+
+      {/* Scope 1 */}
+      <div>
+        <h4 className="text-sm font-semibold mb-1">Scope 1: Is This Interest Valid At All?</h4>
+        <p className="text-xs text-[var(--muted-foreground)] mb-2">
+          The absolute question. Each reason is a scored argument, named by its opening words and
+          attached to the criterion it leans on.
+        </p>
+        <TwoColumnReasons
+          leftTitle="Reasons it IS valid"
+          rightTitle="Reasons it is NOT valid"
+          leftRows={debate.validReasons ?? []}
+          rightRows={debate.invalidReasons ?? []}
+        />
+        <p className="text-sm mt-2">
+          <strong>Resulting Interest Validity:</strong> {validityCell(debate.validityScore)}, traceable
+          to the reasons above.
+        </p>
+      </div>
+
+      {/* Scope 2 */}
+      <div>
+        <h4 className="text-sm font-semibold mb-1">Scope 2: More or Less Valid Than Other Interests, In General?</h4>
+        <p className="text-xs text-[var(--muted-foreground)] mb-2">
+          The comparative question, scenario-independent. Start from the Maslow prior, then let the
+          reasons adjust the ranking.
+        </p>
+        <ComparisonTable rows={debate.generalComparisons ?? []} />
+        <p className="text-sm mt-3 mb-2">
+          The comparative claim, &ldquo;this interest is more valid than the competing interest in
+          general,&rdquo; then gets its own two columns:
+        </p>
+        <TwoColumnReasons
+          leftTitle="Reasons this interest ranks higher"
+          rightTitle="Reasons the other interest ranks higher"
+          leftRows={debate.ranksHigherReasons ?? []}
+          rightRows={debate.ranksLowerReasons ?? []}
+        />
+        <p className="text-sm mt-2">
+          <strong>General ranking:</strong>{' '}
+          {debate.generalRanking ?? (
+            <span className="text-[var(--muted-foreground)] italic">
+              [this interest above / below / tied with the comparison], by [XX] points
+            </span>
+          )}
+        </p>
+      </div>
+
+      {/* Scope 3 */}
+      <div>
+        <h4 className="text-sm font-semibold mb-1">Scope 3: Validity Within a Specific Conflict or Scenario</h4>
+        <p className="text-xs text-[var(--muted-foreground)] mb-2">
+          The contextual question, and the one that drives real conflict resolution. An interest that
+          is generally valid can rank differently once a concrete scenario sets the facts.
+        </p>
+        <div className="space-y-4">
+          {scenarios.map((scenario, i) => (
+            <ScenarioBlock key={i} scenario={scenario} index={i} />
+          ))}
+        </div>
+      </div>
+
+      {/* Objective criteria for this interest's validity */}
+      <div>
+        <h4 className="text-sm font-semibold mb-1">Objective Criteria for This Interest&apos;s Validity</h4>
+        <p className="text-xs text-[var(--muted-foreground)] mb-2">
+          The clear, testable criteria a neutral party would use to judge this interest&apos;s
+          validity. These feed the reasons in all three scopes above.
+        </p>
+        <ul className="list-disc list-inside text-sm space-y-1">
+          {objectiveCriteria.length > 0 ? (
+            objectiveCriteria.map((c, i) => <li key={i}>{c}</li>)
+          ) : (
+            <>
+              <li className="text-[var(--muted-foreground)] italic">
+                [criterion, e.g. &ldquo;number of people whose basic security depends on it&rdquo;]
+              </li>
+              <li className="text-[var(--muted-foreground)] italic">
+                [criterion, e.g. &ldquo;whether the same interest, applied universally, is sustainable&rdquo;]
+              </li>
+            </>
+          )}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default function InterestValiditySection({ debates }: InterestValiditySectionProps) {
+  const data = debates.length > 0 ? debates : [PLACEHOLDER_DEBATE]
+
+  return (
+    <div>
+      <h3 className="text-base font-semibold mb-1">Interest Validity Debate</h3>
+      <p className="text-xs text-[var(--muted-foreground)] italic mb-3">
+        When an interest&apos;s validity is itself the fight, it gets its own pro/con tree at three
+        scopes — valid at all, more or less valid than other interests in general, and valid within a
+        specific conflict. Validity is set by the scored reasons, nothing else. See the{' '}
+        <Link href="/Interests" className="text-[var(--accent)] hover:underline">Interest</Link>{' '}
+        two-score model.
+      </p>
+      <div className="space-y-8">
+        {data.map((debate, i) => (
+          <DebateBlock key={i} debate={debate} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/features/belief-analysis/components/InterestsSection.tsx
+++ b/src/features/belief-analysis/components/InterestsSection.tsx
@@ -5,6 +5,7 @@ import type {
   InterestValueLinkItem,
 } from '../types'
 import SectionHeading from './SectionHeading'
+import InterestValiditySection from './InterestValiditySection'
 
 interface InterestsSectionProps {
   interests: InterestsAnalysisData | null
@@ -169,6 +170,7 @@ export default function InterestsSection({ interests }: InterestsSectionProps) {
   const priorityRankings = interests?.priorityRankings ?? []
   const sharedVsConflicting = interests?.sharedVsConflicting ?? []
   const interestValueLinks = interests?.interestValueLinks ?? []
+  const validityDebates = interests?.validityDebates ?? []
 
   return (
     <section>
@@ -196,7 +198,7 @@ export default function InterestsSection({ interests }: InterestsSectionProps) {
       </div>
 
       {/* 6c. How Interests Drive Value Rankings */}
-      <div>
+      <div className="mb-6">
         <h3 className="text-base font-semibold mb-1">How Interests Drive Value Rankings</h3>
         <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
           When your material interests are at stake, you conveniently deprioritize values
@@ -204,6 +206,9 @@ export default function InterestsSection({ interests }: InterestsSectionProps) {
         </p>
         <InterestValueLinksTable rows={interestValueLinks} />
       </div>
+
+      {/* 6d. Interest Validity Debate (three scopes) — expanded when validity is contested */}
+      <InterestValiditySection debates={validityDebates} />
     </section>
   )
 }

--- a/src/features/belief-analysis/types.ts
+++ b/src/features/belief-analysis/types.ts
@@ -191,6 +191,93 @@ export interface InterestsAnalysisData {
   sharedVsConflicting?: SharedConflictingInterestItem[]
   /** Maps interests at stake to the values each side elevates / deprioritizes. */
   interestValueLinks?: InterestValueLinkItem[]
+  /**
+   * Per-interest three-scope validity debates, per the Interest Validity Debate
+   * Template. Expanded only when an interest's validity score is itself contested;
+   * the quick two-score read lives in the rankings tables above. Empty array means
+   * "not yet contested" and the section renders the template skeleton.
+   */
+  validityDebates?: InterestValidityDebate[]
+}
+
+/**
+ * A single interest's validity debate across the three scopes (valid at all,
+ * generally more/less valid than other interests, valid within a specific
+ * scenario). Validity traces entirely to the scored reasons below — never to who
+ * holds the interest or how loudly it is asserted. All scores are nullable so
+ * cells render blank until grounded in real sub-arguments (Rule 6).
+ */
+export interface InterestValidityDebate {
+  /** The interest stated as a need, fear, or desire. */
+  interest: string
+  /** Maslow band this interest starts from — a prior, not a verdict. e.g. "Safety 70-85". */
+  maslowPrior?: string | null
+
+  // ── Scope 1: Is this interest valid at all? ───────────────────────────────
+  /** Reasons it IS valid, each tied to a validity criterion. */
+  validReasons?: ValidityReasonItem[]
+  /** Reasons it is NOT valid, each tied to a validity criterion. */
+  invalidReasons?: ValidityReasonItem[]
+  /** Resulting Interest Validity (0-100), traceable to the Scope 1 reasons. */
+  validityScore?: number | null
+
+  // ── Scope 2: More or less valid than other interests, in general? ─────────
+  /** The interest plus competing interests, each with Maslow prior and current validity. */
+  generalComparisons?: InterestComparisonItem[]
+  /** Reasons this interest ranks higher than the comparison, in general. */
+  ranksHigherReasons?: ValidityReasonItem[]
+  /** Reasons the other interest ranks higher, in general. */
+  ranksLowerReasons?: ValidityReasonItem[]
+  /** General ranking verdict, e.g. "above the comparison by 12 points". */
+  generalRanking?: string | null
+
+  // ── Scope 3: Validity within specific conflicts or scenarios ──────────────
+  /** One block per concrete scenario; a scenario fact can flip the general ranking. */
+  scenarios?: InterestScenarioItem[]
+
+  /** Objective, testable criteria a neutral party would use to judge this validity. */
+  objectiveCriteria?: string[]
+}
+
+/**
+ * One scored reason in a validity debate column. The reason is a short label
+ * (named by its opening words, per Rule 3); the criterion is the standard it
+ * leans on (e.g. "passes the universal test", "rests on a false premise").
+ */
+export interface ValidityReasonItem {
+  /** Signed score, e.g. +35 / -20. Null renders blank (Rule 6). */
+  score?: number | null
+  /** The reason, named by its opening words (2-6 word label). */
+  reason: string
+  /** The validity criterion this reason leans on. */
+  criterion?: string | null
+}
+
+/** One interest in the Scope 2 comparison table. */
+export interface InterestComparisonItem {
+  interest: string
+  /** Maslow prior starting band, e.g. "Safety 70-85". */
+  maslowPrior?: string | null
+  /** Current validity (0-100). */
+  currentValidity?: number | null
+  /** True for the interest under analysis, false for a competing interest. */
+  isThisInterest?: boolean
+}
+
+/** One concrete scenario in the Scope 3 contextual validity debate. */
+export interface InterestScenarioItem {
+  /** Describe the specific conflict. */
+  scenario: string
+  /** The interest it collides with in this scenario. */
+  competingInterest?: string | null
+  /** The scenario fact that moves the ranking (imminence, scale, reversibility, who else is affected). */
+  scenarioFact?: string | null
+  /** Reasons it should win here, each tied to a scenario fact. */
+  winReasons?: ValidityReasonItem[]
+  /** Reasons it should yield here, each tied to a scenario fact. */
+  yieldReasons?: ValidityReasonItem[]
+  /** In-scenario ranking verdict and why scenario facts caused it to differ from Scope 2. */
+  inScenarioRanking?: string | null
 }
 
 export interface InterestPriorityRankingItem {

--- a/templates/interest-validity-debate-template.html
+++ b/templates/interest-validity-debate-template.html
@@ -1,0 +1,156 @@
+<p style="text-align: right;"><strong><a href="/w/page/159323433/One%20Page%20Per%20Topic">Topic</a>:</strong>&nbsp;<a href="/w/page/21957511/Explanation">ISE Framework</a>&nbsp;&gt;&nbsp;Templates&nbsp;&gt;&nbsp;Interest Validity Debate Template</p>
+<h1 style="background-color: #2c3e50; color: #ffffff; padding: 10px 15px;">Interest Validity Debate Template</h1>
+<p>A validity question is just a claim. "This interest is valid," "this interest matters more than that one," and "in this standoff, safety outranks privacy" are all beliefs with reasons to agree and disagree, and they get scored the same way every other belief on the ISE does. This template is that pro/con skeleton applied to validity at three scopes.</p>
+<p><strong>When to use it:</strong> when the <strong>Interest Validity</strong> score is itself the fight. For the quick two-score read on an interest (Linkage Accuracy and Interest Validity together), use the <a href="/w/page/159387582/InterestsMotivation%20Template">Interest Evaluation Template</a> and only expand to this page when validity is contested. This page is to the Validity score what a belief page is to a single argument: the place it gets its own tree.</p>
+<p>For the definition and the two-score model, see <a href="/w/page/159301140/Interests">Interest</a>. For the criteria and the Maslow priors referenced below, see the <a href="/w/page/159323067/Brainstorming%20Interests%20for%20Policy%20Debates">Interest Scoring Methodology</a>. This page applies that model, it does not restate it.</p>
+<p><em>Scores below are illustrative placeholders. The live scoring engine is on the roadmap, not running yet.</em></p>
+<hr />
+<h2 style="background-color: #34495e; color: #ffffff; padding: 8px 12px;">The Interest and the Ground Rules</h2>
+<p><strong>The interest:</strong> [state it as a need, fear, or desire, e.g. "I need to feel my neighborhood is safe"]</p>
+<ul>
+<li><strong>Default:</strong> treat the interest as valid until an argument lowers it. The burden is on the challenge.</li>
+<li><strong>Both sides are rational:</strong> assume people on each side hold their interest for reasons tied to a real need, not because they are stupid or evil.</li>
+<li><strong>Arguments set the score, nothing else:</strong> validity traces entirely to the scored reasons below. It is never set by who holds the interest, how powerful they are, or how loudly they assert it.</li>
+<li><strong>Maslow is a prior, not a verdict:</strong> where the need sits on the hierarchy is a starting point that the reasons below can move up or down.</li>
+</ul>
+<hr />
+<h2 style="background-color: #34495e; color: #ffffff; padding: 8px 12px;">Scope 1: Is This Interest Valid At All?</h2>
+<p>The absolute question. Each reason is a scored argument, named by its opening words, attached to the criterion it leans on (universal test, reciprocity, rests on a true premise, harm to others, impact scope, reversibility, alternative satisfaction).</p>
+<table style="border-collapse: collapse; width: 100%;" border="1" cellpadding="8">
+<thead style="background-color: #ecf0f1;">
+<tr>
+<th style="width: 50%;">Reasons it IS valid</th>
+<th style="width: 50%;">Reasons it is NOT valid</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[+XX] [reason, named by opening words] (criterion: e.g. passes the universal test)</td>
+<td>[-XX] [reason] (criterion: e.g. rests on a false premise)</td>
+</tr>
+<tr>
+<td>[+XX] [reason] (criterion: e.g. meets a need with no alternative)</td>
+<td>[-XX] [reason] (criterion: e.g. can only be met at another's expense)</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Resulting Interest Validity:</strong> [XX]/100, traceable to the reasons above.</p>
+<hr />
+<h2 style="background-color: #34495e; color: #ffffff; padding: 8px 12px;">Scope 2: Is It More or Less Valid Than Other Interests, In General?</h2>
+<p>The comparative question, scenario-independent. Start from the Maslow prior for each interest, then let the reasons adjust the ranking.</p>
+<table style="border-collapse: collapse; width: 100%;" border="1" cellpadding="8">
+<thead style="background-color: #ecf0f1;">
+<tr>
+<th>Interest</th><th>Maslow prior (starting band)</th><th>Current validity</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>This interest</strong></td>
+<td>[level, e.g. Safety 70-85]</td>
+<td>[XX]</td>
+</tr>
+<tr>
+<td>[Competing interest]</td>
+<td>[level]</td>
+<td>[XX]</td>
+</tr>
+</tbody>
+</table>
+<p>The comparative claim, "this interest is more valid than [competing interest] in general," then gets its own two columns:</p>
+<table style="border-collapse: collapse; width: 100%;" border="1" cellpadding="8">
+<thead style="background-color: #ecf0f1;">
+<tr>
+<th style="width: 50%;">Reasons this interest ranks higher</th>
+<th style="width: 50%;">Reasons the other interest ranks higher</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[+XX] [reason] (criterion: e.g. larger impact scope, harder to meet another way)</td>
+<td>[-XX] [reason] (criterion: e.g. its harm is irreversible)</td>
+</tr>
+<tr>
+<td>[+XX] [reason]</td>
+<td>[-XX] [reason]</td>
+</tr>
+</tbody>
+</table>
+<p><strong>General ranking:</strong> [this interest above / below / tied with the comparison], by [XX] points.</p>
+<hr />
+<h2 style="background-color: #34495e; color: #ffffff; padding: 8px 12px;">Scope 3: Validity Within a Specific Conflict or Scenario</h2>
+<p>The contextual question, and the one that drives real conflict resolution. An interest that is generally valid can rank differently once a concrete scenario sets the facts. A scenario fact (imminence, scale, reversibility, who else is affected) is what flips a general ranking. Copy this block once per scenario.</p>
+<table style="border-collapse: collapse; width: 100%;" border="1" cellpadding="8">
+<thead style="background-color: #ecf0f1;">
+<tr>
+<th style="width: 30%;">Scenario</th><th style="width: 35%;">Competing interest</th><th style="width: 35%;">Scenario fact that moves the ranking</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[describe the specific conflict]</td>
+<td>[the interest it collides with here]</td>
+<td>[e.g. the harm is imminent and irreversible]</td>
+</tr>
+</tbody>
+</table>
+<p>The scenario claim, "in this conflict, this interest should outrank [competing interest]," gets its two columns:</p>
+<table style="border-collapse: collapse; width: 100%;" border="1" cellpadding="8">
+<thead style="background-color: #ecf0f1;">
+<tr>
+<th style="width: 50%;">Reasons it should win here</th>
+<th style="width: 50%;">Reasons it should yield here</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[+XX] [reason tied to a scenario fact]</td>
+<td>[-XX] [reason tied to a scenario fact]</td>
+</tr>
+<tr>
+<td>[+XX] [reason]</td>
+<td>[-XX] [reason]</td>
+</tr>
+</tbody>
+</table>
+<p><strong>In-scenario ranking:</strong> [this interest wins / yields here], which may differ from the general ranking in Scope 2. Note the difference and why the scenario facts caused it.</p>
+<p>This is the input the <a href="/w/page/159387558/Conflict%20Resolution%20Framework%20in%20the%20Idea%20Stock%20Exchange%2C%20Understanding%20Interests%20not%20just%20positions">Conflict Resolution Pipeline</a> reads at steps 5 and 6, and a near-tie here often marks a <a href="/w/page/162560439/Compromise">compromise candidate</a>: a place where a small, achievable change to the scenario facts would flip which interest wins.</p>
+<hr />
+<h2 style="background-color: #34495e; color: #ffffff; padding: 8px 12px;">Objective Criteria for This Interest's Validity</h2>
+<p>List the clear, testable criteria a neutral party would use to judge this interest's validity, so the debate stays anchored to standards instead of sympathy. These feed the reasons in all three scopes above.</p>
+<ul>
+<li>[criterion, e.g. "number of people whose basic security depends on it"]</li>
+<li>[criterion, e.g. "whether the same interest, applied universally, is sustainable"]</li>
+</ul>
+<p><em>See: <a href="/w/page/159351732/Objective%20criteria%20scores">Objective Criteria Scores</a>, <a href="/Insisting%20on%20Objective%20Criteria">Insisting on Objective Criteria</a></em></p>
+<hr />
+<h2 style="background-color: #34495e; color: #ffffff; padding: 8px 12px;">Related Pages</h2>
+<table style="border-collapse: collapse; width: 100%;" border="1" cellpadding="8">
+<tbody>
+<tr>
+<td><a href="/w/page/159301140/Interests">Interest</a></td>
+<td>Definition and the two-score model</td>
+</tr>
+<tr>
+<td><a href="/w/page/159387582/InterestsMotivation%20Template">Interest Evaluation Template</a></td>
+<td>The quick two-score read this page expands from</td>
+</tr>
+<tr>
+<td><a href="/w/page/159323067/Brainstorming%20Interests%20for%20Policy%20Debates">Interest Scoring Methodology</a></td>
+<td>The validity criteria and Maslow priors</td>
+</tr>
+<tr>
+<td><a href="/w/page/159387558/Conflict%20Resolution%20Framework%20in%20the%20Idea%20Stock%20Exchange%2C%20Understanding%20Interests%20not%20just%20positions">Conflict Resolution Pipeline</a></td>
+<td>Where scenario rankings drive resolution</td>
+</tr>
+<tr>
+<td><a href="/w/page/162560439/Compromise">Compromise</a></td>
+<td>Building solutions from near-ties and shared interests</td>
+</tr>
+<tr>
+<td><a href="/w/page/159300543/ReasonRank">ReasonRank</a></td>
+<td>How the pro/con reasons above are scored</td>
+</tr>
+</tbody>
+</table>
+<p><em>Full belief-level pro/con, ethical ends/means, and stakeholder lists live on the parent <a href="/w/page/21959883/Template">belief page</a>, not here.</em></p>


### PR DESCRIPTION
## Summary

Adds a new **Interest Validity Debate** section to the belief analysis page, implementing the three-scope validity framework for contested interests. This section expands the quick two-score Interest Validity read into a full pro/con debate structure when an interest's validity is itself the fight.

## Changes

- **New component:** `InterestValiditySection.tsx` — renders the three-scope validity debate (Scope 1: valid at all, Scope 2: general ranking vs. other interests, Scope 3: validity within specific scenarios). Includes sub-components for reason rows, comparison tables, and scenario blocks. Renders template skeleton when no data exists (Rule 6).

- **New types:** Added to `types.ts`:
  - `InterestValidityDebate` — the root debate structure with Maslow prior, three scopes of reasons, and objective criteria
  - `ValidityReasonItem` — scored reason with criterion attachment
  - `InterestComparisonItem` — interest + Maslow prior + current validity for Scope 2 ranking
  - `InterestScenarioItem` — concrete scenario with competing interest, scenario fact, and win/yield reasons for Scope 3
  - Added `validityDebates` field to `InterestsAnalysisData`

- **Integration:** Updated `InterestsSection.tsx` to import and render `InterestValiditySection` when validity debates are present.

- **Template:** Added `interest-validity-debate-template.html` — the canonical HTML template matching the component structure, with ground rules, three scopes, objective criteria section, and related pages.

- **Documentation:** Updated `BELIEF_PAGE_RULES.md` to reference the new section in the canonical order.

## Implementation Details

- All scores are nullable so cells render blank until grounded in real sub-arguments (Rule 6 compliance).
- Placeholder debate renders when the array is empty, showing the template skeleton.
- Two-column reason tables (pro/con) use color coding: green for positive reasons, red for negative.
- Scenario blocks include a note on near-ties as compromise candidates.
- Maslow prior is treated as a starting point, not a verdict — reasons can move the ranking up or down.
- Validity traces entirely to scored reasons, never to who holds the interest or how loudly it is asserted.

https://claude.ai/code/session_01Sk8zzPiJevftN14EBRH5uc