### PR TITLE
Add the denominator: score beliefs against their counterclaims

### DIFF
--- a/docs/BELIEF_PAGE_RULES.md
+++ b/docs/BELIEF_PAGE_RULES.md
@@ -149,6 +149,16 @@ Score / Related) → "Beliefs this supports" line. No summary or background (Rul
    Disagree), each side with `Argument / Score / Link / Impact`. Each argument cell is
    the claim, the single most famous supporting quote inline (italic, small), then the
    submitter as `~Name`. Pro Total / Con Total row, then the **Net Belief Score** line.
+   The Net Belief Score is reported as a **share and margin** — the net divided by the
+   belief's own `Pro + Con` total — not as a bare numerator. A bare "+9.2" floats free;
+   "58% of the argument weight, a +15-point margin" is actionable. This is the *internal*
+   denominator (the belief vs. its own rebuttals). See `docs/THE_DENOMINATOR.md`.
+1b. **Contrast Class** *(only when the topic has a rival option set)* — the *external*
+   denominator made visible: the mutually exclusive rivals this belief is priced against,
+   each with its own argument-tree score `S` and an **opportunity-cost value**
+   `OCV = S(this) − max S(rivals)`. Exactly one option (the field winner) has `OCV > 0`.
+   Every option's score must trace to its own belief's tree — never a fabricated constant
+   (Rule 6). Comparative arguments ("rival Y beats X") belong here, not in the con column.
 2. **Evidence Ledger** — one two-sided table (Supporting / Weakening), each side with
    `Evidence / Type / Link / Impact`.
 3. **Conflict Resolution Framework**

--- a/docs/THE_DENOMINATOR.md
+++ b/docs/THE_DENOMINATOR.md
@@ -1,0 +1,103 @@
+# The Denominator: Scoring a Belief Against Its Counterclaims
+
+*Framework spec for the ISE scoring engine. A pro-minus-con score floats free
+until you divide it by something, and the right something is the rival claim.*
+
+This document is the canonical reference for the contrast-class / opportunity-cost
+layer. It is referenced by:
+
+- `src/core/scoring/contrast-class.ts` — the engine (pure math, two layers)
+- `src/features/belief-analysis/components/ContrastClassSection.tsx` — the page block
+- `src/features/belief-analysis/components/ArgumentTreesSection.tsx` — the share/margin readout
+- `src/features/belief-analysis/data/contrast-classes.ts` — the static option-set overlay
+- `templates/belief-analysis-template.html` and `docs/BELIEF_PAGE_RULES.md`
+
+Keep this doc, the rules doc, the template, and the page in sync.
+
+---
+
+## 1. The bug
+
+A bare **Net Belief Score** of `Pro Total − Con Total` is a numerator with nothing
+under the line. "+9.2 relative to what?" A pro-minus-con silently picks "do nothing"
+as the denominator and never tells you. The real rival is often already sitting in
+the con column disguised as a single argument. The fix is to stop hiding the
+denominator and make it a structural part of the page.
+
+## 2. Core principle
+
+Value is never absolute. It is always *against the next thing you could have chosen* —
+the economist's **opportunity cost**. The unit of scoring is the belief plus its
+**contrast class**: the set of mutually exclusive claims that answer the same question
+and compete for the same budget. On ISE this is the spectrum of positions on the Topic
+page. One constraint makes it rigorous: **you can only divide commensurable things.**
+Only rival answers to one question share a denominator.
+
+## 3. Two layers (they stack, they do not compete)
+
+- **Layer 1 — Justification (internal denominator).** `J(X) = (Pro − Con) / (Pro + Con)`,
+  range −1..+1. How lopsided the belief is versus its own rebuttals. Doubles as the
+  Rule 9 inversion trigger (negative ⇒ net-refuted). Identity: `J = 2p − 1` where
+  `p = Pro / (Pro + Con)` is the implied-probability / market-share view.
+  - *Cautions:* it washes out evidence volume (`[9,1]` and `[90,10]` both score +0.8 —
+    report mass alongside, never folded in) and it is paddable (discount duplicates).
+- **Layer 2 — Comparative / opportunity cost (external denominator).**
+  `OCV(oi) = S(oi) − max_{j≠i} S(oj)`. Does the belief beat its best rival? Exactly one
+  option has `OCV > 0`. Magnitude is what you give up by not choosing the best rival.
+
+Layer 1 produces the quantity Layer 2 compares: Layer 1 runs inside each node, Layer 2
+across the siblings.
+
+### Criteria-normalized denominator
+Score every option on the same objective criteria, min-max normalize each criterion
+across the rivals (`n(oi,k) = (r − min)/(max − min)`), then weight by per-criterion
+**importance** (which lives on the *topic*, the right home for the otherwise-blank
+Importance column): `W(oi) = Σ_k importance_k · n(oi,k)`. Use `W` to *decompose* a
+margin, not as a second headline.
+
+### Argument sorting (the dedup that cleans Layer 1)
+Sort every argument before scoring: **intrinsic** ("X is true on its own terms") feeds
+Layer 1; **comparative** ("rival Y beats X") is pulled out of the pro/con tally and
+moved to Layer 2. Left in the con column a comparative argument double-counts the rival.
+
+## 4. Signed-score edge case
+
+ReasonRank scores can go negative. A share `S / ΣS` is only meaningful for non-negative
+inputs. **Preferred:** drop the share for signed quantities and report `OCV` (well-defined
+for any reals). **If a 0–1 field view is wanted:** rank-shift `S'(o) = S(o) − min + ε`
+first and state the shift so nobody mistakes it for a probability. Rule 9 (invert
+negative beliefs to positive form) reinforces this — a class of positive claims mostly
+avoids the signed-score problem at the top level.
+
+## 5. Engine spec
+
+For a topic with mutually exclusive options `O = {o1 … on}`:
+
+1. Each `oi` carries an argument-tree score `S(oi)` from existing ReasonRank machinery.
+   No new scoring primitive — the denominator is built from scores the engine produces.
+2. Pairwise margin `M(oi, oj) = S(oi) − S(oj)`.
+3. Opportunity-cost value `OCV(oi) = S(oi) − max_{j≠i} S(oj)` — the headline comparative score.
+4. Criteria matrix `n(oi,k)` (min-max) and `W(oi) = Σ importance_k · n(oi,k)` for decomposition.
+5. Field share (optional) `Price(oi) = S(oi) / Σ S(oj)` **only** when all `S ≥ 0`; otherwise
+   report `OCV`, never a faked probability.
+
+## 6. Invariant contract
+
+All seven engine invariants hold: the 0–1 ranges are affine rescalings of real rival
+scores (no tanh/clamp by fiat); `OCV`/`Price` are **outputs** that must never feed back
+into any argument's `S` (one-way valve); every term under the line is itself a fully
+scored, audited node, so traceability holds end to end.
+
+## 7. What changes on a belief page
+
+1. Add a **Contrast Class** block: the mutually exclusive option set, each rival's `S`, and OCV.
+2. Promote comparative "rival is better" arguments out of the con table into the Contrast Class.
+3. Relabel the headline: bare net → share + margin (Layer 1) and `OCV` vs. the named best rival (Layer 2).
+4. Fill the **Importance** column from the topic's per-criterion weights.
+5. Print the denominator beside every verdict: "harm > good" never stands alone; it carries its "compared to ___".
+
+---
+
+*Bottom line: pro-minus-con answered "do the reasons to agree win on this island,"
+when the real question is "does this island beat the next island over." Put the rival
+under the line.*

--- a/prisma/seed-beliefs.ts
+++ b/prisma/seed-beliefs.ts
@@ -274,6 +274,28 @@ async function main() {
     ],
   })
 
+  // Argument trees for the RIVAL options in the income-floor contrast class.
+  // The denominator framework (docs/THE_DENOMINATOR.md) prices UBI against its
+  // rivals, so each rival needs its own scored tree for OCV to be real and
+  // traceable rather than a fabricated constant. Negative income tax reuses the
+  // shared pro-beliefs (poverty reduction, lower bureaucracy) and is weakened by
+  // the same fiscal worry; automated luxury communism shares the automation
+  // premise but is dragged down by the fiscal-sustainability and work-incentive cons.
+  await prisma.argument.createMany({
+    data: [
+      // Negative income tax (moderateBelief) — a strong, well-supported rival.
+      { parentBeliefId: moderateBelief.id, beliefId: povertyBelief.id, side: 'agree', linkageScore: 0.8, impactScore: 21.0, linkageType: 'STRONG_CAUSAL' },
+      { parentBeliefId: moderateBelief.id, beliefId: bureaucracyBelief.id, side: 'agree', linkageScore: 0.6, impactScore: 14.0, linkageType: 'CONTEXTUAL' },
+      { parentBeliefId: moderateBelief.id, beliefId: marketFreedomBelief.id, side: 'agree', linkageScore: 0.55, impactScore: 11.0, linkageType: 'CONTEXTUAL' },
+      { parentBeliefId: moderateBelief.id, beliefId: fiscalBelief.id, side: 'disagree', linkageScore: 0.5, impactScore: 9.0, linkageType: 'STRONG_CAUSAL' },
+      // Fully automated luxury communism (extremeBelief) — a weak rival: shares
+      // the automation premise but loses badly on fiscal and work-incentive cons.
+      { parentBeliefId: extremeBelief.id, beliefId: automationBelief.id, side: 'agree', linkageScore: 0.7, impactScore: 16.0, linkageType: 'STRONG_CAUSAL' },
+      { parentBeliefId: extremeBelief.id, beliefId: fiscalBelief.id, side: 'disagree', linkageScore: 0.8, impactScore: 24.0, linkageType: 'STRONG_CAUSAL' },
+      { parentBeliefId: extremeBelief.id, beliefId: workIncentiveBelief.id, side: 'disagree', linkageScore: 0.65, impactScore: 18.0, linkageType: 'STRONG_CAUSAL' },
+    ],
+  })
+
   // Create evidence
   await prisma.evidence.createMany({
     data: [

--- a/src/app/beliefs/[slug]/page.tsx
+++ b/src/app/beliefs/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { fetchBeliefBySlug, computeBeliefScores } from '@/features/belief-analysis/data/fetch-belief'
 import ArgumentTreesSection from '@/features/belief-analysis/components/ArgumentTreesSection'
+import ContrastClassSection from '@/features/belief-analysis/components/ContrastClassSection'
 import EvidenceSection from '@/features/belief-analysis/components/EvidenceSection'
 import ConflictResolutionSection from '@/features/belief-analysis/components/ConflictResolutionSection'
 import ObjectiveCriteriaSection from '@/features/belief-analysis/components/ObjectiveCriteriaSection'
@@ -109,6 +110,14 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
             totalCon={scores.totalCon}
             netInterpretation={belief.netInterpretation}
           />
+
+          {belief.contrastClass && belief.contrastClass.options.length > 0 && (
+            <>
+              <hr className="border-gray-200" />
+              {/* The denominator, made visible — rivals this belief is priced against. */}
+              <ContrastClassSection contrastClass={belief.contrastClass} />
+            </>
+          )}
 
           <hr className="border-gray-200" />
 

--- a/src/core/scoring/contrast-class.ts
+++ b/src/core/scoring/contrast-class.ts
@@ -1,0 +1,375 @@
+/**
+ * The Denominator — Scoring a Belief Against Its Counterclaims
+ *
+ * A bare pro-minus-con score is a numerator with nothing under the line:
+ * "+9.2" relative to what? This module supplies the denominator. There are
+ * two layers, and they stack rather than compete:
+ *
+ *   Layer 1 (internal denominator) — the JUSTIFICATION score. Divide the net
+ *   by the belief's OWN total argument weight: (Pro − Con) / (Pro + Con).
+ *   Answers "how lopsided is this claim versus its own rebuttals?" Range −1..+1.
+ *   Doubles as the Rule 9 inversion trigger (negative ⇒ net-refuted).
+ *
+ *   Layer 2 (external denominator) — the COMPARATIVE score. Divide against the
+ *   best RIVAL in the contrast class: OCV(oi) = S(oi) − max_{j≠i} S(oj).
+ *   Answers "does this claim beat the alternatives?" Exactly one option in a
+ *   contrast class has OCV > 0 (the winner); every other option's negative
+ *   magnitude is what you give up by choosing it instead of the best rival.
+ *
+ * Layer 1 produces the quantity Layer 2 compares: Layer 1 runs inside each
+ * node, Layer 2 across the siblings. Nothing here introduces a new scoring
+ * primitive — every term under the line is itself an audited, scored value, so
+ * the engine's traceability invariant holds end to end. These are OUTPUTS
+ * (read-only readouts); they must never feed back into any argument's score.
+ *
+ * Spec: docs/THE_DENOMINATOR.md
+ */
+
+// ─── Layer 1: internal denominator (justification) ────────────────────────
+
+/**
+ * Justification score J(X) = (Pro − Con) / (Pro + Con), range −1..+1.
+ *
+ * The net-margin view of how decisively a belief's own arguments favor it over
+ * its own rebuttals. Negative means the belief is net-refuted (Rule 9 trigger).
+ * Returns 0 when there is no argument weight at all (undefined, not refuted).
+ *
+ * Identity worth knowing: J = 2·share − 1, where share = Pro/(Pro+Con). The two
+ * carry identical information on different scales; the margin form is the more
+ * useful default because its sign does work.
+ */
+export function justificationScore(pro: number, con: number): number {
+  const total = pro + con
+  if (total <= 0) return 0
+  return (pro - con) / total
+}
+
+/**
+ * Truth share p = Pro / (Pro + Con), range 0..1 — the implied-probability /
+ * market-share view of a single belief's internal balance. Returns null when
+ * there is no argument weight (a share of nothing is undefined, not 0.5).
+ */
+export function truthShare(pro: number, con: number): number | null {
+  const total = pro + con
+  if (total <= 0) return null
+  return pro / total
+}
+
+/**
+ * A confidence figure to report ALONGSIDE the ratio, never folded into it.
+ * The justification ratio washes out volume — [Pro 9, Con 1] and
+ * [Pro 90, Con 10] both score +0.8 — so conviction must track evidence volume
+ * separately. This returns the total argument mass (Pro + Con); pair it with a
+ * count of independent items at the call site if available.
+ */
+export function argumentMass(pro: number, con: number): number {
+  return pro + con
+}
+
+// ─── Layer 2: external denominator (opportunity cost) ─────────────────────
+
+/** A mutually exclusive option in a contrast class, carrying its tree score S. */
+export interface ContrastOption {
+  id: string
+  label: string
+  /** S(o): the argument-tree / ReasonRank score. May be signed. */
+  score: number
+}
+
+/** Pairwise margin M(oi, oj) = S(oi) − S(oj). */
+export function pairwiseMargin(a: number, b: number): number {
+  return a - b
+}
+
+/**
+ * Opportunity-cost value OCV(oi) = S(oi) − max_{j≠i} S(oj).
+ *
+ * The value of an option is what it delivers MINUS what the best alternative
+ * would have delivered. Sign tells you win/lose against the field; magnitude
+ * tells you by how much. With a single option (no rivals) OCV is undefined —
+ * there is no denominator — so this returns null.
+ */
+export function opportunityCostValue(
+  optionScore: number,
+  rivalScores: number[],
+): number | null {
+  if (rivalScores.length === 0) return null
+  return optionScore - Math.max(...rivalScores)
+}
+
+/** One option's place in the field after the comparative layer is applied. */
+export interface ComparativeResult extends ContrastOption {
+  /** OCV against the best rival; null only when the class has a single option. */
+  ocv: number | null
+  /** The rival that set the bar (the best other option); null if none. */
+  bestRivalId: string | null
+  /** True for the single option with OCV > 0 — the current winner of the field. */
+  isWinner: boolean
+}
+
+/**
+ * Run the comparative layer across a whole contrast class. Returns each option
+ * with its OCV against its own best rival, the id of that rival, and a winner
+ * flag. Exactly one option wins when scores are distinct; ties produce no
+ * strict winner (no option has OCV strictly > 0).
+ */
+export function comparativeScores(options: ContrastOption[]): ComparativeResult[] {
+  return options.map((option) => {
+    const rivals = options.filter((o) => o.id !== option.id)
+    const ocv = opportunityCostValue(option.score, rivals.map((r) => r.score))
+
+    let bestRivalId: string | null = null
+    if (rivals.length > 0) {
+      const best = rivals.reduce((a, b) => (b.score > a.score ? b : a))
+      bestRivalId = best.id
+    }
+
+    return {
+      ...option,
+      ocv,
+      bestRivalId,
+      isWinner: ocv !== null && ocv > 0,
+    }
+  })
+}
+
+// ─── Layer 2b: criteria-normalized denominator ────────────────────────────
+
+/**
+ * Min-max normalize a criterion's raw scores across the rivals:
+ *   n(oi,k) = (r(oi,k) − min_j) / (max_j − min_j)
+ *
+ * The denominator on each criterion is the SPREAD of the rivals, so a flat 0.6
+ * means nothing while a 0.6 in a field running 0.1..0.7 means a lot. This is an
+ * affine rescaling of real rival scores, not a sigmoid clamp — the range is set
+ * by the actual spread, so a lopsided field stays lopsided. When every option
+ * scores identically (zero spread) the criterion can't discriminate; we return
+ * a neutral 0.5 for each rather than dividing by zero.
+ */
+export function normalizeCriterion(values: number[]): number[] {
+  if (values.length === 0) return []
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const spread = max - min
+  if (spread === 0) return values.map(() => 0.5)
+  return values.map((v) => (v - min) / spread)
+}
+
+/** A shared yardstick scored across every option in the contrast class. */
+export interface Criterion {
+  key: string
+  /**
+   * Importance weight (≥ 0), itself a debatable/scored quantity that lives on
+   * the TOPIC, not the belief — "how much does civilian welfare matter relative
+   * to deterrence" is the same question for every option. This is the real home
+   * for the otherwise-blank Importance column.
+   */
+  importance: number
+  /** Raw score per option id, on any common scale (normalized internally). */
+  raw: Record<string, number>
+}
+
+/** A criteria-decomposed weighted score for one option. */
+export interface WeightedCriteriaResult {
+  optionId: string
+  /** W(oi) = Σ_k importance_k · n(oi,k). */
+  weighted: number
+  /** Per-criterion normalized contribution, for decomposing the margin. */
+  perCriterion: { key: string; normalized: number; contribution: number }[]
+}
+
+/**
+ * Score every option on the shared criteria and weight by per-criterion
+ * importance: W(oi) = Σ_k importance_k · n(oi,k). Use W to DECOMPOSE a margin —
+ * it shows which criterion drove a win or loss — not as a second headline.
+ */
+export function weightedCriteriaScores(
+  options: ContrastOption[],
+  criteria: Criterion[],
+): WeightedCriteriaResult[] {
+  // Pre-normalize each criterion once across the whole field.
+  const normalizedByKey = new Map<string, Map<string, number>>()
+  for (const c of criteria) {
+    const ids = options.map((o) => o.id)
+    const rawValues = ids.map((id) => c.raw[id] ?? 0)
+    const normValues = normalizeCriterion(rawValues)
+    normalizedByKey.set(c.key, new Map(ids.map((id, i) => [id, normValues[i]])))
+  }
+
+  return options.map((option) => {
+    const perCriterion = criteria.map((c) => {
+      const normalized = normalizedByKey.get(c.key)?.get(option.id) ?? 0
+      return { key: c.key, normalized, contribution: c.importance * normalized }
+    })
+    const weighted = perCriterion.reduce((s, p) => s + p.contribution, 0)
+    return { optionId: option.id, weighted, perCriterion }
+  })
+}
+
+// ─── Field share (optional readout) ───────────────────────────────────────
+
+/** Result of attempting a 0..1 market-share view of the field. */
+export interface FieldShareResult {
+  /** Share per option id, summing to 1; null when shares are undefined. */
+  shares: Record<string, number> | null
+  /** True when a rank-shift was applied to make signed scores shareable. */
+  shifted: boolean
+  /**
+   * Why shares are null / shifted, for honest readouts. "ok" | "signed" |
+   * "shifted" | "empty".
+   */
+  status: 'ok' | 'signed' | 'shifted' | 'empty'
+}
+
+/**
+ * Field share Price(oi) = S(oi) / Σ_j S(oj), a market-share view — but ONLY
+ * meaningful for non-negative inputs. ReasonRank scores can go negative, and a
+ * share of signed quantities is nonsense (a near-zero denominator blows up, a
+ * negative share is meaningless).
+ *
+ * Default behaviour (preferred per spec): refuse to fake a probability — return
+ * shares: null with status 'signed', and let the caller report OCV instead.
+ *
+ * With { allowShift: true } a rank-shift S'(o) = S(o) − min + ε is applied
+ * first and status is 'shifted', so nobody mistakes the result for a real
+ * probability.
+ */
+export function fieldShares(
+  options: ContrastOption[],
+  opts: { allowShift?: boolean; epsilon?: number } = {},
+): FieldShareResult {
+  if (options.length === 0) {
+    return { shares: null, shifted: false, status: 'empty' }
+  }
+
+  const scores = options.map((o) => o.score)
+  const hasNegative = scores.some((s) => s < 0)
+
+  if (!hasNegative) {
+    const sum = scores.reduce((a, b) => a + b, 0)
+    if (sum <= 0) return { shares: null, shifted: false, status: 'empty' }
+    const shares: Record<string, number> = {}
+    options.forEach((o) => { shares[o.id] = o.score / sum })
+    return { shares, shifted: false, status: 'ok' }
+  }
+
+  if (!opts.allowShift) {
+    return { shares: null, shifted: false, status: 'signed' }
+  }
+
+  const epsilon = opts.epsilon ?? 1e-6
+  const min = Math.min(...scores)
+  const shifted = options.map((o) => o.score - min + epsilon)
+  const sum = shifted.reduce((a, b) => a + b, 0)
+  const shares: Record<string, number> = {}
+  options.forEach((o, i) => { shares[o.id] = shifted[i] / sum })
+  return { shares, shifted: true, status: 'shifted' }
+}
+
+// ─── Argument sorting: intrinsic vs comparative ───────────────────────────
+
+/**
+ * "Intrinsic" arguments ("X is true / good on its own terms") feed Layer 1's
+ * (Pro − Con)/(Pro + Con) ratio. "Comparative" arguments ("rival Y beats X")
+ * are NOT strikes against the belief — they are statements about the
+ * denominator — and must be pulled out of the pro/con tally entirely and moved
+ * to Layer 2. Left in the con column, a comparative argument double-counts the
+ * rival: it pads Pro + Con AND reappears as a rival option. Sorting first makes
+ * the Layer 1 ratio cleaner, not merely rescaled.
+ */
+export type ArgumentKind = 'intrinsic' | 'comparative'
+
+export interface SortableArgument {
+  kind: ArgumentKind
+  side: 'pro' | 'con'
+  /** Weight this argument contributes (impact / score magnitude). */
+  weight: number
+}
+
+export interface ArgumentSortResult {
+  /** Pro weight from intrinsic arguments only. */
+  intrinsicPro: number
+  /** Con weight from intrinsic arguments only. */
+  intrinsicCon: number
+  /** Weight diverted to the comparative layer (excluded from Layer 1). */
+  comparativeWeight: number
+  /** Layer 1 justification on the cleaned, intrinsic-only totals. */
+  justification: number
+}
+
+/**
+ * Partition arguments into the intrinsic totals that feed Layer 1 and the
+ * comparative weight that belongs in Layer 2, then compute the cleaned Layer 1
+ * justification score from the intrinsic-only totals.
+ */
+export function sortArguments(args: SortableArgument[]): ArgumentSortResult {
+  let intrinsicPro = 0
+  let intrinsicCon = 0
+  let comparativeWeight = 0
+
+  for (const arg of args) {
+    if (arg.kind === 'comparative') {
+      comparativeWeight += arg.weight
+      continue
+    }
+    if (arg.side === 'pro') intrinsicPro += arg.weight
+    else intrinsicCon += arg.weight
+  }
+
+  return {
+    intrinsicPro,
+    intrinsicCon,
+    comparativeWeight,
+    justification: justificationScore(intrinsicPro, intrinsicCon),
+  }
+}
+
+// ─── Combined readout ─────────────────────────────────────────────────────
+
+/** The full denominator readout for one focal option within its contrast class. */
+export interface ContrastClassReadout {
+  /** The comparative layer for every option (OCV, winner flag, best rival). */
+  comparative: ComparativeResult[]
+  /** Pairwise margins of the focal option against each rival. */
+  focalMargins: { rivalId: string; rivalLabel: string; margin: number }[]
+  /** The focal option's OCV against its best rival (the headline number). */
+  focalOcv: number | null
+  /** The best rival's id, the named denominator for the headline. */
+  focalBestRivalId: string | null
+  /** Optional criteria decomposition when criteria are supplied. */
+  criteria: WeightedCriteriaResult[] | null
+  /** Optional market-share view of the field. */
+  fieldShare: FieldShareResult
+}
+
+/**
+ * Assemble the complete contrast-class readout for a focal option. This is the
+ * "state the denominator next to the verdict" payload: the OCV against the
+ * named best rival, the full pairwise-margin table, the optional criteria
+ * decomposition, and the optional field share.
+ */
+export function analyzeContrastClass(
+  focalId: string,
+  options: ContrastOption[],
+  criteria: Criterion[] = [],
+): ContrastClassReadout {
+  const comparative = comparativeScores(options)
+  const focal = comparative.find((o) => o.id === focalId)
+
+  const focalMargins = options
+    .filter((o) => o.id !== focalId)
+    .map((rival) => ({
+      rivalId: rival.id,
+      rivalLabel: rival.label,
+      margin: pairwiseMargin(focal?.score ?? 0, rival.score),
+    }))
+
+  return {
+    comparative,
+    focalMargins,
+    focalOcv: focal?.ocv ?? null,
+    focalBestRivalId: focal?.bestRivalId ?? null,
+    criteria: criteria.length > 0 ? weightedCriteriaScores(options, criteria) : null,
+    fieldShare: fieldShares(options),
+  }
+}

--- a/src/core/scoring/index.ts
+++ b/src/core/scoring/index.ts
@@ -29,6 +29,10 @@ export {
 // Duplication scoring — solves the Redundancy Problem (Topic Overlap Scores)
 export * from './duplication-scoring';
 
+// The Denominator — score a belief against its counterclaims (contrast class).
+// Layer 1 (justification, internal) + Layer 2 (opportunity cost, external).
+export * from './contrast-class';
+
 // All-scores module — remaining ReasonRank score dimensions:
 //   Objective Criteria, Confidence Stability, Media Truth, Media Genre,
 //   Topic Overlap helpers, Belief Equivalency, and combined computeAllBeliefScores

--- a/src/features/belief-analysis/components/ArgumentTreesSection.tsx
+++ b/src/features/belief-analysis/components/ArgumentTreesSection.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import type { ArgumentWithBelief } from '../types'
+import { justificationScore, truthShare, argumentMass } from '@/core/scoring/contrast-class'
 
 interface ArgumentTreesSectionProps {
   arguments: ArgumentWithBelief[]
@@ -88,6 +89,14 @@ export default function ArgumentTreesSection({
   const net = totalPro - totalCon
   const netLabel = `${net >= 0 ? '+' : ''}${net.toFixed(1)}`
 
+  // §4 of THE_DENOMINATOR: a bare net "+9.2" floats free. Divide it by the
+  // belief's own total argument weight to get the justification score — the
+  // share (implied probability) and margin a reader can actually act on.
+  const hasArgs = totalPro > 0 || totalCon > 0
+  const share = truthShare(totalPro, totalCon)
+  const margin = justificationScore(totalPro, totalCon)
+  const mass = argumentMass(totalPro, totalCon)
+
   return (
     <section>
       <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
@@ -149,10 +158,24 @@ export default function ArgumentTreesSection({
       </div>
 
       <p className="text-sm mt-4 p-2 bg-gray-100 border border-gray-300">
-        <strong>Net Belief Score: {totalPro > 0 || totalCon > 0 ? netLabel : '[pending]'}.</strong>{' '}
+        <strong>Net Belief Score: {hasArgs ? netLabel : '[pending]'}.</strong>{' '}
+        {hasArgs && share != null && (
+          <span>
+            The agree-case holds{' '}
+            <strong>{Math.round(share * 100)}%</strong> of the argument weight, a{' '}
+            <strong>{margin >= 0 ? '+' : ''}{Math.round(margin * 100)}-point</strong>{' '}
+            margin{' '}
+            <span className="text-[var(--muted-foreground)]">
+              (mass {mass.toFixed(1)})
+            </span>
+            .{' '}
+          </span>
+        )}
         {netInterpretation ?? (
           <span className="text-[var(--muted-foreground)] italic">
-            Interpretation appears once arguments are scored.
+            {hasArgs
+              ? 'This is the internal denominator only — how lopsided the belief is versus its own rebuttals, not whether it beats its rivals.'
+              : 'Interpretation appears once arguments are scored.'}
           </span>
         )}
       </p>

--- a/src/features/belief-analysis/components/ContrastClassSection.tsx
+++ b/src/features/belief-analysis/components/ContrastClassSection.tsx
@@ -1,0 +1,131 @@
+import Link from 'next/link'
+import type { ContrastClassData } from '../types'
+import {
+  comparativeScores,
+  type ContrastOption,
+} from '@/core/scoring/contrast-class'
+
+interface ContrastClassSectionProps {
+  contrastClass: ContrastClassData | null | undefined
+}
+
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center font-mono text-xs'
+
+function fmtScore(v: number | null): string {
+  if (v == null) return ''
+  return v.toFixed(2)
+}
+
+function fmtOcv(v: number | null): string {
+  if (v == null) return ''
+  return `${v >= 0 ? '+' : ''}${v.toFixed(2)}`
+}
+
+/**
+ * The Contrast Class block — the denominator made visible. Lists the mutually
+ * exclusive rivals the focal belief is priced against, and (once their tree
+ * scores exist) the opportunity-cost value of each against its best rival. A
+ * bare pro-minus-con score silently picks "do nothing" as the denominator;
+ * this section names the real one. See docs/THE_DENOMINATOR.md.
+ */
+export default function ContrastClassSection({ contrastClass }: ContrastClassSectionProps) {
+  if (!contrastClass || contrastClass.options.length === 0) return null
+
+  const { question, options } = contrastClass
+
+  // Only run the comparative layer when every option carries a real score
+  // (Rule 6: no fabricated OCV from missing scores).
+  const allScored = options.every(o => o.score != null)
+  const scored: ContrastOption[] = options.map(o => ({
+    id: o.id,
+    label: o.label,
+    score: o.score ?? 0,
+  }))
+  const comparative = allScored ? comparativeScores(scored) : null
+
+  const focal = options.find(o => o.isFocal)
+  const focalResult = comparative && focal
+    ? comparative.find(r => r.id === focal.id)
+    : null
+  const bestRival = focalResult?.bestRivalId
+    ? options.find(o => o.id === focalResult.bestRivalId)
+    : null
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
+        <span>&#9878;&#65039;</span>
+        Contrast Class
+      </h2>
+      <p className="text-sm text-[var(--muted-foreground)] mb-4">
+        The denominator, made visible. A score is always{' '}
+        <em>compared to what</em> — these are the mutually exclusive rivals that
+        answer the same question and compete for the same slot. The{' '}
+        <Link href="/algorithms/strong-to-weak" className="text-[var(--accent)] hover:underline">value</Link>{' '}
+        of an option is what it delivers minus what the best alternative would
+        have delivered.
+      </p>
+      <p className="text-sm mb-4">
+        <strong>Question:</strong> {question}
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className={`${TH} w-[28%]`}>Option</th>
+              <th className={`${TH} w-[40%]`}>One-line</th>
+              <th className={`${TH} text-center w-[16%]`}>Score</th>
+              <th className={`${TH} text-center w-[16%]`}>vs. best rival</th>
+            </tr>
+          </thead>
+          <tbody>
+            {options.map(o => {
+              const r = comparative?.find(c => c.id === o.id)
+              return (
+                <tr key={o.id} className={o.isFocal ? 'bg-yellow-50 font-semibold' : ''}>
+                  <td className={TD}>
+                    {o.slug ? (
+                      <Link href={`/beliefs/${o.slug}`} className="text-[var(--accent)] hover:underline">
+                        {o.label}
+                      </Link>
+                    ) : (
+                      o.label
+                    )}
+                    {o.isFocal && (
+                      <span className="text-xs text-[var(--muted-foreground)] font-normal"> (this belief)</span>
+                    )}
+                  </td>
+                  <td className={TD}>{o.oneLine ?? <span>&nbsp;</span>}</td>
+                  <td className={TDC}>{fmtScore(o.score)}</td>
+                  <td className={`${TDC} ${r && r.ocv != null ? (r.ocv > 0 ? 'text-green-700' : 'text-red-700') : ''}`}>
+                    {r ? fmtOcv(r.ocv) : ''}
+                    {r?.isWinner && <span className="text-green-700"> ★</span>}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {focalResult && focalResult.ocv != null && bestRival ? (
+        <p className="text-sm mt-4 p-2 bg-gray-100 border border-gray-300">
+          <strong>
+            Opportunity-cost value: {fmtOcv(focalResult.ocv)} vs. {bestRival.label}.
+          </strong>{' '}
+          {focalResult.ocv > 0
+            ? `This is the best option in the field — it beats its strongest rival (${bestRival.label}) by ${focalResult.ocv.toFixed(2)}.`
+            : `This option loses to its best rival (${bestRival.label}) by ${Math.abs(focalResult.ocv).toFixed(2)} — the verdict is "worse than ${bestRival.label}", not "good or bad in the abstract".`}
+        </p>
+      ) : (
+        <p className="text-sm mt-4 text-[var(--muted-foreground)] italic">
+          Opportunity-cost value appears once every option in the class carries a
+          scored argument tree.
+        </p>
+      )}
+    </section>
+  )
+}

--- a/src/features/belief-analysis/data/contrast-classes.ts
+++ b/src/features/belief-analysis/data/contrast-classes.ts
@@ -1,0 +1,111 @@
+import { prisma } from '@/lib/prisma'
+import type { ContrastClassData, ContrastClassOption } from '../types'
+
+/**
+ * Static contrast-class definitions, keyed by the focal belief's slug.
+ *
+ * A contrast class is the set of mutually exclusive rivals that answer the same
+ * topic question and compete for the same slot — the denominator a belief is
+ * priced against (docs/THE_DENOMINATOR.md). The option SCORES are not stored
+ * here: each option points at its own belief by slug, and its score is resolved
+ * from that belief's own argument tree at fetch time, so every number under the
+ * line stays traceable (invariant §8.7). This lives as a static overlay (like
+ * spectrum-coordinates.ts) so existing Prisma data keeps flowing untouched; a
+ * future schema can promote it to a first-class topic relation.
+ */
+interface ContrastClassTemplate {
+  question: string
+  options: Array<{
+    id: string
+    label: string
+    oneLine?: string
+    /** Slug of the belief whose tree supplies this option's score. */
+    slug?: string
+    isFocal?: boolean
+  }>
+}
+
+const CONTRAST_CLASSES: Record<string, ContrastClassTemplate> = {
+  'universal-basic-income-should-be-implemented': {
+    question:
+      'What mechanism should guarantee a basic income floor in a developed economy?',
+    options: [
+      {
+        id: 'ubi',
+        label: 'Universal Basic Income',
+        oneLine: 'Unconditional flat cash payment to every adult',
+        slug: 'universal-basic-income-should-be-implemented',
+        isFocal: true,
+      },
+      {
+        id: 'nit',
+        label: 'Negative income tax',
+        oneLine: 'A transfer that phases out as earnings rise',
+        slug: 'negative-income-tax',
+      },
+      {
+        id: 'falc',
+        label: 'Fully automated luxury communism',
+        oneLine: 'Abolish wage labor once automation is total',
+        slug: 'fully-automated-luxury-communism',
+      },
+    ],
+  },
+}
+
+/** Net score (−100..+100) of a belief computed from its own argument + evidence tree. */
+function netScore(
+  args: Array<{ side: string; impactScore: number }>,
+  evidence: Array<{ side: string; impactScore: number }>,
+): number {
+  const sum = (items: Array<{ side: string; impactScore: number }>, side: string) =>
+    items.filter(i => i.side === side).reduce((s, i) => s + Math.abs(i.impactScore), 0)
+
+  const pos = sum(args, 'agree') + sum(evidence, 'supporting')
+  const neg = sum(args, 'disagree') + sum(evidence, 'weakening')
+  const total = pos + neg
+  return total > 0 ? ((pos - neg) / total) * 100 : 0
+}
+
+/**
+ * Resolve the contrast class for a focal belief, computing each option's score
+ * from its own belief's argument tree. Returns null when no contrast class is
+ * defined for the slug (the section then renders nothing). An option whose
+ * referenced belief is missing or unscored keeps score: null (Rule 6 — blank,
+ * never a fabricated zero).
+ */
+export async function resolveContrastClass(
+  focalSlug: string,
+): Promise<ContrastClassData | null> {
+  const template = CONTRAST_CLASSES[focalSlug]
+  if (!template) return null
+
+  const slugs = template.options
+    .map(o => o.slug)
+    .filter((s): s is string => Boolean(s))
+
+  const beliefs = await prisma.belief.findMany({
+    where: { slug: { in: slugs } },
+    select: {
+      slug: true,
+      arguments: { select: { side: true, impactScore: true } },
+      evidence: { select: { side: true, impactScore: true } },
+    },
+  })
+
+  const scoreBySlug = new Map<string, number>()
+  for (const b of beliefs) {
+    scoreBySlug.set(b.slug, netScore(b.arguments, b.evidence))
+  }
+
+  const options: ContrastClassOption[] = template.options.map(o => ({
+    id: o.id,
+    label: o.label,
+    oneLine: o.oneLine ?? null,
+    slug: o.slug ?? null,
+    isFocal: o.isFocal ?? false,
+    score: o.slug && scoreBySlug.has(o.slug) ? scoreBySlug.get(o.slug)! : null,
+  }))
+
+  return { question: template.question, options }
+}

--- a/src/features/belief-analysis/data/fetch-belief.ts
+++ b/src/features/belief-analysis/data/fetch-belief.ts
@@ -10,6 +10,7 @@ import {
 } from '@/core/scoring/all-scores'
 import { calculateEVS, getEvidenceTypeWeight } from '@/core/scoring/scoring-engine'
 import { applyStrengthPenalty } from '@/core/scoring/claim-strength'
+import { resolveContrastClass } from './contrast-classes'
 
 /** Shared include clause for all belief queries — includes all score-related fields. */
 const BELIEF_INCLUDE = {
@@ -81,7 +82,14 @@ export async function fetchBeliefBySlug(slug: string): Promise<BeliefWithRelatio
     include: BELIEF_INCLUDE,
   })
 
-  return belief as BeliefWithRelations | null
+  if (!belief) return null
+
+  // Resolve the contrast class (the denominator): each rival option's score is
+  // computed from its own argument tree, so OCV stays traceable. Null when no
+  // contrast class is defined for this belief.
+  const contrastClass = await resolveContrastClass(slug)
+
+  return { ...belief, contrastClass } as BeliefWithRelations | null
 }
 
 /** Fetch a belief by numeric ID */

--- a/src/features/belief-analysis/types.ts
+++ b/src/features/belief-analysis/types.ts
@@ -58,6 +58,14 @@ export interface BeliefWithRelations {
   sharedInterests: SharedInterestItem[]
   disputeTypes: DisputeTypeItem[]
 
+  /**
+   * The contrast class — the mutually exclusive rivals this belief is priced
+   * against (the denominator made visible). Optional so existing beliefs keep
+   * flowing; populate via seed as topic option sets land. See
+   * docs/THE_DENOMINATOR.md and src/core/scoring/contrast-class.ts.
+   */
+  contrastClass?: ContrastClassData | null
+
   arguments: ArgumentWithBelief[]
   evidence: EvidenceItem[]
   objectiveCriteria: ObjectiveCriteriaItem[]
@@ -154,6 +162,36 @@ export interface ObjectiveCriteriaItem {
    * e.g., "+2pp sustained over 3 years would settle the debate".
    */
   thresholdForAgreement?: string | null
+}
+
+/**
+ * One mutually exclusive option in a belief's contrast class — a rival answer
+ * to the same topic question, competing for the same slot. The denominator for
+ * the focal belief is the rest of this set (its best rival, in particular).
+ */
+export interface ContrastClassOption {
+  /** Stable id, unique within the class. */
+  id: string
+  /** Short label for the option ("Targeted sanctions"). */
+  label: string
+  /** One-line description of the lever/option. */
+  oneLine?: string | null
+  /**
+   * S(o): the option's argument-tree score on a common scale. May be signed.
+   * Null renders blank (Rule 6) — the class is still shown, just without OCV.
+   */
+  score: number | null
+  /** Slug to the option's own belief page; plain text when null (Rule 5). */
+  slug?: string | null
+  /** True for the focal belief — the page this contrast class lives on. */
+  isFocal?: boolean
+}
+
+/** A belief's contrast class: the shared question plus the rival options. */
+export interface ContrastClassData {
+  /** The question the options compete to answer (lives on the topic). */
+  question: string
+  options: ContrastClassOption[]
 }
 
 /** One row in the Shared Values, Different Rankings table (new template). */

--- a/templates/belief-analysis-template.html
+++ b/templates/belief-analysis-template.html
@@ -23,7 +23,11 @@
 
   CANONICAL SECTION ORDER:
     Header (Belief / metadata / Beliefs this supports)
-    1.  Argument Trees (scored two-sided table + Net Belief Score)
+    1.  Argument Trees (scored two-sided table + Net Belief Score, reported as
+        share/margin: the net divided by the belief's own Pro+Con total)
+    1b. Contrast Class (the denominator: mutually exclusive rivals this belief is
+        priced against, each with its tree score S and opportunity-cost value
+        OCV = S(this) - max S(rivals)). Only when the topic has a rival option set.
     2.  Evidence Ledger (two-sided: Supporting / Weakening)
     3.  Conflict Resolution Framework
         a. Shared Values, Different Rankings
@@ -73,7 +77,27 @@
 </tr>
 </tbody>
 </table>
-<p style="font-size: 13px; padding: 8px; background-color: #f0f3f6; border: 1px solid #ccc;"><strong>Net Belief Score: [NETSCORE].</strong> [NETINTERP]</p>
+<p style="font-size: 13px; padding: 8px; background-color: #f0f3f6; border: 1px solid #ccc;"><strong>Net Belief Score: [NETSCORE].</strong> The agree-case holds [SHARE]% of the argument weight, a [MARGIN]-point margin (mass [MASS]). This is the internal denominator only &mdash; how lopsided the belief is versus its own rebuttals, not whether it beats its rivals (see Contrast Class). [NETINTERP]</p>
+
+<hr />
+<br />
+<!-- CONTRAST CLASS: the denominator made visible. Include ONLY when the topic
+     has a set of mutually exclusive rival options. Each option points at its own
+     belief; its Score is that belief's own tree score, and OCV = Score - best
+     rival's Score. Exactly one option (the field winner) has OCV > 0. Omit this
+     whole block for beliefs with no rival option set. See docs/THE_DENOMINATOR.md. -->
+<h1>&#9878;&#65039; Contrast Class</h1>
+<p style="font-size: 13px;">The denominator, made visible. A score is always <em>compared to what</em> &mdash; these are the mutually exclusive rivals answering the same question. <strong>Question:</strong> [Topic question the options compete to answer].</p>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6; font-size: 12px;"><th width="28%">Option</th> <th width="40%">One-line</th> <th width="16%">Score</th> <th width="16%">vs. best rival</th></tr>
+</thead>
+<tbody>
+<tr style="background-color: #fffbe6;"><td>[This belief] (this belief)</td><td>[One-line]</td><td align="center">[S]</td><td align="center">[OCV]</td></tr>
+<tr><td>[Rival option]</td><td>[One-line]</td><td align="center">[S]</td><td align="center">[OCV] &#9733;</td></tr>
+</tbody>
+</table>
+<p style="font-size: 13px; padding: 8px; background-color: #f0f3f6; border: 1px solid #ccc;"><strong>Opportunity-cost value: [OCV] vs. [best rival].</strong> [Win/lose reading, stating the denominator next to the verdict.]</p>
 
 <hr />
 <br />

--- a/tests/unit/core/scoring/contrast-class.test.ts
+++ b/tests/unit/core/scoring/contrast-class.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for the denominator / contrast-class engine.
+ *
+ * Two layers: Layer 1 (justification, internal denominator — a belief vs its
+ * own rebuttals) and Layer 2 (opportunity cost, external denominator — a belief
+ * vs its best rival). The worked example throughout is the sanctions page from
+ * the spec (docs/THE_DENOMINATOR.md): Pro 35.08, Con 25.87.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  justificationScore,
+  truthShare,
+  argumentMass,
+  pairwiseMargin,
+  opportunityCostValue,
+  comparativeScores,
+  normalizeCriterion,
+  weightedCriteriaScores,
+  fieldShares,
+  sortArguments,
+  analyzeContrastClass,
+  type ContrastOption,
+  type Criterion,
+} from '../../../../src/core/scoring/contrast-class'
+
+describe('justificationScore (Layer 1)', () => {
+  it('turns the sanctions +9.2 numerator into a +15.1% margin', () => {
+    const j = justificationScore(35.08, 25.87)
+    expect(j).toBeCloseTo(0.151, 3)
+  })
+
+  it('is the affine twin of the truth share: J = 2p − 1', () => {
+    const pro = 35.08
+    const con = 25.87
+    const p = truthShare(pro, con)!
+    expect(justificationScore(pro, con)).toBeCloseTo(2 * p - 1, 10)
+  })
+
+  it('washes out volume: [9,1] and [90,10] both score +0.8', () => {
+    expect(justificationScore(9, 1)).toBeCloseTo(0.8, 10)
+    expect(justificationScore(90, 10)).toBeCloseTo(0.8, 10)
+  })
+
+  it('goes negative when cons outweigh pros (the Rule 9 trigger)', () => {
+    expect(justificationScore(10, 30)).toBeLessThan(0)
+  })
+
+  it('returns 0 (undefined, not refuted) with no argument weight', () => {
+    expect(justificationScore(0, 0)).toBe(0)
+  })
+})
+
+describe('truthShare', () => {
+  it('reports the sanctions harm-case at ~57.6%', () => {
+    expect(truthShare(35.08, 25.87)).toBeCloseTo(0.576, 3)
+  })
+
+  it('returns null (not 0.5) when there is no weight', () => {
+    expect(truthShare(0, 0)).toBeNull()
+  })
+})
+
+describe('argumentMass', () => {
+  it('reports total mass to pair beside the ratio', () => {
+    expect(argumentMass(35.08, 25.87)).toBeCloseTo(60.95, 2)
+  })
+})
+
+describe('pairwiseMargin', () => {
+  it('is a simple difference S(oi) − S(oj)', () => {
+    expect(pairwiseMargin(0.7, 0.5)).toBeCloseTo(0.2, 10)
+    expect(pairwiseMargin(0.5, 0.7)).toBeCloseTo(-0.2, 10)
+  })
+})
+
+describe('opportunityCostValue (Layer 2)', () => {
+  it('subtracts the best rival, not nothing', () => {
+    expect(opportunityCostValue(0.6, [0.8, 0.4, 0.2])).toBeCloseTo(-0.2, 10)
+  })
+
+  it('is positive only for the field winner', () => {
+    expect(opportunityCostValue(0.9, [0.8, 0.4])).toBeCloseTo(0.1, 10)
+  })
+
+  it('is undefined (null) with no rivals — no denominator', () => {
+    expect(opportunityCostValue(0.9, [])).toBeNull()
+  })
+})
+
+describe('comparativeScores — the sanctions contrast class', () => {
+  // Stylized scores standing in for the argument-tree S(o) of each lever.
+  const options: ContrastOption[] = [
+    { id: 'military', label: 'Military force', score: 0.30 },
+    { id: 'broad', label: 'Broad sanctions', score: 0.50 },
+    { id: 'targeted', label: 'Targeted sanctions', score: 0.62 },
+    { id: 'engagement', label: 'Conditional engagement', score: 0.45 },
+    { id: 'integration', label: 'Full integration', score: 0.25 },
+  ]
+
+  it('finds exactly one winner (targeted) with positive OCV', () => {
+    const results = comparativeScores(options)
+    const winners = results.filter((r) => r.isWinner)
+    expect(winners).toHaveLength(1)
+    expect(winners[0].id).toBe('targeted')
+    expect(winners[0].ocv!).toBeGreaterThan(0)
+  })
+
+  it('shows broad sanctions LOSING to their best rival (targeted)', () => {
+    const broad = comparativeScores(options).find((r) => r.id === 'broad')!
+    expect(broad.bestRivalId).toBe('targeted')
+    expect(broad.ocv!).toBeCloseTo(0.5 - 0.62, 10)
+    expect(broad.ocv!).toBeLessThan(0)
+  })
+
+  it('produces no strict winner on a tie', () => {
+    const tied: ContrastOption[] = [
+      { id: 'a', label: 'A', score: 0.5 },
+      { id: 'b', label: 'B', score: 0.5 },
+    ]
+    expect(comparativeScores(tied).some((r) => r.isWinner)).toBe(false)
+  })
+})
+
+describe('normalizeCriterion', () => {
+  it('min-max normalizes against the spread of rivals', () => {
+    const [lo, mid, hi] = normalizeCriterion([0.1, 0.4, 0.7])
+    expect(lo).toBeCloseTo(0, 10)
+    expect(mid).toBeCloseTo(0.5, 10)
+    expect(hi).toBeCloseTo(1, 10)
+  })
+
+  it('returns neutral 0.5 when the field is flat (no division by zero)', () => {
+    expect(normalizeCriterion([0.6, 0.6, 0.6])).toEqual([0.5, 0.5, 0.5])
+  })
+})
+
+describe('weightedCriteriaScores', () => {
+  const options: ContrastOption[] = [
+    { id: 'broad', label: 'Broad sanctions', score: 0.5 },
+    { id: 'integration', label: 'Full integration', score: 0.25 },
+  ]
+  // Mike's argument: integration scores worst on C1 (coercive capacity). That
+  // low C1 is precisely why broad sanctions look good against integration.
+  const criteria: Criterion[] = [
+    { key: 'C1-capacity', importance: 1.0, raw: { broad: 0.8, integration: 0.1 } },
+    { key: 'C2-welfare', importance: 0.6, raw: { broad: 0.3, integration: 0.9 } },
+  ]
+
+  it('weights normalized criteria by topic-level importance', () => {
+    const results = weightedCriteriaScores(options, criteria)
+    const broad = results.find((r) => r.optionId === 'broad')!
+    // C1 normalized: broad=1, integration=0 → broad contributes 1.0×1.0.
+    // C2 normalized: broad=0, integration=1 → broad contributes 0.6×0.
+    expect(broad.weighted).toBeCloseTo(1.0, 10)
+  })
+
+  it('decomposes the score per criterion to explain the win', () => {
+    const broad = weightedCriteriaScores(options, criteria)
+      .find((r) => r.optionId === 'broad')!
+    const c1 = broad.perCriterion.find((p) => p.key === 'C1-capacity')!
+    expect(c1.normalized).toBe(1)
+    expect(c1.contribution).toBeCloseTo(1.0, 10)
+  })
+})
+
+describe('fieldShares (signed-score edge case)', () => {
+  it('returns real shares when all scores are non-negative', () => {
+    const result = fieldShares([
+      { id: 'a', label: 'A', score: 0.6 },
+      { id: 'b', label: 'B', score: 0.4 },
+    ])
+    expect(result.status).toBe('ok')
+    expect(result.shares!.a).toBeCloseTo(0.6, 10)
+    expect(result.shares!.b).toBeCloseTo(0.4, 10)
+  })
+
+  it('refuses to fake a probability for signed scores by default', () => {
+    const result = fieldShares([
+      { id: 'a', label: 'A', score: 0.6 },
+      { id: 'b', label: 'B', score: -0.2 },
+    ])
+    expect(result.status).toBe('signed')
+    expect(result.shares).toBeNull()
+  })
+
+  it('rank-shifts and flags it when explicitly allowed', () => {
+    const result = fieldShares(
+      [
+        { id: 'a', label: 'A', score: 0.6 },
+        { id: 'b', label: 'B', score: -0.2 },
+      ],
+      { allowShift: true },
+    )
+    expect(result.status).toBe('shifted')
+    expect(result.shifted).toBe(true)
+    const sum = result.shares!.a + result.shares!.b
+    expect(sum).toBeCloseTo(1, 10)
+    expect(result.shares!.a).toBeGreaterThan(result.shares!.b)
+  })
+})
+
+describe('sortArguments — intrinsic vs comparative dedup', () => {
+  it('pulls "rival beats X" out of the con tally, cleaning Layer 1', () => {
+    // "only non-military lever" is comparative, not a strike against the belief.
+    const result = sortArguments([
+      { kind: 'intrinsic', side: 'pro', weight: 20 },
+      { kind: 'intrinsic', side: 'con', weight: 10 },
+      { kind: 'comparative', side: 'con', weight: 15 },
+    ])
+    expect(result.intrinsicPro).toBe(20)
+    expect(result.intrinsicCon).toBe(10)
+    expect(result.comparativeWeight).toBe(15)
+    // Cleaned justification is 20 vs 10, not 20 vs 25.
+    expect(result.justification).toBeCloseTo(justificationScore(20, 10), 10)
+    expect(result.justification).toBeGreaterThan(justificationScore(20, 25))
+  })
+})
+
+describe('analyzeContrastClass — combined readout', () => {
+  const options: ContrastOption[] = [
+    { id: 'military', label: 'Military force', score: 0.30 },
+    { id: 'broad', label: 'Broad sanctions', score: 0.50 },
+    { id: 'targeted', label: 'Targeted sanctions', score: 0.62 },
+  ]
+
+  it('states the denominator next to the verdict for the focal option', () => {
+    const readout = analyzeContrastClass('broad', options)
+    expect(readout.focalBestRivalId).toBe('targeted')
+    expect(readout.focalOcv!).toBeCloseTo(-0.12, 10)
+    // Pairwise margins against every rival, both signs present.
+    const vsMilitary = readout.focalMargins.find((m) => m.rivalId === 'military')!
+    const vsTargeted = readout.focalMargins.find((m) => m.rivalId === 'targeted')!
+    expect(vsMilitary.margin).toBeCloseTo(0.20, 10) // wins vs military
+    expect(vsTargeted.margin).toBeCloseTo(-0.12, 10) // loses vs targeted
+  })
+
+  it('omits criteria when none are supplied', () => {
+    expect(analyzeContrastClass('broad', options).criteria).toBeNull()
+  })
+})


### PR DESCRIPTION
## The bug

A bare `Pro − Con` Net Belief Score is a numerator with nothing under the line — "+9.2 relative to what?" A pro-minus-con silently picks "do nothing" as the denominator and never tells you. This implements the two-layer denominator framework (`docs/THE_DENOMINATOR.md`).

## What changed

**Engine — `src/core/scoring/contrast-class.ts`**
- **Layer 1 (internal denominator):** `justificationScore` `(Pro−Con)/(Pro+Con)`, plus `truthShare`, `argumentMass` (volume reported beside the ratio, never folded in), with the `J = 2p−1` identity.
- **Layer 2 (external denominator):** `opportunityCostValue` `S(oi) − max S(rivals)`, `pairwiseMargin`, `comparativeScores` (flags the single field winner), `normalizeCriterion` (min-max — affine, no clamp), `weightedCriteriaScores` for margin decomposition, `analyzeContrastClass`.
- **Signed-score edge case:** `fieldShares` refuses to fake a probability for signed scores by default; rank-shifts only when asked, and flags it.
- **Dedup:** `sortArguments` pulls comparative "rival beats X" arguments out of the con tally so they don't double-count.
- All functions are read-only outputs (one-way valve — invariant §8.6).

**Page**
- Argument Trees headline now reads "the agree-case holds **X%** of the argument weight, a **+Y-point** margin" — live on every belief immediately, no new data needed (§4 / §9.3).
- New **Contrast Class** section (§9.1) renders the rivals with each option's tree score and OCV.

**Real, traceable data (Rule 6 / invariant §8.7):** a static overlay (`contrast-classes.ts`) defines the option set; each rival's score is computed from *its own argument tree* at fetch time — nothing under the line is a fabricated constant. Seeded trees for the two rival income-floor beliefs, so the UBI page now shows **UBI losing to its best rival, negative income tax, by −45.5 OCV** — mirroring the spec's "broad sanctions lose to targeted."

> Note: the spec's worked example is a sanctions page that doesn't exist in this repo (the seed is UBI-centric), so the framework is demonstrated on the UBI income-floor topic. The math is identical: UBI : negative income tax :: broad sanctions : targeted sanctions.

## Verification
- 25 new unit tests pass (worked example uses the spec's sanctions figures: +9.2 → 57.6% / +15.1%).
- Belief page rendered via dev server (HTTP 200); Contrast Class table and share/margin both display.
- `tsc` and `eslint` clean on all touched files. Full suite has only 2 pre-existing failures (DB integration + legacy mongoose), confirmed identical on the clean tree.
- `docs/THE_DENOMINATOR.md`, `BELIEF_PAGE_RULES.md`, and the HTML template kept in sync.

https://claude.ai/code/session_016qq2Ej6H2C3PpgTZpo4sUT

---
_Generated by [Claude Code](https://claude.ai/code/session_016qq2Ej6H2C3PpgTZpo4sUT)_