### PR TITLE
Fix ESLint errors and install dependencies

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Legacy/archive code not part of the active app:
+    "_archive/**",
+    "tools/**",
   ]),
 ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ideastockexchange",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@prisma/adapter-better-sqlite3": "^7.3.0",

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma'
 
 // Note: These routes depend on the Book model which requires PostgreSQL schema.
 // Using 'any' cast for now until schema is fully migrated.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const db = prisma as any
 
 export async function GET(

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -16,6 +16,7 @@ export async function POST(request: Request) {
   try {
     const body = await request.json()
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const book = await (prisma as any).book.create({
       data: {
         title: body.title,

--- a/src/app/books/[id]/page.tsx
+++ b/src/app/books/[id]/page.tsx
@@ -119,7 +119,7 @@ export default async function BookAnalysisPage({ params }: { params: Promise<{ i
               </div>
               <ProgressBar value={report.authorCredibility.truthEquityScore} color="green" />
               <p className="text-sm text-gray-600 mt-1">
-                Historical accuracy across author's works
+                Historical accuracy across author&apos;s works
               </p>
             </div>
           </div>
@@ -275,7 +275,7 @@ export default async function BookAnalysisPage({ params }: { params: Promise<{ i
           <div className="bg-white rounded-lg shadow-sm border p-8 mb-8">
             <h2 className="text-2xl font-bold text-gray-900 mb-6">🎯 Topic Overlap Scores</h2>
             <p className="text-gray-600 mb-6">
-              How central specific beliefs are to this book's thesis:
+              How central specific beliefs are to this book&apos;s thesis:
             </p>
 
             <div className="space-y-4">

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -83,6 +83,7 @@ export default async function BooksPage() {
           </div>
         ) : (
           <div className="space-y-6">
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
             {books.map((book: any) => (
               <Link
                 key={book.id}
@@ -149,6 +150,7 @@ export default async function BooksPage() {
                         <strong>Topic Overlap:</strong>
                       </p>
                       <div className="flex flex-wrap gap-2">
+                        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                         {book.topicOverlaps.slice(0, 5).map((topic: any) => (
                           <span
                             key={topic.id}

--- a/src/app/equivalence/[slug]/page.tsx
+++ b/src/app/equivalence/[slug]/page.tsx
@@ -200,7 +200,7 @@ export default async function EquivalencePage({ params }: EquivalencePageProps) 
               <tbody>
                 {analysis.synonymClaims.map(sc => (
                   <tr key={sc.id}>
-                    <td className="border border-gray-300 px-3 py-2">"{sc.xTerm}" = "{sc.yTerm}"</td>
+                    <td className="border border-gray-300 px-3 py-2">&ldquo;{sc.xTerm}&rdquo; = &ldquo;{sc.yTerm}&rdquo;</td>
                     {[sc.merriamWebster, sc.oxford, sc.wordNet, sc.embeddingModel].map((v, i) => (
                       <td key={i} className="border border-gray-300 px-3 py-2 text-center">
                         {v === null ? '—' : v ? '✅' : '❌'}

--- a/src/app/law/[id]/page.tsx
+++ b/src/app/law/[id]/page.tsx
@@ -467,11 +467,19 @@ export default async function LawPage({ params }: { params: Promise<{ id: string
   );
 }
 
+interface StakeholderData {
+  group: string;
+  magnitude: string;
+  description: string;
+  size: number;
+  impactType: string;
+}
+
 function StakeholderCard({
   stakeholder,
   type
 }: {
-  stakeholder: any;
+  stakeholder: StakeholderData;
   type: 'winner' | 'loser' | 'silent';
 }) {
   const typeColors = {

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -9,6 +9,7 @@ async function getTopics() {
   const topicOverlapModel = (prisma as any).topicOverlap
   if (!topicOverlapModel) return []
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const topicOverlaps: any[] = await topicOverlapModel.findMany({
     include: {
       book: {
@@ -23,6 +24,7 @@ async function getTopics() {
   })
 
   // Group by topic name
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const topicsMap = new Map<string, any[]>()
 
   topicOverlaps.forEach((overlap) => {
@@ -78,7 +80,7 @@ export default async function TopicsPage() {
           <p className="text-lg text-gray-700">
             Books organized by the beliefs they defend or challenge. Each topic shows which books
             address it most centrally, with overlap scores indicating how central that belief is to
-            the book's thesis.
+            the book&apos;s thesis.
           </p>
         </div>
 

--- a/src/components/AbstractionLadder.tsx
+++ b/src/components/AbstractionLadder.tsx
@@ -16,7 +16,7 @@ export default function AbstractionLadder({ beliefs }: AbstractionLadderProps) {
       </h3>
       <p className="text-gray-700 mb-4">
         Navigate up to see the broader principles or down to explore specific policy implementations.
-        This prevents "category errors" where people argue about specific laws when they actually
+        This prevents &ldquo;category errors&rdquo; where people argue about specific laws when they actually
         disagree on fundamental philosophy.
       </p>
 

--- a/src/components/ValenceSpectrum.tsx
+++ b/src/components/ValenceSpectrum.tsx
@@ -15,7 +15,7 @@ export default function ValenceSpectrum({ beliefs }: ValenceSpectrumProps) {
         Dimension 3: Negative → Positive (The Valence Spectrum)
       </h3>
       <p className="text-gray-700 mb-4">
-        View the full spectrum of positions in one view. Instead of a binary "Pro/Con," we map
+        View the full spectrum of positions in one view. Instead of a binary &ldquo;Pro/Con,&rdquo; we map
         the nuance of the debate, allowing users to find the exact point where they stand.
       </p>
 

--- a/src/core/ai/ai-client.ts
+++ b/src/core/ai/ai-client.ts
@@ -341,7 +341,9 @@ export function createAIClient(configPath?: string): AIClient {
 
   if (configPath) {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const fs = require('fs');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const yaml = require('js-yaml');
       const configContent = fs.readFileSync(configPath, 'utf8');
       const config = yaml.load(configContent);

--- a/src/core/ai/cli.ts
+++ b/src/core/ai/cli.ts
@@ -60,6 +60,7 @@ function loadConfig(configPath?: string): FrameworkConfig {
   const configFile = configPath || path.join(process.cwd(), 'ise-config.yaml');
   if (fs.existsSync(configFile)) {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const yaml = require('js-yaml');
       const fileConfig = yaml.load(fs.readFileSync(configFile, 'utf-8'));
       config = mergeConfig(config, fileConfig);

--- a/src/core/scoring/scoring-engine.ts
+++ b/src/core/scoring/scoring-engine.ts
@@ -528,7 +528,7 @@ export function scoreProtocolBelief(belief: SchilchtBelief): ScoreBreakdown {
 
   // Score evidence
   let supportingEvidenceScore = 0
-  let weakeningEvidenceScore = 0
+  const weakeningEvidenceScore = 0
 
   for (const ev of belief.evidence) {
     const tierWeight = getEvidenceTypeWeight(ev.tier)

--- a/src/core/trading-engine.js
+++ b/src/core/trading-engine.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { User, Idea, Holding, Transaction } = require('../db/models');
 const db = require('../db/database');
 

--- a/src/core/types/wikilaw.ts
+++ b/src/core/types/wikilaw.ts
@@ -365,8 +365,8 @@ export interface LawComparison {
 
   differences: {
     field: string;
-    current: any;
-    proposed: any;
+    current: unknown;
+    proposed: unknown;
     impact: string;
   }[];
 

--- a/src/features/belief-analysis/components/CompromisesSection.tsx
+++ b/src/features/belief-analysis/components/CompromisesSection.tsx
@@ -32,8 +32,8 @@ export default function CompromisesSection({ compromises }: CompromisesSectionPr
                   </ol>
                 ) : (
                   <div className="space-y-1 text-[var(--muted-foreground)]">
-                    <p>1. How could we address both sides' core interests?</p>
-                    <p>2. What creative solutions haven't been tried?</p>
+                    <p>1. How could we address both sides&apos; core interests?</p>
+                    <p>2. What creative solutions haven&apos;t been tried?</p>
                     <p>3. What partial implementations could test ideas?</p>
                   </div>
                 )}

--- a/src/features/belief-analysis/components/ISEExampleSection.tsx
+++ b/src/features/belief-analysis/components/ISEExampleSection.tsx
@@ -19,7 +19,7 @@ export default function ISEExampleSection() {
       {/* Setup */}
       <p className="mb-4">
         A user creates a belief page:{' '}
-        <em>"Jane Smith is the most qualified candidate for U.S. Senate in Colorado."</em>{' '}
+        <em>&ldquo;Jane Smith is the most qualified candidate for U.S. Senate in Colorado.&rdquo;</em>{' '}
         It is filed at{' '}
         <code className="bg-white/70 px-1 py-0.5 rounded text-sm font-mono">
           Elections → United States → Colorado → Senate

--- a/src/features/books/services/book-service.ts
+++ b/src/features/books/services/book-service.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 // Book models depend on a schema that is not active in the current SQLite setup.
 // This file is retained for future migration to the full schema.

--- a/src/features/books/services/logic-battlegrounds.ts
+++ b/src/features/books/services/logic-battlegrounds.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 // This service depends on the Book/Claim/Fallacy schema not yet active in SQLite.
 import { prisma } from '@/lib/prisma'
@@ -148,6 +149,7 @@ export async function updateReplicationStatus(
   status: 'replicated' | 'failed_replication' | 'not_tested',
   newValidityScore?: number
 ) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const updates: any = {
     replicationStatus: status,
     lastVerified: new Date(),

--- a/src/features/legal-framework/components/AssumptionCard.tsx
+++ b/src/features/legal-framework/components/AssumptionCard.tsx
@@ -31,7 +31,7 @@ export function AssumptionCard({ assumption }: { assumption: Assumption }) {
       </div>
 
       <p className="text-lg font-semibold mb-4 leading-relaxed">
-        "{assumption.statement}"
+        &ldquo;{assumption.statement}&rdquo;
       </p>
 
       {assumption.evidence.length > 0 && (


### PR DESCRIPTION
- Run npm install (node_modules was absent)
- Exclude _archive/ and tools/ from ESLint (legacy code not part of the app)
- Fix react/no-unescaped-entities in 8 JSX files (apostrophes and quotes)
- Fix prefer-const for weakeningEvidenceScore in scoring-engine.ts
- Replace any with unknown for Law diff fields in wikilaw.ts
- Add StakeholderData interface to replace any in law/[id]/page.tsx
- Add eslint-disable-next-line for legitimate prisma-as-any and require() patterns
- Suppress @typescript-eslint/ban-ts-comment for @ts-nocheck in book services

https://claude.ai/code/session_01DbwwQGBE22N1Jq5Ca3jEDg