### PR TITLE
Add relationship scores and score-ranked tables for all belief page content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,21 +26,21 @@ The repo has ~50 pre-existing implicit-any errors in routes I didn't touch (nota
 
 The single most important thing to get right in this codebase is the belief page (`/beliefs/[slug]`). It is the product. Everything else supports it.
 
-- **Canonical rules:** `docs/BELIEF_PAGE_RULES.md`. Read this before generating, restructuring, or refactoring any belief content. The seven hard rules (no top-of-page summary, definitions go last, arguments are 2-6 word labels, arguments != evidence, no broken links, blank scores until real, symmetric Supporters/Opponents) are non-negotiable.
+- **Canonical rules:** `docs/BELIEF_PAGE_RULES.md`. Read this before generating, restructuring, or refactoring any belief content. The eight hard rules (no top-of-page summary, definitions go last, arguments are 2-6 word labels, arguments != evidence, no broken links, blank scores until real, symmetric Supporters/Opponents, every table score-ranked with top rows shown and the rest collapsed) are non-negotiable.
 - **Canonical template:** `templates/belief-analysis-template.html`. This is the source of truth for the canonical section order. The live page is built around it.
 - **Live implementation:** `src/app/beliefs/[slug]/page.tsx` plus the section components in `src/features/belief-analysis/components/*`.
 - **Types:** `src/features/belief-analysis/types.ts`. New fields on Values/Interests analysis are optional so existing Prisma data still flows; populate via seed scripts as data lands.
 
 If you change the rules doc, update the template and the page. If you change the template or page, update the rules doc. The three must stay in sync.
 
-### Sections that no longer exist as standalones
+### Section layout notes (July 2026 template)
 
-Per the new template (April 2026), the page does NOT have separate `Falsifiability`, `Testable Predictions`, `Media Resources`, or `Short vs Long-Term Impact` sections.
-
-- Falsifiability is implicit in Objective Criteria thresholds.
-- Testable predictions, when relevant, render as objective criteria.
-- Visual/video items live in the Visual and Video Evidence sub-table under Evidence Ledger.
-- Short vs Long-Term renders as a sub-table inside Cost-Benefit Analysis.
+Falsifiability Test, Testable Predictions, and Media Resources ARE standalone sections
+(reintroduced in the April 2026 redesign; the current components are
+`FalsifiabilityTestSection` and `MediaResourcesSection`). Short vs Long-Term still
+renders as a sub-table inside Cost-Benefit Analysis. Every per-row table carries a
+nullable relationship `score`, sorts by it descending (nulls last), and shows its top
+rows with the rest collapsed — see Rule 8 and `src/features/belief-analysis/lib/ranking.ts`.
 
 The legacy `FalsifiabilitySection`, `TestablePredictionsSection`, `MediaSection`, and `ImpactSection` components remain on disk because `/product-reviews/[slug]` and `/beliefs/set-aside-distractions-for-real-solutions` still import them. Don't delete them without migrating those routes.
 

--- a/docs/BELIEF_PAGE_RULES.md
+++ b/docs/BELIEF_PAGE_RULES.md
@@ -136,53 +136,93 @@ Every section with "Supporters" and "Opponents" (Values, Interests, Biases, Moti
 
 ---
 
+## Rule 8: Every Table Ranks by Relationship Score
+
+Every row in every table relates to the belief through a scored relationship: the
+ReasonRank performance of that row's own pro/con sub-debate. Tables sort by that
+Score, descending — highest-scoring content first — and the software shows each
+table's top rows (currently five) and collapses the rest until expanded. Rows enter
+and rank only by how their sub-arguments perform, never by editorial placement.
+
+**Why:** If editors can order rows by hand, the ordering becomes an argument nobody
+can audit. Score-ranked tables make placement itself a claim that traces to scored
+sub-debates, and top-N collapse keeps every table scannable without hiding anything.
+
+**How to apply:**
+
+- Every per-row model carries a nullable `score` (Cost-Benefit rows use
+  `expectedValue = magnitude × likelihood` as their rank key; Media rows use their
+  impact score; Similar Beliefs use the equivalency score).
+- Sort descending with unscored rows last — their score cells render blank (Rule 6),
+  and blanks must never bury real scores.
+- Render the top rows, then a "Show N more lower-scoring rows" toggle for the rest.
+- Never hand-order rows to promote a favorite. If a row deserves to be higher, win
+  its sub-debate.
+
+---
+
 ## Canonical Section Order
 
-The April 2026 redesign restructures the page around a single **Conflict Resolution
-Framework** and brings back the Falsifiability Test, Testable Predictions, and Media
-Resources sections. The source of truth is `templates/belief-analysis-template.html`.
+The July 2026 revision adds the **Scorecard** readout, per-row relationship scores on
+every table, the **Logical Anatomy** decomposition, and row-based Falsifiability and
+Cost-Benefit tables. The source of truth is `templates/belief-analysis-template.html`.
 
 Header: Belief statement → metadata line (Topic / Dewey / Positivity / Net Belief
 Score / Related) → "Beliefs this supports" line. No summary or background (Rule 2).
 
+0. **Scorecard** — a readout of the scored content below, not a prose summary:
+   `Net Belief Score (Pro vs. Con)` / `Bottom line` (one-sentence verdict scoped to
+   what the tree supports) / `Strongest pro / con` (the top-ranked argument from each
+   side) / `What would move this score most` (the top falsifiability score-mover).
+   Followed by the "How to read this page" box explaining score-ranked tables.
 1. **Argument Trees** — one two-sided scored table (Reasons to Agree / Reasons to
-   Disagree), each side with `Argument / Score / Link / Impact`. Each argument cell is
-   the claim, the single most famous supporting quote inline (italic, small), then the
-   submitter as `~Name`. Pro Total / Con Total row, then the **Net Belief Score** line.
+   Disagree), each side with `Argument / Score / Link / Imp / Impact`. Each argument
+   cell is the claim, the single most famous supporting quote inline (italic, small),
+   then the submitter as `~Name`. Pro Total / Con Total row, then the **Net Belief
+   Score** line.
 2. **Evidence Ledger** — one two-sided table (Supporting / Weakening), each side with
    `Evidence / Type / Link / Impact`.
-3. **Conflict Resolution Framework**
-   - 3a. Shared Values, Different Rankings (`Value / Supporter Rank / Opponent Rank /
-     Why Rankings Differ`, then a "What would shift these rankings?" row)
-   - 3b. Likely Interests of Supporters (`Interest / Prevalence / Linkage Confidence /
+3. **Objective Criteria** (`Criterion / How to Measure / Reading That Would Strengthen /
+   Reading That Would Weaken / Latest Reading / Score`) — the best criteria are ones
+   where the two sides predict different readings.
+4. **Falsifiability Test** (`Evidence That Would Strengthen / Score / Evidence That
+   Would Weaken / Score` — each row a realistic, bet-specific score-mover) +
+   **Testable Predictions** (`Prediction / Follows If / Timeframe / Verification
+   Method / Result So Far / Score`)
+5. **Logical Anatomy & Foundational Assumptions** — the belief's logical form
+   (ANDs/ORs), the Component Claims table (`Component Claim / Type / Stated? /
+   If false, does the belief survive? / Unstated assumptions / Score`), then
+   Assumptions by Side (`Required to Accept / Score / Required to Reject / Score`)
+6. **Cost-Benefit Analysis** — Benefits table and Costs and Risks table, each
+   `Claim (links to its own page) / Category (Units) / Magnitude / Likelihood % /
+   Expected Value`, ranked by Expected Value with subtotals only within a category;
+   then **Short vs. Long-Term Impacts** (`Short-Term / Score / Long-Term / Score`)
+7. **Conflict Resolution Framework**
+   - 7a. Shared Values, Different Rankings (`Value / Supporter Rank / Opponent Rank /
+     Why Rankings Differ / Score`, then a "What would shift these rankings?" row)
+   - 7b. Likely Interests of Supporters (`Interest / Prevalence / Linkage Confidence /
      Validity / Evidence Basis / Connected Value`, plus a Pretextual/Low-validity row)
-   - 3c. Likely Interests of Opponents (same columns, symmetric)
-   - 3d. Shared and Conflicting Interests — Shared Interests table (`Shared Interest /
-     Validity / Compromise direction`) + Primary Conflict Pair (`Interest in the pair /
-     Standalone Validity / Claim strength on THIS issue / What drives its claim here`)
-   - 3e. Advertised vs. Actual Motivations (rows: Advertised reason / Actual driver /
-     Evidence for divergence, columns Supporters / Opponents)
-   - 3f. Dispute Types (Empirical / Definitional / Values)
-   - 3g. Primary Obstacles to Resolution (Supporters / Opponents)
-4. **Objective Criteria** (`Criterion / How to Measure / Current Status / Target`)
-5. **Falsifiability Test** (Evidence That Would Confirm / Falsify) + **Testable
-   Predictions** (`Prediction / Timeframe / Verification Method`)
-6. **Foundational Assumptions** (Required to Accept / Required to Reject)
-7. **Cost-Benefit Analysis** (Benefits / Costs and Risks), then **Short vs. Long-Term
-   Impacts**, then **Best Compromise Solutions** (`Shared Premise / Proposed Synthesis /
-   Why This Is Difficult`)
-8. **Biases** (Affecting Supporters / Affecting Opponents)
-9. **Media Resources** (Supporting / Challenging or Complicating, with Books)
-10. **Legal Framework** (Supporting / Complicating)
-11. **General to Specific Belief Mapping** (Upstream Support/Oppose, Downstream
-    Support/Oppose)
-12. **Similar Beliefs** (More Extreme / More Moderate)
-13. **Definitions** (`Term / Definition`) — LAST before footer
-14. **Contribute / footer**
-
-**Reintroduced in this redesign:** Falsifiability Test, Testable Predictions, and Media
-Resources are once again top-level sections. (They were folded into other sections in the
-prior revision; the April 2026 template restores them as standalone sections.)
+   - 7c. Likely Interests of Opponents (same columns, symmetric)
+   - 7d. Shared and Conflicting Interests — Shared Interests table (`Shared Interest /
+     Validity / Compromise direction / Score`) + Primary Conflict Pair (`Interest in
+     the pair / Standalone Validity / Claim strength on THIS issue / What drives its
+     claim here`)
+   - 7e. Best Compromise Solutions (`Shared Premise / Proposed Synthesis / Why This Is
+     Difficult / Score (interests satisfied)`)
+   - 7f. Advertised vs. Actual Motivations (rows: Advertised reason / Actual driver /
+     Evidence for divergence / Divergence Score, columns Supporters / Opponents)
+   - 7g. Dispute Types (Empirical / Definitional / Values, each with Score)
+   - 7h. Primary Obstacles to Resolution (`Obstacles for Supporters / Score /
+     Obstacles for Opponents / Score`)
+   - 7i. Biases (`Affecting Supporters / Score / Affecting Opponents / Score`)
+8. **Media Resources** (two-sided: `Resource (Author, Year) / Type / Score`)
+9. **Legal Framework** (`Supporting / Score / Complicating / Score`)
+10. **General to Specific Belief Mapping** (Upstream and Downstream, each
+    `Support / Score / Oppose / Score`)
+11. **Similar Beliefs** (`More Extreme / Score / More Moderate / Score`, scored by
+    belief equivalency)
+12. **Definitions** (`Term / Definition / Score`) — LAST before footer
+13. **Contribute / footer**
 
 ---
 
@@ -190,16 +230,19 @@ prior revision; the April 2026 template restores them as standalone sections.)
 
 Before outputting any ISE belief page, verify:
 
-- [ ] No summary or background section at the top
-- [ ] Header has the metadata line (Topic / Dewey / Positivity / Net Belief Score / Related) and "Beliefs this supports"
+- [ ] No summary or background section at the top — the Scorecard is a scored readout, not prose
+- [ ] Header has the metadata line (Topic / Dewey / Positivity / Related) and "Beliefs this supports"
+- [ ] Scorecard shows Net Belief Score, Bottom line, Strongest pro/con (top-ranked argument each side), and the top score-mover
 - [ ] Definitions section is LAST, not first
 - [ ] Argument cells are short claim labels with the famous quote inline and `~Name` submitter — no citations, percentages, or study names
 - [ ] Argument Trees and Evidence Ledger each render as a single two-sided table with Pro/Con (or Supporting/Weakening) halves
 - [ ] All evidence lives in the Evidence Ledger with tier assigned
-- [ ] Conflict Resolution Framework has all seven sub-sections: Shared Values rankings, Interests of Supporters, Interests of Opponents, Shared+Conflicting (Shared Interests + Primary Conflict Pair), Advertised vs. Actual, Dispute Types, Primary Obstacles
-- [ ] Objective Criteria has Criterion / How to Measure / Current Status / Target
-- [ ] Falsifiability Test, Testable Predictions, and Media Resources are present as standalone sections
-- [ ] Cost-Benefit Analysis bundles Short vs. Long-Term and Best Compromise Solutions (3 columns)
+- [ ] Every table has its Score column(s), sorts by score descending, and unscored rows sink to the bottom
+- [ ] Objective Criteria has Criterion / How to Measure / Reading That Would Strengthen / Reading That Would Weaken / Latest Reading / Score
+- [ ] Falsifiability Test rows are bet-specific score-movers with per-row Scores; Testable Predictions include Follows If and Result So Far
+- [ ] Logical Anatomy decomposes the belief (logical form + typed, load-bearing-flagged component claims)
+- [ ] Cost-Benefit rows carry Category (Units) / Magnitude / Likelihood % / Expected Value and subtotal only within a category
+- [ ] Conflict Resolution Framework has all sub-sections: Shared Values rankings, Interests of Supporters, Interests of Opponents, Shared+Conflicting (Shared Interests + Primary Conflict Pair), Best Compromise Solutions, Advertised vs. Actual (with Divergence Score), Dispute Types, Primary Obstacles, Biases
 - [ ] Every link points to a page that exists OR is plain text
 - [ ] No `href="#"` anchors anywhere
 - [ ] Both sides have symmetric structure in Interests, Advertised vs. Actual, Biases, Obstacles

--- a/prisma/migrations/20260703180252_add_belief_content_relationship_scores/migration.sql
+++ b/prisma/migrations/20260703180252_add_belief_content_relationship_scores/migration.sql
@@ -1,0 +1,139 @@
+-- AlterTable
+ALTER TABLE "Assumption" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "Belief" ADD COLUMN "bottomLine" TEXT;
+ALTER TABLE "Belief" ADD COLUMN "logicalForm" TEXT;
+ALTER TABLE "Belief" ADD COLUMN "scoreMover" TEXT;
+
+-- AlterTable
+ALTER TABLE "BeliefMapping" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "BiasEntry" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "Compromise" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "Definition" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "DisputeType" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "InterestEntry" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "LegalEntry" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "ObjectiveCriteria" ADD COLUMN "strengthenReading" TEXT;
+ALTER TABLE "ObjectiveCriteria" ADD COLUMN "weakenReading" TEXT;
+
+-- AlterTable
+ALTER TABLE "Obstacle" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "SharedInterest" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "ValueRanking" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "ValuesAnalysis" ADD COLUMN "opposingDivergenceScore" REAL;
+ALTER TABLE "ValuesAnalysis" ADD COLUMN "supportingDivergenceScore" REAL;
+
+-- CreateTable
+CREATE TABLE "ComponentClaim" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "beliefId" INTEGER NOT NULL,
+    "claim" TEXT NOT NULL,
+    "claimType" TEXT,
+    "stated" BOOLEAN NOT NULL DEFAULT true,
+    "survivesWithout" BOOLEAN,
+    "unstatedAssumptions" TEXT,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ComponentClaim_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "FalsifiabilityItem" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "beliefId" INTEGER NOT NULL,
+    "side" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FalsifiabilityItem_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "CostBenefitItem" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "beliefId" INTEGER NOT NULL,
+    "side" TEXT NOT NULL,
+    "claim" TEXT NOT NULL,
+    "claimBeliefId" INTEGER,
+    "category" TEXT,
+    "magnitude" REAL,
+    "likelihood" REAL,
+    "expectedValue" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "CostBenefitItem_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "CostBenefitItem_claimBeliefId_fkey" FOREIGN KEY ("claimBeliefId") REFERENCES "Belief" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ImpactEntry" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "beliefId" INTEGER NOT NULL,
+    "term" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ImpactEntry_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_TestablePrediction" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "beliefId" INTEGER NOT NULL,
+    "prediction" TEXT NOT NULL,
+    "timeframe" TEXT,
+    "verificationMethod" TEXT,
+    "followsIf" TEXT NOT NULL DEFAULT 'true',
+    "resultSoFar" TEXT,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "TestablePrediction_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_TestablePrediction" ("beliefId", "createdAt", "id", "prediction", "sortOrder", "timeframe", "verificationMethod") SELECT "beliefId", "createdAt", "id", "prediction", "sortOrder", "timeframe", "verificationMethod" FROM "TestablePrediction";
+DROP TABLE "TestablePrediction";
+ALTER TABLE "new_TestablePrediction" RENAME TO "TestablePrediction";
+CREATE INDEX "TestablePrediction_beliefId_idx" ON "TestablePrediction"("beliefId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "ComponentClaim_beliefId_idx" ON "ComponentClaim"("beliefId");
+
+-- CreateIndex
+CREATE INDEX "FalsifiabilityItem_beliefId_idx" ON "FalsifiabilityItem"("beliefId");
+
+-- CreateIndex
+CREATE INDEX "CostBenefitItem_beliefId_idx" ON "CostBenefitItem"("beliefId");
+
+-- CreateIndex
+CREATE INDEX "CostBenefitItem_claimBeliefId_idx" ON "CostBenefitItem"("claimBeliefId");
+
+-- CreateIndex
+CREATE INDEX "ImpactEntry_beliefId_idx" ON "ImpactEntry"("beliefId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -249,6 +249,18 @@ model Belief {
   /// trees (e.g. "Pro arguments outweigh con arguments roughly 2:1").
   netInterpretation String?
 
+  /// Scorecard "Bottom line": one-sentence verdict scoped to what the argument
+  /// tree actually supports — no bigger claim than the leaves can carry.
+  bottomLine String?
+
+  /// Scorecard "What would move this score most": the single piece of evidence
+  /// that would most change the verdict (mirrors the Falsifiability Test).
+  scoreMover String?
+
+  /// Logical Anatomy "Logical form" line, e.g.
+  /// "[This belief] = [Part 1] AND [Part 2] AND ([Part 3] OR [Part 4])".
+  logicalForm String?
+
   /// Header metadata (new template). Newline- or pipe-separated lists of related
   /// belief labels and the higher-level beliefs this one supports. Plain text so
   /// they never render as broken links (Rule 5).
@@ -259,6 +271,14 @@ model Belief {
   interestEntries InterestEntry[]
   sharedInterests SharedInterest[]
   disputeTypes   DisputeType[]
+
+  falsifiabilityItems FalsifiabilityItem[]
+  componentClaims     ComponentClaim[]
+  costBenefitItems    CostBenefitItem[]  @relation("BeliefCostBenefitItems")
+  impactEntries       ImpactEntry[]
+
+  /// Cost/benefit rows on OTHER beliefs whose claim links to this belief's page.
+  costBenefitClaimOf  CostBenefitItem[]  @relation("CostBenefitClaimBelief")
 
   productReview  ProductReview?
 }
@@ -418,6 +438,12 @@ model ObjectiveCriteria {
   currentStatus String?
   target        String?
 
+  /// The readings each side predicts: a good criterion is one where supporters
+  /// and opponents predict DIFFERENT readings. strengthenReading falls back to
+  /// `target` and latest reading to `currentStatus` when unset.
+  strengthenReading String?
+  weakenReading     String?
+
   createdAt DateTime @default(now())
 }
 
@@ -435,6 +461,11 @@ model ValuesAnalysis {
   /// advertised reason and the actual driver diverge, per side.
   supportingDivergenceEvidence String?
   opposingDivergenceEvidence   String?
+
+  /// Divergence Score per side: performance of the sub-debate that
+  /// advertised ≠ actual. Null renders blank (Rule 6).
+  supportingDivergenceScore Float?
+  opposingDivergenceScore   Float?
 
   /// "What would shift these rankings?" prompt answer beneath the Shared Values table.
   whatWouldShift String?
@@ -479,6 +510,9 @@ model ValueRanking {
   supporterRank Int?
   opponentRank  Int?
   whyDiffer     String?
+  /// Row score: ReasonRank performance of this row's own pro/con sub-debate.
+  /// Null renders blank (Rule 6). The table sorts by this, descending.
+  score         Float?
   sortOrder     Int    @default(0)
 
   createdAt DateTime @default(now())
@@ -501,6 +535,9 @@ model InterestEntry {
   connectedValue   String?
   /// Pretextual / low-validity interest (renders in the italic low-validity row).
   pretextual       Boolean @default(false)
+  /// Row score used for ranking (estimated prevalence weighted by linkage
+  /// confidence). Null renders blank (Rule 6); the table sorts by this, descending.
+  score            Float?
   sortOrder        Int     @default(0)
 
   createdAt DateTime @default(now())
@@ -517,6 +554,8 @@ model SharedInterest {
   interest           String
   validity           String?
   compromiseDirection String?
+  /// Row score: performance of this row's pro/con sub-debate. Sorts descending.
+  score              Float?
   sortOrder          Int    @default(0)
 
   createdAt DateTime @default(now())
@@ -533,6 +572,8 @@ model DisputeType {
   disputeType       String // "Empirical" | "Definitional" | "Values"
   disagreement      String?
   evidenceThatMoves String?
+  /// Row score: performance of this row's pro/con sub-debate. Sorts descending.
+  score             Float?
   sortOrder         Int    @default(0)
 
   createdAt DateTime @default(now())
@@ -548,8 +589,54 @@ model Assumption {
   side       String // "accept" or "reject"
   statement  String
   strength   String @default("MODERATE")
+  /// Row score: performance of this assumption's pro/con sub-debate. Sorts descending.
+  score      Float?
 
   createdAt DateTime @default(now())
+}
+
+/// One row in the Logical Anatomy table: a component claim the belief statement
+/// contains (stated or implied), typed and marked load-bearing or not. A belief
+/// that is a chain of ANDs is exactly as strong as its weakest load-bearing part.
+model ComponentClaim {
+  id       Int    @id @default(autoincrement())
+  beliefId Int
+  belief   Belief @relation(fields: [beliefId], references: [id])
+
+  claim     String
+  /// "Empirical" | "Causal" | "Definitional" | "Normative"
+  claimType String?
+  /// True when the component is stated outright, false when only implied.
+  stated    Boolean @default(true)
+  /// If this part is false, does the belief survive? false = load-bearing.
+  survivesWithout     Boolean?
+  unstatedAssumptions String?
+  /// Row score: performance of this component's pro/con sub-debate. Sorts descending.
+  score     Float?
+  sortOrder Int    @default(0)
+
+  createdAt DateTime @default(now())
+
+  @@index([beliefId])
+}
+
+/// One row in the Falsifiability Test table: a realistic score-mover in either
+/// direction, as specific as a bet (what result, from what source, by when).
+model FalsifiabilityItem {
+  id       Int    @id @default(autoincrement())
+  beliefId Int
+  belief   Belief @relation(fields: [beliefId], references: [id])
+
+  side        String // "strengthen" or "weaken"
+  description String
+  /// Row score: performance of the sub-debate "if this evidence appeared, would
+  /// it actually move this belief?". Sorts descending.
+  score     Float?
+  sortOrder Int    @default(0)
+
+  createdAt DateTime @default(now())
+
+  @@index([beliefId])
 }
 
 model CostBenefitAnalysis {
@@ -564,6 +651,57 @@ model CostBenefitAnalysis {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+/// One row in the Benefits / Costs and Risks tables. Every cost and benefit is
+/// itself a debatable claim (optionally linked to its own belief page). Keep
+/// unlike categories (dollars, life-years, hours, freedom) in separate rows and
+/// subtotal only within a category.
+model CostBenefitItem {
+  id       Int    @id @default(autoincrement())
+  beliefId Int
+  belief   Belief @relation("BeliefCostBenefitItems", fields: [beliefId], references: [id])
+
+  side  String // "benefit" or "cost"
+  claim String
+
+  /// The claim's own belief page, when one exists. Likelihood is computed from
+  /// how THAT belief's pro/con arguments score — never assigned by gut.
+  claimBeliefId Int?
+  claimBelief   Belief? @relation("CostBenefitClaimBelief", fields: [claimBeliefId], references: [id])
+
+  /// Category (units): "dollars" | "life-years" | "hours" | "freedom".
+  category   String?
+  /// Magnitude: an estimate in explicit category units.
+  magnitude  Float?
+  /// Likelihood (0-1), computed from the claim's pro/con argument scores.
+  likelihood Float?
+  /// Expected Value = Magnitude × Likelihood. Null renders blank (Rule 6).
+  /// The table sorts by this, descending.
+  expectedValue Float?
+  sortOrder     Int  @default(0)
+
+  createdAt DateTime @default(now())
+
+  @@index([beliefId])
+  @@index([claimBeliefId])
+}
+
+/// One row in the Short vs. Long-Term Impacts sub-table (inside Cost-Benefit).
+model ImpactEntry {
+  id       Int    @id @default(autoincrement())
+  beliefId Int
+  belief   Belief @relation(fields: [beliefId], references: [id])
+
+  term        String // "short" (0-2 years) or "long" (5+ years)
+  description String
+  /// Row score: performance of this impact's pro/con sub-debate. Sorts descending.
+  score     Float?
+  sortOrder Int    @default(0)
+
+  createdAt DateTime @default(now())
+
+  @@index([beliefId])
 }
 
 // ─── Automated CBA Skill Models ──────────────────────────────────────────────
@@ -730,6 +868,10 @@ model Compromise {
   synthesis     String?
   whyDifficult  String?
 
+  /// Row score: share of both sides' interests this compromise satisfies,
+  /// per its own pro/con sub-debate. Sorts descending.
+  score Float?
+
   createdAt   DateTime @default(now())
 }
 
@@ -740,6 +882,8 @@ model Obstacle {
 
   side        String // "supporter" or "opposition"
   description String
+  /// Row score: performance of this obstacle's pro/con sub-debate. Sorts descending.
+  score       Float?
   createdAt   DateTime @default(now())
 }
 
@@ -751,6 +895,9 @@ model BiasEntry {
   side     String
   biasType String
   description String?
+  /// Row score: how strongly this bias plausibly operates on this side here,
+  /// per its own pro/con sub-debate. Sorts descending.
+  score    Float?
 
   createdAt DateTime @default(now())
 }
@@ -844,6 +991,9 @@ model LegalEntry {
   side        String // "supporting" or "contradicting"
   description String
   jurisdiction String?
+  /// Row score: how strongly this law bears on the belief, per its own
+  /// pro/con sub-debate. Sorts descending.
+  score       Float?
 
   createdAt DateTime @default(now())
 }
@@ -859,6 +1009,10 @@ model BeliefMapping {
 
   direction String // "upstream" or "downstream"
   side      String // "support" or "oppose"
+
+  /// Row score: strength of the general↔specific relationship, per its own
+  /// pro/con sub-debate. Sorts descending.
+  score Float?
 
   createdAt DateTime @default(now())
 }
@@ -889,6 +1043,9 @@ model Definition {
   belief     Belief @relation(fields: [beliefId], references: [id])
   term       String
   definition String
+  /// Row score: how well this operational definition serves the analysis,
+  /// per its own pro/con sub-debate. Sorts descending.
+  score      Float?
   sortOrder  Int    @default(0)
   createdAt  DateTime @default(now())
 
@@ -902,6 +1059,14 @@ model TestablePrediction {
   prediction         String
   timeframe          String?
   verificationMethod String?
+  /// "true" when the prediction follows if the belief is true, "false" when it
+  /// follows if the belief is false (the template's "Follows If…" column).
+  followsIf          String  @default("true")
+  /// What has actually been observed so far, if anything.
+  resultSoFar        String?
+  /// Row score: how discriminating this prediction is, per its own pro/con
+  /// sub-debate. Sorts descending.
+  score              Float?
   sortOrder          Int    @default(0)
   createdAt          DateTime @default(now())
 

--- a/src/app/beliefs/[slug]/page.tsx
+++ b/src/app/beliefs/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { fetchBeliefBySlug, computeBeliefScores } from '@/features/belief-analysis/data/fetch-belief'
+import ScorecardSection from '@/features/belief-analysis/components/ScorecardSection'
 import ArgumentTreesSection from '@/features/belief-analysis/components/ArgumentTreesSection'
 import EvidenceSection from '@/features/belief-analysis/components/EvidenceSection'
 import ConflictResolutionSection from '@/features/belief-analysis/components/ConflictResolutionSection'
@@ -102,6 +103,18 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
         )}
 
         <div className="space-y-12">
+          {/* 0. Scorecard — a readout of the top-scoring rows below, not a prose summary */}
+          <ScorecardSection
+            arguments={belief.arguments}
+            totalPro={scores.totalPro}
+            totalCon={scores.totalCon}
+            bottomLine={belief.bottomLine ?? null}
+            scoreMover={belief.scoreMover ?? null}
+            falsifiabilityItems={belief.falsifiabilityItems ?? []}
+          />
+
+          <hr className="border-gray-200" />
+
           {/* 1. Argument Trees */}
           <ArgumentTreesSection
             arguments={belief.arguments}
@@ -137,6 +150,7 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
 
           {/* 5. Falsifiability Test + Testable Predictions */}
           <FalsifiabilityTestSection
+            items={belief.falsifiabilityItems ?? []}
             confirm={belief.falsifiabilityConfirm}
             falsify={belief.falsifiabilityFalsify}
             legacy={belief.falsifiability}
@@ -145,15 +159,21 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
 
           <hr className="border-gray-200" />
 
-          {/* 6. Foundational Assumptions */}
-          <AssumptionsSection assumptions={belief.assumptions} />
+          {/* 6. Logical Anatomy & Foundational Assumptions */}
+          <AssumptionsSection
+            assumptions={belief.assumptions}
+            componentClaims={belief.componentClaims ?? []}
+            logicalForm={belief.logicalForm ?? null}
+          />
 
           <hr className="border-gray-200" />
 
           {/* 7. Cost-Benefit Analysis (+ Short/Long-Term + Best Compromise Solutions) */}
           <CostBenefitSection
             cba={belief.costBenefitAnalysis}
+            items={belief.costBenefitItems ?? []}
             impact={belief.impactAnalysis}
+            impactEntries={belief.impactEntries ?? []}
             compromises={belief.compromises}
           />
 

--- a/src/features/belief-analysis/components/ArgumentTreesSection.tsx
+++ b/src/features/belief-analysis/components/ArgumentTreesSection.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import type { ArgumentWithBelief } from '../types'
+import { TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface ArgumentTreesSectionProps {
   arguments: ArgumentWithBelief[]
@@ -24,6 +26,12 @@ function impactCell(arg: ArgumentWithBelief): string {
   if (!arg.impactScore) return ''
   const sign = arg.side === 'agree' ? '+' : '-'
   return `${sign}${Math.abs(arg.impactScore).toFixed(1)}`
+}
+
+/** Importance column: blank until the argument itself is scored (Rule 6). */
+function impCell(arg: ArgumentWithBelief): string {
+  if (arg.argumentScore == null && !arg.impactScore) return ''
+  return arg.importanceScore.toFixed(1)
 }
 
 /** The argument cell: claim label, inline famous quote (italic), then ~Author link. */
@@ -61,6 +69,7 @@ function HalfRow({ arg }: { arg: ArgumentWithBelief | undefined }) {
         <td className="border border-gray-300 px-2 py-2 text-center">&nbsp;</td>
         <td className="border border-gray-300 px-2 py-2 text-center">&nbsp;</td>
         <td className="border border-gray-300 px-2 py-2 text-center">&nbsp;</td>
+        <td className="border border-gray-300 px-2 py-2 text-center">&nbsp;</td>
       </>
     )
   }
@@ -69,6 +78,7 @@ function HalfRow({ arg }: { arg: ArgumentWithBelief | undefined }) {
       <td className="border border-gray-300 px-3 py-2 align-top"><ArgumentCell arg={arg} /></td>
       <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs">{scoreCell(arg)}</td>
       <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs">{linkCell(arg)}</td>
+      <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs">{impCell(arg)}</td>
       <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs font-semibold">{impactCell(arg)}</td>
     </>
   )
@@ -84,6 +94,8 @@ export default function ArgumentTreesSection({
   const conArgs = args.filter(a => a.side === 'disagree')
   const rowCount = Math.max(proArgs.length, conArgs.length, 1)
   const rows = Array.from({ length: rowCount }, (_, i) => i)
+  const topRows = rows.slice(0, TABLE_TOP_LIMIT)
+  const restRows = rows.slice(TABLE_TOP_LIMIT)
 
   const net = totalPro - totalCon
   const netLabel = `${net >= 0 ? '+' : ''}${net.toFixed(1)}`
@@ -105,41 +117,55 @@ export default function ArgumentTreesSection({
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr>
-              <th className="border border-gray-300 bg-green-100 text-center font-semibold px-3 py-2" colSpan={4}>
+              <th className="border border-gray-300 bg-green-100 text-center font-semibold px-3 py-2" colSpan={5}>
                 ✅ Reasons to Agree
               </th>
-              <th className="border border-gray-300 bg-red-100 text-center font-semibold px-3 py-2" colSpan={4}>
+              <th className="border border-gray-300 bg-red-100 text-center font-semibold px-3 py-2" colSpan={5}>
                 ❌ Reasons to Disagree
               </th>
             </tr>
             <tr className="bg-gray-100 text-xs">
-              <th className="border border-gray-300 px-2 py-1.5 text-left w-[25%]">Argument</th>
-              <th className="border border-gray-300 px-2 py-1.5 w-[6%]">Score</th>
-              <th className="border border-gray-300 px-2 py-1.5 w-[6%]">
+              <th className="border border-gray-300 px-2 py-1.5 text-left w-[22%]">Argument</th>
+              <th className="border border-gray-300 px-2 py-1.5 w-[5%]">Score</th>
+              <th className="border border-gray-300 px-2 py-1.5 w-[5%]">
                 <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Link</Link>
               </th>
-              <th className="border border-gray-300 px-2 py-1.5 w-[7%]">Impact</th>
-              <th className="border border-gray-300 px-2 py-1.5 text-left w-[25%]">Argument</th>
-              <th className="border border-gray-300 px-2 py-1.5 w-[6%]">Score</th>
-              <th className="border border-gray-300 px-2 py-1.5 w-[6%]">
+              <th className="border border-gray-300 px-2 py-1.5 w-[5%]">
+                <Link href="/importance%20score" className="text-[var(--accent)] hover:underline">Imp</Link>
+              </th>
+              <th className="border border-gray-300 px-2 py-1.5 w-[6%]">Impact</th>
+              <th className="border border-gray-300 px-2 py-1.5 text-left w-[22%]">Argument</th>
+              <th className="border border-gray-300 px-2 py-1.5 w-[5%]">Score</th>
+              <th className="border border-gray-300 px-2 py-1.5 w-[5%]">
                 <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Link</Link>
               </th>
-              <th className="border border-gray-300 px-2 py-1.5 w-[7%]">Impact</th>
+              <th className="border border-gray-300 px-2 py-1.5 w-[5%]">
+                <Link href="/importance%20score" className="text-[var(--accent)] hover:underline">Imp</Link>
+              </th>
+              <th className="border border-gray-300 px-2 py-1.5 w-[6%]">Impact</th>
             </tr>
           </thead>
           <tbody>
-            {rows.map(i => (
+            {topRows.map(i => (
               <tr key={i}>
                 <HalfRow arg={proArgs[i]} />
                 <HalfRow arg={conArgs[i]} />
               </tr>
             ))}
+            <ExpandableRows moreCount={restRows.length} colSpan={10}>
+              {restRows.map(i => (
+                <tr key={i}>
+                  <HalfRow arg={proArgs[i]} />
+                  <HalfRow arg={conArgs[i]} />
+                </tr>
+              ))}
+            </ExpandableRows>
             <tr className="bg-gray-100 italic text-[#666]">
-              <td className="border border-gray-300 px-3 py-2 text-right font-semibold" colSpan={3}>Pro Total:</td>
+              <td className="border border-gray-300 px-3 py-2 text-right font-semibold" colSpan={4}>Pro Total:</td>
               <td className="border border-gray-300 px-2 py-2 text-center font-mono text-green-700">
                 {totalPro > 0 ? `+${totalPro.toFixed(1)}` : ''}
               </td>
-              <td className="border border-gray-300 px-3 py-2 text-right font-semibold" colSpan={3}>Con Total:</td>
+              <td className="border border-gray-300 px-3 py-2 text-right font-semibold" colSpan={4}>Con Total:</td>
               <td className="border border-gray-300 px-2 py-2 text-center font-mono text-red-700">
                 {totalCon > 0 ? `-${totalCon.toFixed(1)}` : ''}
               </td>

--- a/src/features/belief-analysis/components/AssumptionsSection.tsx
+++ b/src/features/belief-analysis/components/AssumptionsSection.tsx
@@ -1,9 +1,19 @@
-import type { AssumptionItem } from '../types'
+import type { AssumptionItem, ComponentClaimItem } from '../types'
 import SectionHeading from './SectionHeading'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface AssumptionsSectionProps {
   assumptions: AssumptionItem[]
+  /** Logical Anatomy rows: the component claims inside the belief statement. */
+  componentClaims?: ComponentClaimItem[]
+  /** The belief decomposed into ANDs/ORs, e.g. "[This belief] = [Part 1] AND [Part 2]". */
+  logicalForm?: string | null
 }
+
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
 
 function strengthBadge(strength: string): string {
   switch (strength) {
@@ -15,63 +25,132 @@ function strengthBadge(strength: string): string {
   }
 }
 
-export default function AssumptionsSection({ assumptions }: AssumptionsSectionProps) {
-  const accept = assumptions.filter(a => a.side === 'accept')
-  const reject = assumptions.filter(a => a.side === 'reject')
+function ComponentClaimRow({ c }: { c: ComponentClaimItem | null }) {
+  return (
+    <tr>
+      <td className={TD}>{c?.claim ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{c?.claimType ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{c ? (c.stated ? 'Stated' : 'Implied') : <span>&nbsp;</span>}</td>
+      <td className={TDC}>
+        {c?.survivesWithout == null ? (
+          <span>&nbsp;</span>
+        ) : c.survivesWithout ? (
+          'Yes'
+        ) : (
+          <strong>No = load-bearing</strong>
+        )}
+      </td>
+      <td className={TD}>{c?.unstatedAssumptions ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(c?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
+function AssumptionCell({ a }: { a: AssumptionItem | null }) {
+  if (!a) return <span>&nbsp;</span>
+  return (
+    <>
+      {a.statement}
+      <span className={`ml-2 text-xs px-1.5 py-0.5 rounded ${strengthBadge(a.strength)}`}>
+        {a.strength}
+      </span>
+    </>
+  )
+}
+
+export default function AssumptionsSection({
+  assumptions,
+  componentClaims = [],
+  logicalForm,
+}: AssumptionsSectionProps) {
+  const accept = rankByScore(assumptions.filter(a => a.side === 'accept'), a => a.score, Infinity).top
+  const reject = rankByScore(assumptions.filter(a => a.side === 'reject'), a => a.score, Infinity).top
+  const pairs = pairBySide(accept, reject)
+  const topPairs = pairs.length > 0 ? pairs.slice(0, TABLE_TOP_LIMIT) : [[null, null] as [AssumptionItem | null, AssumptionItem | null]]
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
+
+  const claims = rankByScore(componentClaims, c => c.score)
 
   return (
-    <section>
-      <SectionHeading
-        emoji="&#x1F4DC;"
-        title="Foundational Assumptions"
-        href="/Assumptions"
-      />
+    <section className="space-y-6">
+      <div>
+        <SectionHeading
+          emoji="&#x1F4A1;"
+          title="Logical Anatomy and Foundational Assumptions"
+          href="/Assumptions"
+        />
+        <p className="text-sm text-[var(--muted-foreground)] mb-2">
+          A belief statement that reads as one claim is usually several claims wearing one sentence.
+          If the belief is a chain of ANDs, it is exactly as strong as its weakest load-bearing part.
+        </p>
+        <p className="text-sm mb-3">
+          <strong>Logical form:</strong>{' '}
+          {logicalForm ?? (
+            <span className="text-[var(--muted-foreground)] italic">
+              [This belief] = [Part 1] AND [Part 2] AND ([Part 3] OR [Part 4])
+            </span>
+          )}
+        </p>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr className="bg-gray-100 text-xs">
+                <th className={`${TH} w-[30%]`}>Component Claim (stated or implied)</th>
+                <th className={`${TH} text-center w-[14%]`}>Type</th>
+                <th className={`${TH} text-center w-[12%]`}>Stated?</th>
+                <th className={`${TH} text-center w-[18%]`}>If this part is false, does the belief survive?</th>
+                <th className={`${TH} w-[18%]`}>Unstated assumptions this part relies on</th>
+                <th className={`${TH} text-center w-[8%]`}>Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(claims.top.length > 0 ? claims.top : [null]).map((c, i) => (
+                <ComponentClaimRow key={c?.id ?? i} c={c} />
+              ))}
+              <ExpandableRows moreCount={claims.rest.length} colSpan={6}>
+                {claims.rest.map(c => (
+                  <ComponentClaimRow key={c.id} c={c} />
+                ))}
+              </ExpandableRows>
+            </tbody>
+          </table>
+        </div>
+      </div>
 
-      <div className="overflow-x-auto">
-        <table className="w-full border-collapse border border-gray-300 text-sm">
-          <thead>
-            <tr className="bg-gray-100">
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Required to Accept This Belief</th>
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Required to Reject This Belief</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td className="px-3 py-3 align-top">
-                {accept.length > 0 ? (
-                  <ol className="list-decimal list-inside space-y-1">
-                    {accept.map(a => (
-                      <li key={a.id} className="text-sm">
-                        {a.statement}
-                        <span className={`ml-2 text-xs px-1.5 py-0.5 rounded ${strengthBadge(a.strength)}`}>
-                          {a.strength}
-                        </span>
-                      </li>
-                    ))}
-                  </ol>
-                ) : (
-                  <span className="text-[var(--muted-foreground)] italic text-sm">Not yet analyzed</span>
-                )}
-              </td>
-              <td className="px-3 py-3 align-top">
-                {reject.length > 0 ? (
-                  <ol className="list-decimal list-inside space-y-1">
-                    {reject.map(a => (
-                      <li key={a.id} className="text-sm">
-                        {a.statement}
-                        <span className={`ml-2 text-xs px-1.5 py-0.5 rounded ${strengthBadge(a.strength)}`}>
-                          {a.strength}
-                        </span>
-                      </li>
-                    ))}
-                  </ol>
-                ) : (
-                  <span className="text-[var(--muted-foreground)] italic text-sm">Not yet analyzed</span>
-                )}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      <div>
+        <h3 className="text-base font-semibold mb-2">Assumptions by Side</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className={`${TH} w-[42%]`}>Required to Accept This Belief</th>
+                <th className={`${TH} text-center w-[8%]`}>Score</th>
+                <th className={`${TH} w-[42%]`}>Required to Reject This Belief</th>
+                <th className={`${TH} text-center w-[8%]`}>Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {topPairs.map(([a, r], i) => (
+                <tr key={a?.id ?? r?.id ?? i}>
+                  <td className={TD}><AssumptionCell a={a} /></td>
+                  <td className={`${TDC} font-mono`}>{formatScore(a?.score) ?? <span>&nbsp;</span>}</td>
+                  <td className={TD}><AssumptionCell a={r} /></td>
+                  <td className={`${TDC} font-mono`}>{formatScore(r?.score) ?? <span>&nbsp;</span>}</td>
+                </tr>
+              ))}
+              <ExpandableRows moreCount={restPairs.length} colSpan={4}>
+                {restPairs.map(([a, r], i) => (
+                  <tr key={a?.id ?? r?.id ?? i}>
+                    <td className={TD}><AssumptionCell a={a} /></td>
+                    <td className={`${TDC} font-mono`}>{formatScore(a?.score) ?? <span>&nbsp;</span>}</td>
+                    <td className={TD}><AssumptionCell a={r} /></td>
+                    <td className={`${TDC} font-mono`}>{formatScore(r?.score) ?? <span>&nbsp;</span>}</td>
+                  </tr>
+                ))}
+              </ExpandableRows>
+            </tbody>
+          </table>
+        </div>
       </div>
     </section>
   )

--- a/src/features/belief-analysis/components/BeliefMappingSection.tsx
+++ b/src/features/belief-analysis/components/BeliefMappingSection.tsx
@@ -1,72 +1,85 @@
 import Link from 'next/link'
 import type { MappingItem } from '../types'
 import SectionHeading from './SectionHeading'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface BeliefMappingSectionProps {
   upstreamMappings: MappingItem[]
   downstreamMappings: MappingItem[]
 }
 
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+function MappingCell({ m }: { m: MappingItem | null }) {
+  if (!m) return <span>&nbsp;</span>
+  const target = m.direction === 'upstream' ? m.parentBelief : m.childBelief
+  return (
+    <Link href={`/beliefs/${target.slug}`} className="text-[var(--accent)] hover:underline">
+      {target.statement}
+    </Link>
+  )
+}
+
+function MappingPairRow({ s, o }: { s: MappingItem | null; o: MappingItem | null }) {
+  return (
+    <tr>
+      <td className={TD}><MappingCell m={s} /></td>
+      <td className={`${TDC} font-mono`}>{formatScore(s?.score) ?? <span>&nbsp;</span>}</td>
+      <td className={TD}><MappingCell m={o} /></td>
+      <td className={`${TDC} font-mono`}>{formatScore(o?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
 function MappingTable({ mappings, label }: { mappings: MappingItem[]; label: string }) {
-  const supportMappings = mappings.filter(m => m.side === 'support')
-  const opposeMappings = mappings.filter(m => m.side === 'oppose')
+  const support = rankByScore(mappings.filter(m => m.side === 'support'), m => m.score, Infinity).top
+  const oppose = rankByScore(mappings.filter(m => m.side === 'oppose'), m => m.score, Infinity).top
+  const pairs = pairBySide(support, oppose)
+  const topPairs = pairs.slice(0, TABLE_TOP_LIMIT)
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
 
   return (
     <div className="overflow-x-auto">
       <table className="w-full border-collapse border border-gray-300 text-sm">
         <thead>
           <tr className="bg-gray-100">
-            <th className="px-3 py-2 text-center w-1/2 font-semibold">Support</th>
-            <th className="px-3 py-2 text-center w-1/2 font-semibold">Oppose</th>
+            <th className={`${TH} w-[42%]`}>Support</th>
+            <th className={`${TH} text-center w-[8%]`}>Score</th>
+            <th className={`${TH} w-[42%]`}>Oppose</th>
+            <th className={`${TH} text-center w-[8%]`}>Score</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td className="px-3 py-3 align-top text-sm">
-              {supportMappings.length > 0 ? (
-                <ol className="list-decimal list-inside space-y-1">
-                  {supportMappings.map(m => {
-                    const target = m.direction === 'upstream' ? m.parentBelief : m.childBelief
-                    return (
-                      <li key={m.id}>
-                        <Link href={`/beliefs/${target.slug}`} className="text-[var(--accent)] hover:underline">
-                          {target.statement}
-                        </Link>
-                      </li>
-                    )
-                  })}
-                </ol>
-              ) : (
-                <span className="text-[var(--muted-foreground)] italic">
-                  {label === 'upstream'
-                    ? 'Broader principles that, if true, would support this belief'
-                    : 'More specific claims that depend on this belief being true'}
-                </span>
-              )}
-            </td>
-            <td className="px-3 py-3 align-top text-sm">
-              {opposeMappings.length > 0 ? (
-                <ol className="list-decimal list-inside space-y-1">
-                  {opposeMappings.map(m => {
-                    const target = m.direction === 'upstream' ? m.parentBelief : m.childBelief
-                    return (
-                      <li key={m.id}>
-                        <Link href={`/beliefs/${target.slug}`} className="text-[var(--accent)] hover:underline">
-                          {target.statement}
-                        </Link>
-                      </li>
-                    )
-                  })}
-                </ol>
-              ) : (
-                <span className="text-[var(--muted-foreground)] italic">
-                  {label === 'upstream'
-                    ? 'Broader principles that, if true, would oppose this belief'
-                    : 'More specific claims that depend on this belief being false'}
-                </span>
-              )}
-            </td>
-          </tr>
+          {pairs.length > 0 ? (
+            <>
+              {topPairs.map(([s, o], i) => (
+                <MappingPairRow key={s?.id ?? o?.id ?? i} s={s} o={o} />
+              ))}
+              <ExpandableRows moreCount={restPairs.length} colSpan={4}>
+                {restPairs.map(([s, o], i) => (
+                  <MappingPairRow key={s?.id ?? o?.id ?? i} s={s} o={o} />
+                ))}
+              </ExpandableRows>
+            </>
+          ) : (
+            <tr>
+              <td className={`${TD} text-[var(--muted-foreground)] italic`}>
+                {label === 'upstream'
+                  ? 'Broader principles that, if true, would support this belief'
+                  : 'More specific claims that depend on this belief being true'}
+              </td>
+              <td className={TDC}>&nbsp;</td>
+              <td className={`${TD} text-[var(--muted-foreground)] italic`}>
+                {label === 'upstream'
+                  ? 'Broader principles that, if true, would oppose this belief'
+                  : 'More specific claims that depend on this belief being false'}
+              </td>
+              <td className={TDC}>&nbsp;</td>
+            </tr>
+          )}
         </tbody>
       </table>
     </div>

--- a/src/features/belief-analysis/components/BiasesSection.tsx
+++ b/src/features/belief-analysis/components/BiasesSection.tsx
@@ -1,17 +1,47 @@
 import type { BiasItem } from '../types'
 import SectionHeading from './SectionHeading'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface BiasesSectionProps {
   biases: BiasItem[]
 }
 
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
 function formatBiasType(type: string): string {
   return type.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
+function BiasCell({ b }: { b: BiasItem | null }) {
+  if (!b) return <span>&nbsp;</span>
+  return (
+    <>
+      <strong>{formatBiasType(b.biasType)}</strong>
+      {b.description && <span className="text-[var(--muted-foreground)]"> - {b.description}</span>}
+    </>
+  )
+}
+
+function BiasPairRow({ s, o }: { s: BiasItem | null; o: BiasItem | null }) {
+  return (
+    <tr>
+      <td className={TD}><BiasCell b={s} /></td>
+      <td className={`${TDC} font-mono`}>{formatScore(s?.score) ?? <span>&nbsp;</span>}</td>
+      <td className={TD}><BiasCell b={o} /></td>
+      <td className={`${TDC} font-mono`}>{formatScore(o?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
 export default function BiasesSection({ biases }: BiasesSectionProps) {
-  const supporterBiases = biases.filter(b => b.side === 'supporter')
-  const opponentBiases = biases.filter(b => b.side === 'opponent')
+  const supporters = rankByScore(biases.filter(b => b.side === 'supporter'), b => b.score, Infinity).top
+  const opponents = rankByScore(biases.filter(b => b.side === 'opponent'), b => b.score, Infinity).top
+  const pairs = pairBySide(supporters, opponents)
+  const topPairs = pairs.slice(0, TABLE_TOP_LIMIT)
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
 
   return (
     <section>
@@ -25,49 +55,40 @@ export default function BiasesSection({ biases }: BiasesSectionProps) {
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Affecting Supporters</th>
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Affecting Opponents</th>
+              <th className={`${TH} w-[42%]`}>Biases Affecting Supporters</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
+              <th className={`${TH} w-[42%]`}>Biases Affecting Opponents</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td className="px-3 py-3 align-top text-sm">
-                {supporterBiases.length > 0 ? (
-                  <ol className="list-decimal list-inside space-y-1">
-                    {supporterBiases.map(b => (
-                      <li key={b.id}>
-                        <strong>{formatBiasType(b.biasType)}</strong>
-                        {b.description && <span className="text-[var(--muted-foreground)]"> - {b.description}</span>}
-                      </li>
-                    ))}
-                  </ol>
-                ) : (
-                  <div className="text-[var(--muted-foreground)]">
-                    <p>1. Confirmation bias?</p>
-                    <p>2. Motivated reasoning?</p>
-                    <p>3. Availability heuristic?</p>
-                  </div>
-                )}
-              </td>
-              <td className="px-3 py-3 align-top text-sm">
-                {opponentBiases.length > 0 ? (
-                  <ol className="list-decimal list-inside space-y-1">
-                    {opponentBiases.map(b => (
-                      <li key={b.id}>
-                        <strong>{formatBiasType(b.biasType)}</strong>
-                        {b.description && <span className="text-[var(--muted-foreground)]"> - {b.description}</span>}
-                      </li>
-                    ))}
-                  </ol>
-                ) : (
-                  <div className="text-[var(--muted-foreground)]">
-                    <p>1. Confirmation bias?</p>
-                    <p>2. Motivated reasoning?</p>
-                    <p>3. Availability heuristic?</p>
-                  </div>
-                )}
-              </td>
-            </tr>
+            {pairs.length > 0 ? (
+              <>
+                {topPairs.map(([s, o], i) => (
+                  <BiasPairRow key={s?.id ?? o?.id ?? i} s={s} o={o} />
+                ))}
+                <ExpandableRows moreCount={restPairs.length} colSpan={4}>
+                  {restPairs.map(([s, o], i) => (
+                    <BiasPairRow key={s?.id ?? o?.id ?? i} s={s} o={o} />
+                  ))}
+                </ExpandableRows>
+              </>
+            ) : (
+              <tr>
+                <td className={`${TD} text-[var(--muted-foreground)]`}>
+                  <p>1. Confirmation bias?</p>
+                  <p>2. Motivated reasoning?</p>
+                  <p>3. Availability heuristic?</p>
+                </td>
+                <td className={TDC}>&nbsp;</td>
+                <td className={`${TD} text-[var(--muted-foreground)]`}>
+                  <p>1. Confirmation bias?</p>
+                  <p>2. Motivated reasoning?</p>
+                  <p>3. Availability heuristic?</p>
+                </td>
+                <td className={TDC}>&nbsp;</td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/src/features/belief-analysis/components/ConflictResolutionSection.tsx
+++ b/src/features/belief-analysis/components/ConflictResolutionSection.tsx
@@ -8,6 +8,8 @@ import type {
   DisputeTypeItem,
   ObstacleItem,
 } from '../types'
+import { byScoreDesc, formatScore, rankByScore, TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface ConflictResolutionSectionProps {
   values: ValuesAnalysisData | null
@@ -33,31 +35,45 @@ const TD = 'border border-gray-300 px-3 py-2 align-top'
 const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
 
 /* ── Shared Values, Different Rankings ──────────────────────────────────── */
+function ValueRow({ row, striped }: { row: ValueRankingItem | null; striped: boolean }) {
+  return (
+    <tr className={striped ? 'bg-gray-50' : ''}>
+      <td className={TD}>{row?.value ?? <span className="text-[var(--muted-foreground)] italic">[value]</span>}</td>
+      <td className={`${TDC} font-mono`}>{rank(row?.supporterRank ?? null)}</td>
+      <td className={`${TDC} font-mono`}>{rank(row?.opponentRank ?? null)}</td>
+      <td className={TD}>{lines(row?.whyDiffer)}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(row?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
 function SharedValuesTable({ rows, whatWouldShift }: { rows: ValueRankingItem[]; whatWouldShift: string | null | undefined }) {
-  const data = rows.length > 0 ? rows : [null, null, null]
+  const { top, rest } = rankByScore(rows, r => r.score)
+  const data: Array<ValueRankingItem | null> = top.length > 0 ? top : [null, null, null]
   return (
     <table className="w-full border-collapse border border-gray-300 text-sm mb-2">
       <thead>
         <tr className="bg-gray-100">
-          <th className={`${TH} w-[28%]`}>
+          <th className={`${TH} w-[24%]`}>
             <Link href="/American%20values" className="text-[var(--accent)] hover:underline">Value</Link>
           </th>
-          <th className={`${TH} text-center w-[12%]`}>Supporter Rank</th>
-          <th className={`${TH} text-center w-[12%]`}>Opponent Rank</th>
+          <th className={`${TH} text-center w-[10%]`}>Supporter Rank</th>
+          <th className={`${TH} text-center w-[10%]`}>Opponent Rank</th>
           <th className={`${TH} w-[48%]`}>Why Rankings Differ on This Issue</th>
+          <th className={`${TH} text-center w-[8%]`}>Score</th>
         </tr>
       </thead>
       <tbody>
         {data.map((row, i) => (
-          <tr key={i} className={i % 2 === 1 ? 'bg-gray-50' : ''}>
-            <td className={TD}>{row?.value ?? <span className="text-[var(--muted-foreground)] italic">[value]</span>}</td>
-            <td className={`${TDC} font-mono`}>{rank(row?.supporterRank ?? null)}</td>
-            <td className={`${TDC} font-mono`}>{rank(row?.opponentRank ?? null)}</td>
-            <td className={TD}>{lines(row?.whyDiffer)}</td>
-          </tr>
+          <ValueRow key={row?.id ?? i} row={row} striped={i % 2 === 1} />
         ))}
+        <ExpandableRows moreCount={rest.length} colSpan={5}>
+          {rest.map((row, i) => (
+            <ValueRow key={row.id} row={row} striped={(top.length + i) % 2 === 1} />
+          ))}
+        </ExpandableRows>
         <tr className="bg-gray-100">
-          <td className={TD} colSpan={4}>
+          <td className={TD} colSpan={5}>
             <strong>What would shift these rankings?</strong>{' '}
             {whatWouldShift ?? <span className="text-[var(--muted-foreground)] italic">What evidence, cost-benefit findings, or likelihood changes would cause either side to re-rank?</span>}
           </td>
@@ -68,10 +84,24 @@ function SharedValuesTable({ rows, whatWouldShift }: { rows: ValueRankingItem[];
 }
 
 /* ── Likely Interests of one side ───────────────────────────────────────── */
+function InterestRow({ e }: { e: InterestEntryItem | null }) {
+  return (
+    <tr>
+      <td className={TD}>{e?.interest ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{e?.prevalence ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{e?.linkageConfidence ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{e?.validity ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{e?.evidenceBasis ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{e?.connectedValue ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
 function InterestTable({ entries, headerClass }: { entries: InterestEntryItem[]; headerClass: string }) {
   const main = entries.filter(e => !e.pretextual)
   const pretextual = entries.filter(e => e.pretextual)
-  const mainRows: Array<InterestEntryItem | null> = main.length > 0 ? main : [null]
+  const { top, rest } = rankByScore(main, e => e.score)
+  const mainRows: Array<InterestEntryItem | null> = top.length > 0 ? top : [null]
   return (
     <table className="w-full border-collapse border border-gray-300 text-sm">
       <thead>
@@ -90,17 +120,15 @@ function InterestTable({ entries, headerClass }: { entries: InterestEntryItem[];
       </thead>
       <tbody>
         {mainRows.map((e, i) => (
-          <tr key={`m${i}`}>
-            <td className={TD}>{e?.interest ?? <span>&nbsp;</span>}</td>
-            <td className={TDC}>{e?.prevalence ?? <span>&nbsp;</span>}</td>
-            <td className={TDC}>{e?.linkageConfidence ?? <span>&nbsp;</span>}</td>
-            <td className={TDC}>{e?.validity ?? <span>&nbsp;</span>}</td>
-            <td className={TD}>{e?.evidenceBasis ?? <span>&nbsp;</span>}</td>
-            <td className={TD}>{e?.connectedValue ?? <span>&nbsp;</span>}</td>
-          </tr>
+          <InterestRow key={e?.id ?? `m${i}`} e={e} />
         ))}
+        <ExpandableRows moreCount={rest.length} colSpan={6}>
+          {rest.map(e => (
+            <InterestRow key={e.id} e={e} />
+          ))}
+        </ExpandableRows>
         {(pretextual.length > 0 ? pretextual : [null]).map((e, i) => (
-          <tr key={`p${i}`} className="bg-gray-50 italic">
+          <tr key={e?.id ?? `p${i}`} className="bg-gray-50 italic">
             <td className={TD}>{e?.interest ?? <em>Pretextual / Low-validity (if any)</em>}</td>
             <td className={TDC}>{e?.prevalence ?? <span>&nbsp;</span>}</td>
             <td className={TDC}>{e?.linkageConfidence ?? <span>&nbsp;</span>}</td>
@@ -115,25 +143,39 @@ function InterestTable({ entries, headerClass }: { entries: InterestEntryItem[];
 }
 
 /* ── Shared Interests + Primary Conflict Pair ───────────────────────────── */
+function SharedInterestRow({ row }: { row: SharedInterestItem | null }) {
+  return (
+    <tr>
+      <td className={TD}>{row?.interest ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{row?.validity ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{lines(row?.compromiseDirection)}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(row?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
 function SharedInterestsTable({ rows }: { rows: SharedInterestItem[] }) {
-  const data: Array<SharedInterestItem | null> = rows.length > 0 ? rows : [null]
+  const { top, rest } = rankByScore(rows, r => r.score)
+  const data: Array<SharedInterestItem | null> = top.length > 0 ? top : [null]
   return (
     <table className="w-full border-collapse border border-gray-300 text-sm">
       <thead>
         <tr className="bg-green-100">
-          <th className={`${TH} w-[40%]`}>Shared Interest</th>
+          <th className={`${TH} w-[36%]`}>Shared Interest</th>
           <th className={`${TH} text-center w-[12%]`}>Validity</th>
-          <th className={`${TH} w-[48%]`}>Compromise direction it opens</th>
+          <th className={`${TH} w-[44%]`}>Compromise direction it opens</th>
+          <th className={`${TH} text-center w-[8%]`}>Score</th>
         </tr>
       </thead>
       <tbody>
         {data.map((row, i) => (
-          <tr key={i}>
-            <td className={TD}>{row?.interest ?? <span>&nbsp;</span>}</td>
-            <td className={TDC}>{row?.validity ?? <span>&nbsp;</span>}</td>
-            <td className={TD}>{lines(row?.compromiseDirection)}</td>
-          </tr>
+          <SharedInterestRow key={row?.id ?? i} row={row} />
         ))}
+        <ExpandableRows moreCount={rest.length} colSpan={4}>
+          {rest.map(row => (
+            <SharedInterestRow key={row.id} row={row} />
+          ))}
+        </ExpandableRows>
       </tbody>
     </table>
   )
@@ -204,6 +246,16 @@ function AdvertisedVsActual({ values }: { values: ValuesAnalysisData | null }) {
             <td className={TD}>{lines(o)}</td>
           </tr>
         ))}
+        <tr className="bg-gray-50">
+          <td className={`${TD} bg-gray-100`}>
+            <strong>Divergence Score</strong>{' '}
+            <span className="text-[11px] text-[#555] font-normal">
+              (performance of the sub-debate that advertised &ne; actual)
+            </span>
+          </td>
+          <td className={`${TDC} font-mono`}>{formatScore(values?.supportingDivergenceScore) ?? <span>&nbsp;</span>}</td>
+          <td className={`${TDC} font-mono`}>{formatScore(values?.opposingDivergenceScore) ?? <span>&nbsp;</span>}</td>
+        </tr>
       </tbody>
     </table>
   )
@@ -212,52 +264,71 @@ function AdvertisedVsActual({ values }: { values: ValuesAnalysisData | null }) {
 /* ── Dispute Types ──────────────────────────────────────────────────────── */
 function DisputeTypesTable({ rows }: { rows: DisputeTypeItem[] }) {
   const order = ['Empirical', 'Definitional', 'Values']
-  const byType = (t: string) => rows.find(r => r.disputeType === t)
+  // The three canonical types always render; populated types sort by score.
+  const typed = order.map(t => ({ type: t, row: rows.find(r => r.disputeType === t) ?? null }))
+  typed.sort(byScoreDesc(t => t.row?.score))
   return (
     <table className="w-full border-collapse border border-gray-300 text-sm">
       <thead>
         <tr className="bg-gray-100">
-          <th className={`${TH} w-[20%]`}>Dispute Type</th>
-          <th className={`${TH} w-[40%]`}>The Specific Disagreement</th>
-          <th className={`${TH} w-[40%]`}>Evidence That Would Move Both Sides</th>
+          <th className={`${TH} w-[18%]`}>Dispute Type</th>
+          <th className={`${TH} w-[37%]`}>The Specific Disagreement</th>
+          <th className={`${TH} w-[37%]`}>Evidence That Would Move Both Sides</th>
+          <th className={`${TH} text-center w-[8%]`}>Score</th>
         </tr>
       </thead>
       <tbody>
-        {order.map((t, i) => {
-          const row = byType(t)
-          return (
-            <tr key={t} className={i % 2 === 1 ? 'bg-gray-50' : ''}>
-              <td className={TD}><strong>{t}</strong></td>
-              <td className={TD}>{lines(row?.disagreement)}</td>
-              <td className={TD}>{lines(row?.evidenceThatMoves)}</td>
-            </tr>
-          )
-        })}
+        {typed.map(({ type, row }, i) => (
+          <tr key={type} className={i % 2 === 1 ? 'bg-gray-50' : ''}>
+            <td className={TD}><strong>{type}</strong></td>
+            <td className={TD}>{lines(row?.disagreement)}</td>
+            <td className={TD}>{lines(row?.evidenceThatMoves)}</td>
+            <td className={`${TDC} font-mono`}>{formatScore(row?.score) ?? <span>&nbsp;</span>}</td>
+          </tr>
+        ))}
       </tbody>
     </table>
   )
 }
 
 /* ── Primary Obstacles to Resolution ────────────────────────────────────── */
+function ObstaclePairRow({ sup, opp }: { sup: ObstacleItem | null; opp: ObstacleItem | null }) {
+  return (
+    <tr>
+      <td className={TD}>{sup?.description ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(sup?.score) ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{opp?.description ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(opp?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
 function ObstaclesTable({ obstacles }: { obstacles: ObstacleItem[] }) {
-  const sup = obstacles.filter(o => o.side === 'supporter')
-  const opp = obstacles.filter(o => o.side === 'opposition')
+  const sup = [...obstacles.filter(o => o.side === 'supporter')].sort(byScoreDesc(o => o.score))
+  const opp = [...obstacles.filter(o => o.side === 'opposition')].sort(byScoreDesc(o => o.score))
   const n = Math.max(sup.length, opp.length, 1)
+  const rows = Array.from({ length: n }, (_, i) => i)
+  const top = rows.slice(0, TABLE_TOP_LIMIT)
+  const rest = rows.slice(TABLE_TOP_LIMIT)
   return (
     <table className="w-full border-collapse border border-gray-300 text-sm">
       <thead>
         <tr className="bg-gray-100">
-          <th className={`${TH} w-[50%]`}>Obstacles for Supporters</th>
-          <th className={`${TH} w-[50%]`}>Obstacles for Opponents</th>
+          <th className={`${TH} w-[42%]`}>Obstacles for Supporters</th>
+          <th className={`${TH} text-center w-[8%]`}>Score</th>
+          <th className={`${TH} w-[42%]`}>Obstacles for Opponents</th>
+          <th className={`${TH} text-center w-[8%]`}>Score</th>
         </tr>
       </thead>
       <tbody>
-        {Array.from({ length: n }, (_, i) => (
-          <tr key={i}>
-            <td className={TD}>{sup[i]?.description ?? <span>&nbsp;</span>}</td>
-            <td className={TD}>{opp[i]?.description ?? <span>&nbsp;</span>}</td>
-          </tr>
+        {top.map(i => (
+          <ObstaclePairRow key={i} sup={sup[i] ?? null} opp={opp[i] ?? null} />
         ))}
+        <ExpandableRows moreCount={rest.length} colSpan={4}>
+          {rest.map(i => (
+            <ObstaclePairRow key={i} sup={sup[i] ?? null} opp={opp[i] ?? null} />
+          ))}
+        </ExpandableRows>
       </tbody>
     </table>
   )

--- a/src/features/belief-analysis/components/CostBenefitSection.tsx
+++ b/src/features/belief-analysis/components/CostBenefitSection.tsx
@@ -1,16 +1,23 @@
 import Link from 'next/link'
-import type { CostBenefitData, ImpactData, CompromiseItem } from '../types'
+import type { CostBenefitData, CostBenefitItemRow, ImpactData, ImpactEntryItem, CompromiseItem } from '../types'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface CostBenefitSectionProps {
   cba: CostBenefitData | null
+  /** Row-based benefit/cost claims, ranked by Expected Value. */
+  items?: CostBenefitItemRow[]
   /** Short vs. long-term impacts render as a sub-table inside the CBA section. */
   impact?: ImpactData | null
+  /** Row-based short/long-term impacts, ranked by score. */
+  impactEntries?: ImpactEntryItem[]
   /** Best Compromise Solutions render as a sub-table inside the CBA section. */
   compromises: CompromiseItem[]
 }
 
 const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
 const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
 
 function lines(text: string | null | undefined): React.ReactNode {
   if (!text) return <span>&nbsp;</span>
@@ -24,30 +31,177 @@ function joined(a: string | null | undefined, b: string | null | undefined): Rea
   return lines(parts.join('\n'))
 }
 
-export default function CostBenefitSection({ cba, impact, compromises }: CostBenefitSectionProps) {
-  const compromiseRows: Array<CompromiseItem | null> = compromises.length > 0 ? compromises : [null]
+function pct(likelihood: number | null | undefined): string | null {
+  if (likelihood == null) return null
+  return `${Math.round(likelihood * 100)}%`
+}
+
+function ItemRow({ item }: { item: CostBenefitItemRow | null }) {
+  return (
+    <tr>
+      <td className={TD}>
+        {item ? (
+          item.claimBelief ? (
+            <Link href={`/beliefs/${item.claimBelief.slug}`} className="text-[var(--accent)] hover:underline">
+              {item.claim}
+            </Link>
+          ) : (
+            item.claim
+          )
+        ) : (
+          <span>&nbsp;</span>
+        )}
+      </td>
+      <td className={TDC}>{item?.category ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(item?.magnitude) ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{pct(item?.likelihood) ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(item?.expectedValue) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
+/**
+ * One side of the CBA (Benefits or Costs and Risks): rows ranked by Expected
+ * Value, then one subtotal row per category — unlike categories (dollars,
+ * life-years, hours, freedom) never sum together.
+ */
+function ItemsTable({
+  items,
+  header,
+  headerClass,
+  claimHeader,
+}: {
+  items: CostBenefitItemRow[]
+  header: string
+  headerClass: string
+  claimHeader: string
+}) {
+  const { top, rest } = rankByScore(items, i => i.expectedValue)
+  const categories = [...new Set(items.map(i => i.category).filter(Boolean))] as string[]
+  const subtotal = (cat: string) =>
+    items
+      .filter(i => i.category === cat && i.expectedValue != null)
+      .reduce((sum, i) => sum + (i.expectedValue as number), 0)
+
+  return (
+    <table className="w-full border-collapse border border-gray-300 text-sm">
+      <thead>
+        <tr>
+          <th className={`border border-gray-300 text-center font-semibold px-3 py-2 ${headerClass}`} colSpan={5}>
+            {header}
+          </th>
+        </tr>
+        <tr className="bg-gray-100 text-xs">
+          <th className={`${TH} w-[34%]`}>{claimHeader}</th>
+          <th className={`${TH} text-center w-[16%]`}>Category (Units)</th>
+          <th className={`${TH} text-center w-[16%]`}>Magnitude</th>
+          <th className={`${TH} text-center w-[14%]`}>Likelihood %</th>
+          <th className={`${TH} text-center w-[20%]`}>Expected Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {(top.length > 0 ? top : [null]).map((item, i) => (
+          <ItemRow key={item?.id ?? i} item={item} />
+        ))}
+        <ExpandableRows moreCount={rest.length} colSpan={5}>
+          {rest.map(item => (
+            <ItemRow key={item.id} item={item} />
+          ))}
+        </ExpandableRows>
+        {categories.length > 0 ? (
+          categories.map(cat => (
+            <tr key={cat} className="bg-gray-100 italic text-[#666]">
+              <td className={`${TD} text-right font-semibold`} colSpan={4}>
+                Subtotal ({cat} only):
+              </td>
+              <td className={`${TDC} font-mono`}>{formatScore(subtotal(cat))}</td>
+            </tr>
+          ))
+        ) : (
+          <tr className="bg-gray-100 italic text-[#666]">
+            <td className={`${TD} text-right font-semibold`} colSpan={4}>
+              Subtotal (within each category only):
+            </td>
+            <td className={TDC}>&nbsp;</td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  )
+}
+
+function ImpactPairRow({ s, l }: { s: ImpactEntryItem | null; l: ImpactEntryItem | null }) {
+  return (
+    <tr>
+      <td className={TD}>{s?.description ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(s?.score) ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{l?.description ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(l?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
+export default function CostBenefitSection({
+  cba,
+  items = [],
+  impact,
+  impactEntries = [],
+  compromises,
+}: CostBenefitSectionProps) {
+  const benefits = items.filter(i => i.side === 'benefit')
+  const costs = items.filter(i => i.side === 'cost')
+
+  const shortTerm = rankByScore(impactEntries.filter(e => e.term === 'short'), e => e.score, Infinity).top
+  const longTerm = rankByScore(impactEntries.filter(e => e.term === 'long'), e => e.score, Infinity).top
+  const impactPairs = pairBySide(shortTerm, longTerm)
+  const topImpactPairs = impactPairs.slice(0, TABLE_TOP_LIMIT)
+  const restImpactPairs = impactPairs.slice(TABLE_TOP_LIMIT)
+
+  const rankedCompromises = rankByScore(compromises, c => c.score)
 
   return (
     <section className="space-y-6">
       <div>
-        <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-3">
+        <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
           <span>&#9878;</span>
           <Link href="/cost-benefit%20analysis" className="text-[var(--accent)] hover:underline">Cost-Benefit Analysis</Link>
         </h2>
-        <table className="w-full border-collapse border border-gray-300 text-sm">
-          <thead>
-            <tr className="bg-gray-100">
-              <th className={`${TH} w-1/2`}>Benefits</th>
-              <th className={`${TH} w-1/2`}>Costs and Risks</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td className={TD}>{lines(cba?.benefits)}</td>
-              <td className={TD}>{lines(cba?.costs)}</td>
-            </tr>
-          </tbody>
-        </table>
+        <p className="text-sm text-[var(--muted-foreground)] mb-3">
+          Every cost and benefit is itself a debatable claim with its own argument tree. Magnitude is
+          an estimate in explicit units. Likelihood is computed from how that claim&apos;s pro and con
+          arguments score, never assigned by gut. Expected Value = Magnitude &times; Likelihood.
+        </p>
+        {items.length > 0 ? (
+          <div className="space-y-4">
+            <ItemsTable
+              items={benefits}
+              header="✅ Benefits"
+              headerClass="bg-green-100"
+              claimHeader="Benefit Claim (links to its own page)"
+            />
+            <ItemsTable
+              items={costs}
+              header="❌ Costs and Risks"
+              headerClass="bg-red-100"
+              claimHeader="Cost Claim (links to its own page)"
+            />
+          </div>
+        ) : (
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className={`${TH} w-1/2`}>Benefits</th>
+                <th className={`${TH} w-1/2`}>Costs and Risks</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className={TD}>{lines(cba?.benefits)}</td>
+                <td className={TD}>{lines(cba?.costs)}</td>
+              </tr>
+            </tbody>
+          </table>
+        )}
       </div>
 
       <div>
@@ -57,15 +211,32 @@ export default function CostBenefitSection({ cba, impact, compromises }: CostBen
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className={`${TH} w-1/2`}>Short-Term (0-2 Years)</th>
-              <th className={`${TH} w-1/2`}>Long-Term (5+ Years)</th>
+              <th className={`${TH} w-[42%]`}>Short-Term (0-2 Years)</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
+              <th className={`${TH} w-[42%]`}>Long-Term (5+ Years)</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td className={TD}>{joined(impact?.shortTermEffects, impact?.shortTermCosts)}</td>
-              <td className={TD}>{joined(impact?.longTermEffects, impact?.longTermChanges)}</td>
-            </tr>
+            {impactPairs.length > 0 ? (
+              <>
+                {topImpactPairs.map(([s, l], i) => (
+                  <ImpactPairRow key={s?.id ?? l?.id ?? i} s={s} l={l} />
+                ))}
+                <ExpandableRows moreCount={restImpactPairs.length} colSpan={4}>
+                  {restImpactPairs.map(([s, l], i) => (
+                    <ImpactPairRow key={s?.id ?? l?.id ?? i} s={s} l={l} />
+                  ))}
+                </ExpandableRows>
+              </>
+            ) : (
+              <tr>
+                <td className={TD}>{joined(impact?.shortTermEffects, impact?.shortTermCosts)}</td>
+                <td className={TDC}>&nbsp;</td>
+                <td className={TD}>{joined(impact?.longTermEffects, impact?.longTermChanges)}</td>
+                <td className={TDC}>&nbsp;</td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
@@ -78,19 +249,31 @@ export default function CostBenefitSection({ cba, impact, compromises }: CostBen
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className={`${TH} w-[33%]`}>Shared Premise Both Sides Accept</th>
-              <th className={`${TH} w-[34%]`}>Proposed Synthesis</th>
-              <th className={`${TH} w-[33%]`}>Why This Is Difficult</th>
+              <th className={`${TH} w-[28%]`}>Shared Premise Both Sides Accept</th>
+              <th className={`${TH} w-[30%]`}>Proposed Synthesis</th>
+              <th className={`${TH} w-[28%]`}>Why This Is Difficult</th>
+              <th className={`${TH} text-center w-[14%]`}>Score (interests satisfied)</th>
             </tr>
           </thead>
           <tbody>
-            {compromiseRows.map((c, i) => (
+            {(rankedCompromises.top.length > 0 ? rankedCompromises.top : [null]).map((c, i) => (
               <tr key={c?.id ?? i}>
                 <td className={TD}>{lines(c?.sharedPremise)}</td>
                 <td className={TD}>{lines(c?.synthesis ?? c?.description)}</td>
                 <td className={TD}>{lines(c?.whyDifficult)}</td>
+                <td className={`${TDC} font-mono`}>{formatScore(c?.score) ?? <span>&nbsp;</span>}</td>
               </tr>
             ))}
+            <ExpandableRows moreCount={rankedCompromises.rest.length} colSpan={4}>
+              {rankedCompromises.rest.map(c => (
+                <tr key={c.id}>
+                  <td className={TD}>{lines(c.sharedPremise)}</td>
+                  <td className={TD}>{lines(c.synthesis ?? c.description)}</td>
+                  <td className={TD}>{lines(c.whyDifficult)}</td>
+                  <td className={`${TDC} font-mono`}>{formatScore(c.score) ?? <span>&nbsp;</span>}</td>
+                </tr>
+              ))}
+            </ExpandableRows>
           </tbody>
         </table>
       </div>

--- a/src/features/belief-analysis/components/DefinitionsSection.tsx
+++ b/src/features/belief-analysis/components/DefinitionsSection.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import type { DefinitionItem } from '../types'
+import { formatScore, rankByScore } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface DefinitionsSectionProps {
   definitions: DefinitionItem[]
@@ -60,21 +62,36 @@ export default function DefinitionsSection({ definitions }: DefinitionsSectionPr
       <table className="w-full border-collapse text-sm" style={{ borderColor: '#cccccc' }}>
         <thead>
           <tr>
-            <th className="border border-gray-300 px-3 py-2 text-center bg-gray-50 w-[30%]">Term</th>
-            <th className="border border-gray-300 px-3 py-2 text-center bg-gray-50 w-[70%]">Definition Used in This Analysis</th>
+            <th className="border border-gray-300 px-3 py-2 text-center bg-gray-50 w-[26%]">Term</th>
+            <th className="border border-gray-300 px-3 py-2 text-center bg-gray-50 w-[66%]">Definition Used in This Analysis</th>
+            <th className="border border-gray-300 px-3 py-2 text-center bg-gray-50 w-[8%]">Score</th>
           </tr>
         </thead>
         <tbody>
           {definitions.length > 0 ? (
-            definitions.map(def => (
-              <tr key={def.id}>
-                <td className="border border-gray-300 px-3 py-2 font-medium">{def.term}</td>
-                <td className="border border-gray-300 px-3 py-2">{def.definition}</td>
-              </tr>
-            ))
+            (() => {
+              const { top, rest } = rankByScore(definitions, d => d.score)
+              const row = (def: DefinitionItem) => (
+                <tr key={def.id}>
+                  <td className="border border-gray-300 px-3 py-2 font-medium">{def.term}</td>
+                  <td className="border border-gray-300 px-3 py-2">{def.definition}</td>
+                  <td className="border border-gray-300 px-3 py-2 text-center font-mono">
+                    {formatScore(def.score) ?? <span>&nbsp;</span>}
+                  </td>
+                </tr>
+              )
+              return (
+                <>
+                  {top.map(row)}
+                  <ExpandableRows moreCount={rest.length} colSpan={3}>
+                    {rest.map(row)}
+                  </ExpandableRows>
+                </>
+              )
+            })()
           ) : (
             <tr>
-              <td className="border border-gray-300 px-3 py-2 text-[var(--muted-foreground)] italic" colSpan={2}>
+              <td className="border border-gray-300 px-3 py-2 text-[var(--muted-foreground)] italic" colSpan={3}>
                 No page-specific definitions yet. Contribute to clarify the terms this page uses.
               </td>
             </tr>

--- a/src/features/belief-analysis/components/EvidenceSection.tsx
+++ b/src/features/belief-analysis/components/EvidenceSection.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import type { EvidenceItem } from '../types'
+import { TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface EvidenceSectionProps {
   evidence: EvidenceItem[]
@@ -54,6 +56,8 @@ export default function EvidenceSection({ evidence }: EvidenceSectionProps) {
   const weakening = evidence.filter(e => e.side === 'weakening')
   const rowCount = Math.max(supporting.length, weakening.length, 1)
   const rows = Array.from({ length: rowCount }, (_, i) => i)
+  const topRows = rows.slice(0, TABLE_TOP_LIMIT)
+  const restRows = rows.slice(TABLE_TOP_LIMIT)
 
   return (
     <section>
@@ -93,12 +97,20 @@ export default function EvidenceSection({ evidence }: EvidenceSectionProps) {
             </tr>
           </thead>
           <tbody>
-            {rows.map(i => (
+            {topRows.map(i => (
               <tr key={i}>
                 <EvidenceHalf item={supporting[i]} />
                 <EvidenceHalf item={weakening[i]} />
               </tr>
             ))}
+            <ExpandableRows moreCount={restRows.length} colSpan={8}>
+              {restRows.map(i => (
+                <tr key={i}>
+                  <EvidenceHalf item={supporting[i]} />
+                  <EvidenceHalf item={weakening[i]} />
+                </tr>
+              ))}
+            </ExpandableRows>
           </tbody>
         </table>
       </div>

--- a/src/features/belief-analysis/components/ExpandableRows.tsx
+++ b/src/features/belief-analysis/components/ExpandableRows.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useState } from 'react'
+
+interface ExpandableRowsProps {
+  /** How many rows are hidden behind the toggle. Renders nothing when 0. */
+  moreCount: number
+  /** Column count of the host table, so the toggle row spans it. */
+  colSpan: number
+  /** The below-the-fold rows (already score-ordered), shown when expanded. */
+  children: React.ReactNode
+}
+
+/**
+ * Collapses a table's lower-scoring rows behind a "Show N more" toggle so
+ * each table leads with its top-scoring content. Rendered inside <tbody>.
+ */
+export default function ExpandableRows({ moreCount, colSpan, children }: ExpandableRowsProps) {
+  const [open, setOpen] = useState(false)
+  if (moreCount <= 0) return null
+  return (
+    <>
+      {open && children}
+      <tr>
+        <td colSpan={colSpan} className="border border-gray-300 px-3 py-1.5 text-center bg-gray-50">
+          <button
+            type="button"
+            onClick={() => setOpen(o => !o)}
+            className="text-xs text-[var(--accent)] hover:underline"
+          >
+            {open ? 'Show top rows only' : `Show ${moreCount} more lower-scoring ${moreCount === 1 ? 'row' : 'rows'}`}
+          </button>
+        </td>
+      </tr>
+    </>
+  )
+}

--- a/src/features/belief-analysis/components/FalsifiabilityTestSection.tsx
+++ b/src/features/belief-analysis/components/FalsifiabilityTestSection.tsx
@@ -1,6 +1,11 @@
-import type { TestablePredictionItem } from '../types'
+import type { FalsifiabilityItemRow, TestablePredictionItem } from '../types'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface FalsifiabilityTestSectionProps {
+  /** Scored score-mover rows (side "strengthen" / "weaken"), ranked by score. */
+  items?: FalsifiabilityItemRow[]
+  /** Legacy free-text fallbacks when no scored rows exist yet. */
   confirm: string | null
   falsify: string | null
   /** Legacy single-field fallback when confirm/falsify are absent. */
@@ -10,60 +15,135 @@ interface FalsifiabilityTestSectionProps {
 
 const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
 const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
 
 function lines(text: string | null): React.ReactNode {
   if (!text) return <span>&nbsp;</span>
   return text.split('\n').map((l, i) => <span key={i}>{l}<br /></span>)
 }
 
+function MoverPairRow({ s, w }: { s: FalsifiabilityItemRow | null; w: FalsifiabilityItemRow | null }) {
+  return (
+    <tr>
+      <td className={TD}>{s?.description ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(s?.score) ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{w?.description ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(w?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
 export default function FalsifiabilityTestSection({
+  items = [],
   confirm,
   falsify,
   legacy,
   predictions,
 }: FalsifiabilityTestSectionProps) {
+  const strengthen = rankByScore(items.filter(i => i.side === 'strengthen'), i => i.score, Infinity).top
+  const weaken = rankByScore(items.filter(i => i.side === 'weaken'), i => i.score, Infinity).top
+  const pairs = pairBySide(strengthen, weaken)
+  const topPairs = pairs.slice(0, TABLE_TOP_LIMIT)
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
+
+  const rankedPredictions = rankByScore(predictions, p => p.score, Infinity).top
+  const topPredictions = rankedPredictions.slice(0, TABLE_TOP_LIMIT)
+  const restPredictions = rankedPredictions.slice(TABLE_TOP_LIMIT)
+
   return (
     <section className="space-y-6">
       <div>
-        <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-3">
-          <span>&#128269;</span> Falsifiability Test
+        <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
+          <span>&#129514;</span> Falsifiability Test
         </h2>
+        <p className="text-sm text-[var(--muted-foreground)] mb-3">
+          Evidence rarely proves or disproves anything outright; it strengthens or weakens. Each
+          row&apos;s Score is the performance of its own pro/con sub-debate: if this evidence
+          appeared, would it actually move this belief?
+        </p>
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className={`${TH} w-1/2`}>Evidence That Would Confirm</th>
-              <th className={`${TH} w-1/2`}>Evidence That Would Falsify</th>
+              <th className={`${TH} w-[42%]`}>Evidence That Would Strengthen</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
+              <th className={`${TH} w-[42%]`}>Evidence That Would Weaken</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td className={TD}>{lines(confirm)}</td>
-              <td className={TD}>{lines(falsify ?? legacy)}</td>
+            {pairs.length > 0 ? (
+              <>
+                {topPairs.map(([s, w], i) => (
+                  <MoverPairRow key={s?.id ?? w?.id ?? i} s={s} w={w} />
+                ))}
+                <ExpandableRows moreCount={restPairs.length} colSpan={4}>
+                  {restPairs.map(([s, w], i) => (
+                    <MoverPairRow key={s?.id ?? w?.id ?? i} s={s} w={w} />
+                  ))}
+                </ExpandableRows>
+              </>
+            ) : (
+              <tr>
+                <td className={TD}>{lines(confirm)}</td>
+                <td className={TDC}>&nbsp;</td>
+                <td className={TD}>{lines(falsify ?? legacy)}</td>
+                <td className={TDC}>&nbsp;</td>
+              </tr>
+            )}
+            <tr className="bg-gray-50">
+              <td className={`${TD} text-xs text-[#555]`} colSpan={4}>
+                <em>
+                  If no realistic evidence could falsify this belief, say so here and note what that
+                  implies about the strength of the claim.
+                </em>
+              </td>
             </tr>
           </tbody>
         </table>
       </div>
 
       <div>
-        <h3 className="text-base font-semibold mb-2 flex items-center gap-2">
+        <h3 className="text-base font-semibold mb-1 flex items-center gap-2">
           <span>&#128302;</span> Testable Predictions
         </h3>
+        <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
+          If this belief is true, what should the world show us that it would not show us otherwise?
+          Each prediction that comes true or fails feeds back into the belief score above.
+        </p>
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className={`${TH} w-[45%]`}>Prediction</th>
-              <th className={`${TH} w-[20%]`}>Timeframe</th>
-              <th className={`${TH} w-[35%]`}>Verification Method</th>
+              <th className={`${TH} w-[30%]`}>Prediction</th>
+              <th className={`${TH} text-center w-[10%]`}>Follows If&hellip;</th>
+              <th className={`${TH} w-[12%]`}>Timeframe</th>
+              <th className={`${TH} w-[26%]`}>Verification Method</th>
+              <th className={`${TH} text-center w-[14%]`}>Result So Far</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
             </tr>
           </thead>
           <tbody>
-            {(predictions.length > 0 ? predictions : [null]).map((p, i) => (
+            {(topPredictions.length > 0 ? topPredictions : [null]).map((p, i) => (
               <tr key={p?.id ?? i}>
                 <td className={TD}>{p?.prediction ?? <span>&nbsp;</span>}</td>
+                <td className={`${TDC} capitalize`}>{p ? (p.followsIf ?? 'true') : <span>&nbsp;</span>}</td>
                 <td className={TD}>{p?.timeframe ?? <span>&nbsp;</span>}</td>
                 <td className={TD}>{p?.verificationMethod ?? <span>&nbsp;</span>}</td>
+                <td className={TDC}>{p?.resultSoFar ?? <span>&nbsp;</span>}</td>
+                <td className={`${TDC} font-mono`}>{formatScore(p?.score) ?? <span>&nbsp;</span>}</td>
               </tr>
             ))}
+            <ExpandableRows moreCount={restPredictions.length} colSpan={6}>
+              {restPredictions.map(p => (
+                <tr key={p.id}>
+                  <td className={TD}>{p.prediction}</td>
+                  <td className={`${TDC} capitalize`}>{p.followsIf ?? 'true'}</td>
+                  <td className={TD}>{p.timeframe ?? <span>&nbsp;</span>}</td>
+                  <td className={TD}>{p.verificationMethod ?? <span>&nbsp;</span>}</td>
+                  <td className={TDC}>{p.resultSoFar ?? <span>&nbsp;</span>}</td>
+                  <td className={`${TDC} font-mono`}>{formatScore(p.score) ?? <span>&nbsp;</span>}</td>
+                </tr>
+              ))}
+            </ExpandableRows>
           </tbody>
         </table>
       </div>

--- a/src/features/belief-analysis/components/LegalSection.tsx
+++ b/src/features/belief-analysis/components/LegalSection.tsx
@@ -1,13 +1,45 @@
 import type { LegalItem } from '../types'
 import SectionHeading from './SectionHeading'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface LegalSectionProps {
   legal: LegalItem[]
 }
 
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+function LegalCell({ l }: { l: LegalItem | null }) {
+  if (!l) return <span>&nbsp;</span>
+  return (
+    <>
+      {l.description}
+      {l.jurisdiction && (
+        <span className="ml-1 text-xs text-[var(--muted-foreground)]">({l.jurisdiction})</span>
+      )}
+    </>
+  )
+}
+
+function LegalPairRow({ s, c }: { s: LegalItem | null; c: LegalItem | null }) {
+  return (
+    <tr>
+      <td className={TD}><LegalCell l={s} /></td>
+      <td className={`${TDC} font-mono`}>{formatScore(s?.score) ?? <span>&nbsp;</span>}</td>
+      <td className={TD}><LegalCell l={c} /></td>
+      <td className={`${TDC} font-mono`}>{formatScore(c?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
 export default function LegalSection({ legal }: LegalSectionProps) {
-  const supporting = legal.filter(l => l.side === 'supporting')
-  const contradicting = legal.filter(l => l.side === 'contradicting')
+  const supporting = rankByScore(legal.filter(l => l.side === 'supporting'), l => l.score, Infinity).top
+  const contradicting = rankByScore(legal.filter(l => l.side === 'contradicting'), l => l.score, Infinity).top
+  const pairs = pairBySide(supporting, contradicting)
+  const topPairs = pairs.slice(0, TABLE_TOP_LIMIT)
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
 
   return (
     <section>
@@ -21,51 +53,38 @@ export default function LegalSection({ legal }: LegalSectionProps) {
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Supporting Laws</th>
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">Contradicting Laws</th>
+              <th className={`${TH} w-[42%]`}>Laws and Frameworks Supporting</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
+              <th className={`${TH} w-[42%]`}>Laws and Constraints Complicating</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td className="px-3 py-3 align-top text-sm">
-                {supporting.length > 0 ? (
-                  <ol className="list-decimal list-inside space-y-1">
-                    {supporting.map(l => (
-                      <li key={l.id}>
-                        {l.description}
-                        {l.jurisdiction && (
-                          <span className="ml-1 text-xs text-[var(--muted-foreground)]">({l.jurisdiction})</span>
-                        )}
-                      </li>
-                    ))}
-                  </ol>
-                ) : (
-                  <div className="text-[var(--muted-foreground)]">
-                    <p>1. Local, state, federal laws that support this</p>
-                    <p>2. International treaties</p>
-                  </div>
-                )}
-              </td>
-              <td className="px-3 py-3 align-top text-sm">
-                {contradicting.length > 0 ? (
-                  <ol className="list-decimal list-inside space-y-1">
-                    {contradicting.map(l => (
-                      <li key={l.id}>
-                        {l.description}
-                        {l.jurisdiction && (
-                          <span className="ml-1 text-xs text-[var(--muted-foreground)]">({l.jurisdiction})</span>
-                        )}
-                      </li>
-                    ))}
-                  </ol>
-                ) : (
-                  <div className="text-[var(--muted-foreground)]">
-                    <p>1. Local, state, federal laws that contradict this</p>
-                    <p>2. International treaties</p>
-                  </div>
-                )}
-              </td>
-            </tr>
+            {pairs.length > 0 ? (
+              <>
+                {topPairs.map(([s, c], i) => (
+                  <LegalPairRow key={s?.id ?? c?.id ?? i} s={s} c={c} />
+                ))}
+                <ExpandableRows moreCount={restPairs.length} colSpan={4}>
+                  {restPairs.map(([s, c], i) => (
+                    <LegalPairRow key={s?.id ?? c?.id ?? i} s={s} c={c} />
+                  ))}
+                </ExpandableRows>
+              </>
+            ) : (
+              <tr>
+                <td className={`${TD} text-[var(--muted-foreground)]`}>
+                  <p>1. Local, state, federal laws that support this</p>
+                  <p>2. International treaties</p>
+                </td>
+                <td className={TDC}>&nbsp;</td>
+                <td className={`${TD} text-[var(--muted-foreground)]`}>
+                  <p>1. Local, state, federal laws that contradict this</p>
+                  <p>2. International treaties</p>
+                </td>
+                <td className={TDC}>&nbsp;</td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/src/features/belief-analysis/components/MediaResourcesSection.tsx
+++ b/src/features/belief-analysis/components/MediaResourcesSection.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import type { MediaItem } from '../types'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface MediaResourcesSectionProps {
   media: MediaItem[]
@@ -7,46 +9,59 @@ interface MediaResourcesSectionProps {
 
 const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
 const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
 
-function MediaList({ items }: { items: MediaItem[] }) {
-  const books = items.filter(m => m.mediaType === 'book')
-  const other = items.filter(m => m.mediaType !== 'book')
+function typeLabel(mediaType: string): string {
+  return mediaType.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+}
+
+function MediaCell({ m }: { m: MediaItem | null }) {
+  if (!m) return <span>&nbsp;</span>
   return (
     <>
-      <strong><Link href="/Books" className="text-[var(--accent)] hover:underline">Books</Link></strong>
-      <br />
-      {books.length > 0 ? (
-        books.map(m => (
-          <span key={m.id} className="block">
-            {m.url ? (
-              <a href={m.url} target="_blank" rel="noopener noreferrer" className="text-[var(--accent)] hover:underline">{m.title}</a>
-            ) : m.title}
-            {m.author && <span className="text-[var(--muted-foreground)]"> — {m.author}</span>}
-          </span>
-        ))
+      {m.url ? (
+        <a href={m.url} target="_blank" rel="noopener noreferrer" className="text-[var(--accent)] hover:underline">
+          {m.title}
+        </a>
       ) : (
-        <span>&nbsp;</span>
+        m.title
       )}
-      {other.length > 0 && (
-        <div className="mt-2">
-          {other.map(m => (
-            <span key={m.id} className="block">
-              <span className="capitalize text-[var(--muted-foreground)]">{m.mediaType.replace(/_/g, ' ')}: </span>
-              {m.url ? (
-                <a href={m.url} target="_blank" rel="noopener noreferrer" className="text-[var(--accent)] hover:underline">{m.title}</a>
-              ) : m.title}
-              {m.author && <span className="text-[var(--muted-foreground)]"> — {m.author}</span>}
-            </span>
-          ))}
-        </div>
+      {(m.author || m.year) && (
+        <span className="text-[var(--muted-foreground)]">
+          {' '}({[m.author, m.year].filter(Boolean).join(', ')})
+        </span>
       )}
     </>
   )
 }
 
+function MediaPairRow({ s, c }: { s: MediaItem | null; c: MediaItem | null }) {
+  return (
+    <tr>
+      <td className={TD}><MediaCell m={s} /></td>
+      <td className={TDC}>{s ? typeLabel(s.mediaType) : <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{s ? formatScore(s.impactScore) : <span>&nbsp;</span>}</td>
+      <td className={TD}><MediaCell m={c} /></td>
+      <td className={TDC}>{c ? typeLabel(c.mediaType) : <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{c ? formatScore(c.impactScore) : <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
 export default function MediaResourcesSection({ media }: MediaResourcesSectionProps) {
-  const supporting = media.filter(m => m.side === 'supporting' || m.side === 'agree')
-  const challenging = media.filter(m => m.side === 'opposing' || m.side === 'weakening' || m.side === 'disagree')
+  const supporting = rankByScore(
+    media.filter(m => m.side === 'supporting' || m.side === 'agree'),
+    m => m.impactScore,
+    Infinity,
+  ).top
+  const challenging = rankByScore(
+    media.filter(m => m.side === 'opposing' || m.side === 'weakening' || m.side === 'disagree'),
+    m => m.impactScore,
+    Infinity,
+  ).top
+  const pairs = pairBySide(supporting, challenging)
+  const topPairs = pairs.length > 0 ? pairs.slice(0, TABLE_TOP_LIMIT) : [[null, null] as [MediaItem | null, MediaItem | null]]
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
 
   return (
     <section>
@@ -56,16 +71,32 @@ export default function MediaResourcesSection({ media }: MediaResourcesSectionPr
       </h2>
       <table className="w-full border-collapse border border-gray-300 text-sm">
         <thead>
-          <tr className="bg-gray-100">
-            <th className={`${TH} w-1/2`}>Supporting the Belief</th>
-            <th className={`${TH} w-1/2`}>Challenging or Complicating the Belief</th>
+          <tr>
+            <th className="border border-gray-300 bg-green-100 text-center font-semibold px-3 py-2" colSpan={3}>
+              Supporting the Belief
+            </th>
+            <th className="border border-gray-300 bg-red-100 text-center font-semibold px-3 py-2" colSpan={3}>
+              Challenging or Complicating the Belief
+            </th>
+          </tr>
+          <tr className="bg-gray-100 text-xs">
+            <th className={`${TH} w-[30%]`}>Resource (Author, Year)</th>
+            <th className={`${TH} text-center w-[12%]`}>Type</th>
+            <th className={`${TH} text-center w-[8%]`}>Score</th>
+            <th className={`${TH} w-[30%]`}>Resource (Author, Year)</th>
+            <th className={`${TH} text-center w-[12%]`}>Type</th>
+            <th className={`${TH} text-center w-[8%]`}>Score</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td className={TD}><MediaList items={supporting} /></td>
-            <td className={TD}><MediaList items={challenging} /></td>
-          </tr>
+          {topPairs.map(([s, c], i) => (
+            <MediaPairRow key={s?.id ?? c?.id ?? i} s={s} c={c} />
+          ))}
+          <ExpandableRows moreCount={restPairs.length} colSpan={6}>
+            {restPairs.map(([s, c], i) => (
+              <MediaPairRow key={s?.id ?? c?.id ?? i} s={s} c={c} />
+            ))}
+          </ExpandableRows>
         </tbody>
       </table>
     </section>

--- a/src/features/belief-analysis/components/ObjectiveCriteriaSection.tsx
+++ b/src/features/belief-analysis/components/ObjectiveCriteriaSection.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import type { ObjectiveCriteriaItem } from '../types'
+import { formatScore, rankByScore } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface ObjectiveCriteriaSectionProps {
   criteria: ObjectiveCriteriaItem[]
@@ -9,34 +11,62 @@ const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
 const TD = 'border border-gray-300 px-3 py-2 align-top'
 const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
 
+/** totalScore 0 is the unscored default — render blank per Rule 6. */
+function criterionScore(c: ObjectiveCriteriaItem | null): number | null {
+  if (!c || !c.totalScore) return null
+  return c.totalScore
+}
+
+function CriterionRow({ c }: { c: ObjectiveCriteriaItem | null }) {
+  return (
+    <tr>
+      <td className={TD}>{c?.description ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{c?.howToMeasure ?? c?.thresholdForAgreement ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{c?.strengthenReading ?? c?.target ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{c?.weakenReading ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{c?.currentStatus ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(criterionScore(c)) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+}
+
 export default function ObjectiveCriteriaSection({ criteria }: ObjectiveCriteriaSectionProps) {
-  const rows: Array<ObjectiveCriteriaItem | null> = criteria.length > 0 ? criteria : [null]
+  const { top, rest } = rankByScore(criteria, criterionScore)
+  const rows: Array<ObjectiveCriteriaItem | null> = top.length > 0 ? top : [null]
 
   return (
     <section>
-      <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-3">
+      <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
         <span>&#127919;</span>
         <Link href="/Objective%20criteria%20scores" className="text-[var(--accent)] hover:underline">Objective Criteria</Link>
       </h2>
+      <p className="text-sm text-[var(--muted-foreground)] mb-3">
+        These are the measurements that would settle this debate if both sides committed to them in
+        advance. The best criteria are specific enough that supporters and opponents would predict{' '}
+        <em>different</em> readings — a criterion both sides expect to come out the same way tests
+        nothing.
+      </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
-              <th className={`${TH} w-[35%]`}>Criterion</th>
-              <th className={`${TH} w-[30%]`}>How to Measure</th>
-              <th className={`${TH} text-center w-[15%]`}>Current Status</th>
-              <th className={`${TH} text-center w-[20%]`}>Target</th>
+            <tr className="bg-gray-100 text-xs">
+              <th className={`${TH} w-[20%]`}>Criterion</th>
+              <th className={`${TH} w-[24%]`}>How to Measure</th>
+              <th className={`${TH} text-center w-[17%]`}>Reading That Would Strengthen</th>
+              <th className={`${TH} text-center w-[17%]`}>Reading That Would Weaken</th>
+              <th className={`${TH} text-center w-[14%]`}>Latest Reading</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
             </tr>
           </thead>
           <tbody>
             {rows.map((c, i) => (
-              <tr key={c?.id ?? i}>
-                <td className={TD}>{c?.description ?? <span>&nbsp;</span>}</td>
-                <td className={TD}>{c?.howToMeasure ?? c?.thresholdForAgreement ?? <span>&nbsp;</span>}</td>
-                <td className={TDC}>{c?.currentStatus ?? <span>&nbsp;</span>}</td>
-                <td className={TDC}>{c?.target ?? <span>&nbsp;</span>}</td>
-              </tr>
+              <CriterionRow key={c?.id ?? i} c={c} />
             ))}
+            <ExpandableRows moreCount={rest.length} colSpan={6}>
+              {rest.map(c => (
+                <CriterionRow key={c.id} c={c} />
+              ))}
+            </ExpandableRows>
           </tbody>
         </table>
       </div>

--- a/src/features/belief-analysis/components/ScorecardSection.tsx
+++ b/src/features/belief-analysis/components/ScorecardSection.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link'
+import type { ArgumentWithBelief, FalsifiabilityItemRow } from '../types'
+import { byScoreDesc } from '../lib/ranking'
+
+interface ScorecardSectionProps {
+  arguments: ArgumentWithBelief[]
+  totalPro: number
+  totalCon: number
+  /** One-sentence verdict scoped to what the argument tree actually supports. */
+  bottomLine: string | null
+  /** The single piece of evidence that would most change the verdict. */
+  scoreMover: string | null
+  /** Fallback for scoreMover: the top-ranked falsifiability score-movers. */
+  falsifiabilityItems: FalsifiabilityItemRow[]
+}
+
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const LABEL = `${TD} bg-[#f0f3f6] w-1/4 font-semibold`
+
+function ArgumentLink({ arg }: { arg: ArgumentWithBelief | null }) {
+  if (!arg) return <span className="text-[var(--muted-foreground)] italic">[pending]</span>
+  return (
+    <Link href={`/beliefs/${arg.belief.slug}`} className="text-[var(--accent)] hover:underline">
+      {arg.claim ?? arg.belief.statement}
+    </Link>
+  )
+}
+
+/**
+ * The Scorecard readout at the top of the page: the computed Net Belief Score
+ * and the single highest-scoring row from each side of the argument tree.
+ * Everything here is derived from scored content below — it is a readout of
+ * the tables, not a prose summary (Rule 2 still applies to prose).
+ */
+export default function ScorecardSection({
+  arguments: args,
+  totalPro,
+  totalCon,
+  bottomLine,
+  scoreMover,
+  falsifiabilityItems,
+}: ScorecardSectionProps) {
+  const impact = (a: ArgumentWithBelief) => (a.impactScore ? Math.abs(a.impactScore) : null)
+  const bestPro = args.filter(a => a.side === 'agree').sort(byScoreDesc(impact))[0] ?? null
+  const bestCon = args.filter(a => a.side === 'disagree').sort(byScoreDesc(impact))[0] ?? null
+
+  const hasArgs = totalPro > 0 || totalCon > 0
+  const net = totalPro - totalCon
+  const netLabel = hasArgs ? `${net >= 0 ? '+' : ''}${net.toFixed(1)}` : '[pending]'
+
+  const topMover = scoreMover ?? falsifiabilityItems[0]?.description ?? null
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-3">
+        <span>&#128203;</span> Scorecard
+      </h2>
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <tbody>
+          <tr>
+            <td className={LABEL}>Net Belief Score</td>
+            <td className={TD}>
+              <strong>{netLabel}</strong>
+              {hasArgs && (
+                <> · Pro +{totalPro.toFixed(1)} vs. Con -{totalCon.toFixed(1)}</>
+              )}{' '}
+              <span className="text-xs text-[#555]">
+                · scores are the{' '}
+                <Link href="/ReasonRank" className="text-[var(--accent)] hover:underline">ReasonRank</Link>{' '}
+                performance of each row&apos;s pro/con sub-debate
+              </span>
+            </td>
+          </tr>
+          <tr className="bg-gray-50">
+            <td className={LABEL}>Bottom line</td>
+            <td className={TD}>
+              {bottomLine ?? (
+                <span className="text-[var(--muted-foreground)] italic">
+                  One-sentence verdict, scoped to what the argument tree below actually supports.
+                </span>
+              )}
+            </td>
+          </tr>
+          <tr>
+            <td className={LABEL}>Strongest pro / con</td>
+            <td className={TD}>
+              <ArgumentLink arg={bestPro} /> · <ArgumentLink arg={bestCon} />
+            </td>
+          </tr>
+          <tr className="bg-gray-50">
+            <td className={LABEL}>What would move this score most</td>
+            <td className={TD}>
+              {topMover ?? (
+                <span className="text-[var(--muted-foreground)] italic">
+                  The single piece of evidence that would most change the verdict; see the Falsifiability Test below.
+                </span>
+              )}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p className="text-sm mt-3 p-2 bg-[#f0f3f6] border border-gray-300">
+        <strong>How to read this page:</strong> nothing here is placed by editorial choice. Every row
+        in every table is itself a claim, and its Score is the{' '}
+        <Link href="/ReasonRank" className="text-[var(--accent)] hover:underline">ReasonRank</Link>{' '}
+        performance of the pro/con sub-debate about that claim, computed recursively down to the
+        evidence. Every table sorts by Score, best content first; each table shows its top rows and
+        collapses the rest until expanded. Score cells stay blank until real content exists to score.
+      </p>
+    </section>
+  )
+}

--- a/src/features/belief-analysis/components/SimilarBeliefsSection.tsx
+++ b/src/features/belief-analysis/components/SimilarBeliefsSection.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import type { SimilarBeliefItem } from '../types'
 import SectionHeading from './SectionHeading'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../lib/ranking'
+import ExpandableRows from './ExpandableRows'
 
 interface SimilarBeliefsSectionProps {
   similarTo: SimilarBeliefItem[]
@@ -8,13 +10,47 @@ interface SimilarBeliefsSectionProps {
   currentBeliefId: number
 }
 
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+/** Equivalency 0.0 is the unscored default — render blank per Rule 6. */
+function equivalency(item: SimilarBeliefItem | null): number | null {
+  if (!item || !item.equivalencyScore) return null
+  return item.equivalencyScore
+}
+
 export default function SimilarBeliefsSection({ similarTo, similarFrom, currentBeliefId }: SimilarBeliefsSectionProps) {
   const allSimilar = [...similarTo, ...similarFrom]
-  const extreme = allSimilar.filter(s => s.variant === 'extreme')
-  const moderate = allSimilar.filter(s => s.variant === 'moderate')
+  const extreme = rankByScore(allSimilar.filter(s => s.variant === 'extreme'), equivalency, Infinity).top
+  const moderate = rankByScore(allSimilar.filter(s => s.variant === 'moderate'), equivalency, Infinity).top
+  const pairs = pairBySide(extreme, moderate)
+  const topPairs = pairs.slice(0, TABLE_TOP_LIMIT)
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
 
   function getLinkedBelief(item: SimilarBeliefItem) {
     return item.fromBelief.id === currentBeliefId ? item.toBelief : item.fromBelief
+  }
+
+  function SimilarCell({ item }: { item: SimilarBeliefItem | null }) {
+    if (!item) return <span>&nbsp;</span>
+    const linked = getLinkedBelief(item)
+    return (
+      <Link href={`/beliefs/${linked.slug}`} className="text-[var(--accent)] hover:underline">
+        {linked.statement}
+      </Link>
+    )
+  }
+
+  function SimilarPairRow({ e, m }: { e: SimilarBeliefItem | null; m: SimilarBeliefItem | null }) {
+    return (
+      <tr>
+        <td className={TD}><SimilarCell item={e} /></td>
+        <td className={`${TDC} font-mono`}>{formatScore(equivalency(e)) ?? <span>&nbsp;</span>}</td>
+        <td className={TD}><SimilarCell item={m} /></td>
+        <td className={`${TDC} font-mono`}>{formatScore(equivalency(m)) ?? <span>&nbsp;</span>}</td>
+      </tr>
+    )
   }
 
   return (
@@ -29,49 +65,32 @@ export default function SimilarBeliefsSection({ similarTo, similarFrom, currentB
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">More Extreme Versions</th>
-              <th className="px-3 py-2 text-center w-1/2 font-semibold">More Moderate Versions</th>
+              <th className={`${TH} w-[42%]`}>More Extreme Versions</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
+              <th className={`${TH} w-[42%]`}>More Moderate Versions</th>
+              <th className={`${TH} text-center w-[8%]`}>Score</th>
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td className="px-3 py-3 align-top text-sm">
-                {extreme.length > 0 ? (
-                  <ol className="list-decimal list-inside space-y-1">
-                    {extreme.map(s => {
-                      const linked = getLinkedBelief(s)
-                      return (
-                        <li key={s.id}>
-                          <Link href={`/beliefs/${linked.slug}`} className="text-[var(--accent)] hover:underline">
-                            {linked.statement}
-                          </Link>
-                        </li>
-                      )
-                    })}
-                  </ol>
-                ) : (
-                  <span className="text-[var(--muted-foreground)] italic">None identified yet</span>
-                )}
-              </td>
-              <td className="px-3 py-3 align-top text-sm">
-                {moderate.length > 0 ? (
-                  <ol className="list-decimal list-inside space-y-1">
-                    {moderate.map(s => {
-                      const linked = getLinkedBelief(s)
-                      return (
-                        <li key={s.id}>
-                          <Link href={`/beliefs/${linked.slug}`} className="text-[var(--accent)] hover:underline">
-                            {linked.statement}
-                          </Link>
-                        </li>
-                      )
-                    })}
-                  </ol>
-                ) : (
-                  <span className="text-[var(--muted-foreground)] italic">None identified yet</span>
-                )}
-              </td>
-            </tr>
+            {pairs.length > 0 ? (
+              <>
+                {topPairs.map(([e, m], i) => (
+                  <SimilarPairRow key={e?.id ?? m?.id ?? i} e={e} m={m} />
+                ))}
+                <ExpandableRows moreCount={restPairs.length} colSpan={4}>
+                  {restPairs.map(([e, m], i) => (
+                    <SimilarPairRow key={e?.id ?? m?.id ?? i} e={e} m={m} />
+                  ))}
+                </ExpandableRows>
+              </>
+            ) : (
+              <tr>
+                <td className={`${TD} text-[var(--muted-foreground)] italic`}>None identified yet</td>
+                <td className={TDC}>&nbsp;</td>
+                <td className={`${TD} text-[var(--muted-foreground)] italic`}>None identified yet</td>
+                <td className={TDC}>&nbsp;</td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/src/features/belief-analysis/data/fetch-belief.ts
+++ b/src/features/belief-analysis/data/fetch-belief.ts
@@ -11,14 +11,46 @@ import {
 import { calculateEVS, getEvidenceTypeWeight } from '@/core/scoring/scoring-engine'
 import { applyStrengthPenalty } from '@/core/scoring/claim-strength'
 
+/**
+ * Standard ordering for score-ranked table rows: highest relationship score
+ * first, unscored rows last (their score cells render blank per Rule 6),
+ * then editorial sortOrder as the tiebreak. Mutable arrays (not `as const`)
+ * because Prisma's orderBy input types reject readonly tuples.
+ */
+const SCORE_RANKED = [
+  { score: { sort: 'desc' as const, nulls: 'last' as const } },
+  { sortOrder: 'asc' as const },
+]
+
+/** Same ranking for row models without a sortOrder column (id as tiebreak). */
+const SCORE_RANKED_BY_ID = [
+  { score: { sort: 'desc' as const, nulls: 'last' as const } },
+  { id: 'asc' as const },
+]
+
+/** Cost/benefit rows rank by Expected Value = Magnitude × Likelihood. */
+const EXPECTED_VALUE_RANKED = [
+  { expectedValue: { sort: 'desc' as const, nulls: 'last' as const } },
+  { sortOrder: 'asc' as const },
+]
+
 /** Shared include clause for all belief queries — includes all score-related fields. */
 const BELIEF_INCLUDE = {
-  definitions: { orderBy: { sortOrder: 'asc' as const } },
-  testablePredictions: { orderBy: { sortOrder: 'asc' as const } },
-  valueRankings: { orderBy: { sortOrder: 'asc' as const } },
-  interestEntries: { orderBy: { sortOrder: 'asc' as const } },
-  sharedInterests: { orderBy: { sortOrder: 'asc' as const } },
-  disputeTypes: { orderBy: { sortOrder: 'asc' as const } },
+  definitions: { orderBy: SCORE_RANKED },
+  testablePredictions: { orderBy: SCORE_RANKED },
+  valueRankings: { orderBy: SCORE_RANKED },
+  interestEntries: { orderBy: SCORE_RANKED },
+  sharedInterests: { orderBy: SCORE_RANKED },
+  disputeTypes: { orderBy: SCORE_RANKED },
+  falsifiabilityItems: { orderBy: SCORE_RANKED },
+  componentClaims: { orderBy: SCORE_RANKED },
+  impactEntries: { orderBy: SCORE_RANKED },
+  costBenefitItems: {
+    include: {
+      claimBelief: { select: { id: true, slug: true, statement: true } },
+    },
+    orderBy: EXPECTED_VALUE_RANKED,
+  },
   arguments: {
     include: {
       belief: {
@@ -34,43 +66,48 @@ const BELIEF_INCLUDE = {
   objectiveCriteria: { orderBy: { totalScore: 'desc' as const } },
   valuesAnalysis: true,
   interestsAnalysis: true,
-  assumptions: true,
+  assumptions: { orderBy: SCORE_RANKED_BY_ID },
   costBenefitAnalysis: true,
   impactAnalysis: true,
-  compromises: true,
-  obstacles: true,
-  biases: true,
+  compromises: { orderBy: SCORE_RANKED_BY_ID },
+  obstacles: { orderBy: SCORE_RANKED_BY_ID },
+  biases: { orderBy: SCORE_RANKED_BY_ID },
   mediaResources: {
     include: {
       qualityArguments: {
         orderBy: { impactScore: 'desc' as const },
       },
     },
+    orderBy: { impactScore: 'desc' as const },
   },
-  legalEntries: true,
+  legalEntries: { orderBy: SCORE_RANKED_BY_ID },
   upstreamMappings: {
     include: {
       parentBelief: { select: { id: true, slug: true, statement: true } },
       childBelief: { select: { id: true, slug: true, statement: true } },
     },
+    orderBy: SCORE_RANKED_BY_ID,
   },
   downstreamMappings: {
     include: {
       parentBelief: { select: { id: true, slug: true, statement: true } },
       childBelief: { select: { id: true, slug: true, statement: true } },
     },
+    orderBy: SCORE_RANKED_BY_ID,
   },
   similarTo: {
     include: {
       fromBelief: { select: { id: true, slug: true, statement: true } },
       toBelief: { select: { id: true, slug: true, statement: true } },
     },
+    orderBy: { equivalencyScore: 'desc' as const },
   },
   similarFrom: {
     include: {
       fromBelief: { select: { id: true, slug: true, statement: true } },
       toBelief: { select: { id: true, slug: true, statement: true } },
     },
+    orderBy: { equivalencyScore: 'desc' as const },
   },
 } as const
 

--- a/src/features/belief-analysis/lib/ranking.ts
+++ b/src/features/belief-analysis/lib/ranking.ts
@@ -1,0 +1,65 @@
+/**
+ * Ranking helpers for score-sorted belief page tables.
+ *
+ * Every table row on a belief page relates to the belief through a scored
+ * relationship (the ReasonRank performance of the row's own pro/con
+ * sub-debate). Tables show their highest-scoring rows first and collapse the
+ * rest until expanded. Unscored rows (null/undefined) sort last — their score
+ * cells render blank per Rule 6 — so real scores are never buried beneath
+ * placeholders.
+ */
+
+/** How many rows a table shows before collapsing the remainder. */
+export const TABLE_TOP_LIMIT = 5
+
+type ScoreGetter<T> = (row: T) => number | null | undefined
+
+/** Comparator: score descending, nulls last. Stable for equal/missing scores. */
+export function byScoreDesc<T>(getScore: ScoreGetter<T>): (a: T, b: T) => number {
+  return (a, b) => {
+    const sa = getScore(a)
+    const sb = getScore(b)
+    if (sa == null && sb == null) return 0
+    if (sa == null) return 1
+    if (sb == null) return -1
+    return sb - sa
+  }
+}
+
+export interface RankedRows<T> {
+  /** The top-scoring rows, at most `limit` of them, best first. */
+  top: T[]
+  /** Everything below the fold, still score-ordered. */
+  rest: T[]
+}
+
+/**
+ * Sort rows by relationship score (descending, nulls last) and split them at
+ * `limit`. The database already orders most relations this way; sorting again
+ * here is cheap and covers callers that merge lists (e.g. similarTo +
+ * similarFrom) or receive hand-built data.
+ */
+export function rankByScore<T>(
+  rows: T[],
+  getScore: ScoreGetter<T>,
+  limit: number = TABLE_TOP_LIMIT,
+): RankedRows<T> {
+  const sorted = [...rows].sort(byScoreDesc(getScore))
+  return { top: sorted.slice(0, limit), rest: sorted.slice(limit) }
+}
+
+/**
+ * Pair two score-ranked side columns row-by-row for the page's two-sided
+ * tables (pro/con, supporter/opponent, short/long). Each side keeps its own
+ * ranking; row i holds the i-th best of each side, padded with null.
+ */
+export function pairBySide<T>(left: T[], right: T[]): Array<[T | null, T | null]> {
+  const n = Math.max(left.length, right.length)
+  return Array.from({ length: n }, (_, i) => [left[i] ?? null, right[i] ?? null])
+}
+
+/** Score cell text: null/undefined renders blank (Rule 6), integers stay bare. */
+export function formatScore(score: number | null | undefined): string | null {
+  if (score == null) return null
+  return Number.isInteger(score) ? String(score) : score.toFixed(1)
+}

--- a/src/features/belief-analysis/types.ts
+++ b/src/features/belief-analysis/types.ts
@@ -1,10 +1,18 @@
 // Types for the Belief Analysis template
 // These map to the Prisma models but are used as plain objects in components
 
+/**
+ * Every per-row table on the belief page carries a nullable relationship
+ * score: the ReasonRank performance of that row's own pro/con sub-debate
+ * about its relationship to the belief. Rows enter and rank only by this
+ * score — never by editorial placement. Null renders blank (Rule 6);
+ * tables sort by score descending with the highest-scoring content first.
+ */
 export interface DefinitionItem {
   id: number
   term: string
   definition: string
+  score?: number | null
   sortOrder: number
 }
 
@@ -13,6 +21,60 @@ export interface TestablePredictionItem {
   prediction: string
   timeframe: string | null
   verificationMethod: string | null
+  /** "true" if the prediction follows when the belief is true, "false" otherwise. */
+  followsIf?: string
+  /** What has actually been observed so far, if anything. */
+  resultSoFar?: string | null
+  score?: number | null
+  sortOrder: number
+}
+
+/** One row in the Falsifiability Test table: a realistic score-mover. */
+export interface FalsifiabilityItemRow {
+  id: number
+  side: string // "strengthen" | "weaken"
+  description: string
+  score?: number | null
+  sortOrder: number
+}
+
+/** One row in the Logical Anatomy table: a component claim of the belief. */
+export interface ComponentClaimItem {
+  id: number
+  claim: string
+  claimType: string | null // "Empirical" | "Causal" | "Definitional" | "Normative"
+  stated: boolean
+  /** If this part is false, does the belief survive? false = load-bearing. */
+  survivesWithout: boolean | null
+  unstatedAssumptions: string | null
+  score?: number | null
+  sortOrder: number
+}
+
+/** One row in the Benefits / Costs and Risks tables. */
+export interface CostBenefitItemRow {
+  id: number
+  side: string // "benefit" | "cost"
+  claim: string
+  /** Category (units): dollars / life-years / hours / freedom. */
+  category: string | null
+  /** Magnitude in explicit category units. */
+  magnitude: number | null
+  /** Likelihood (0-1), computed from the claim's own pro/con argument scores. */
+  likelihood: number | null
+  /** Expected Value = Magnitude × Likelihood. Sort key for the table. */
+  expectedValue: number | null
+  sortOrder: number
+  /** The claim's own belief page, when one exists. */
+  claimBelief?: { id: number; slug: string; statement: string } | null
+}
+
+/** One row in the Short vs. Long-Term Impacts sub-table. */
+export interface ImpactEntryItem {
+  id: number
+  term: string // "short" | "long"
+  description: string
+  score?: number | null
   sortOrder: number
 }
 
@@ -49,6 +111,12 @@ export interface BeliefWithRelations {
 
   /** One-line interpretation of the Net Belief Score, shown beneath the argument trees. */
   netInterpretation: string | null
+  /** Scorecard "Bottom line": one-sentence verdict scoped to the argument tree. */
+  bottomLine?: string | null
+  /** Scorecard "What would move this score most". */
+  scoreMover?: string | null
+  /** Logical Anatomy "Logical form" line. */
+  logicalForm?: string | null
   /** Header metadata: related belief labels and beliefs this one supports (plain text). */
   relatedBeliefs: string | null
   supportsBeliefs: string | null
@@ -57,6 +125,11 @@ export interface BeliefWithRelations {
   interestEntries: InterestEntryItem[]
   sharedInterests: SharedInterestItem[]
   disputeTypes: DisputeTypeItem[]
+
+  falsifiabilityItems?: FalsifiabilityItemRow[]
+  componentClaims?: ComponentClaimItem[]
+  costBenefitItems?: CostBenefitItemRow[]
+  impactEntries?: ImpactEntryItem[]
 
   arguments: ArgumentWithBelief[]
   evidence: EvidenceItem[]
@@ -149,6 +222,10 @@ export interface ObjectiveCriteriaItem {
   currentStatus?: string | null
   /** The target/threshold that would settle the debate (new template column). */
   target?: string | null
+  /** Reading supporters predict — falls back to `target` when unset. */
+  strengthenReading?: string | null
+  /** Reading opponents predict; a criterion both sides expect to read the same tests nothing. */
+  weakenReading?: string | null
   /**
    * The threshold both sides agreed (or could agree) constitutes resolution —
    * e.g., "+2pp sustained over 3 years would settle the debate".
@@ -163,6 +240,7 @@ export interface ValueRankingItem {
   supporterRank: number | null
   opponentRank: number | null
   whyDiffer: string | null
+  score?: number | null
   sortOrder: number
 }
 
@@ -177,6 +255,7 @@ export interface InterestEntryItem {
   evidenceBasis: string | null
   connectedValue: string | null
   pretextual: boolean
+  score?: number | null
   sortOrder: number
 }
 
@@ -186,6 +265,7 @@ export interface SharedInterestItem {
   interest: string
   validity: string | null
   compromiseDirection: string | null
+  score?: number | null
   sortOrder: number
 }
 
@@ -195,6 +275,7 @@ export interface DisputeTypeItem {
   disputeType: string // "Empirical" | "Definitional" | "Values"
   disagreement: string | null
   evidenceThatMoves: string | null
+  score?: number | null
   sortOrder: number
 }
 
@@ -206,6 +287,9 @@ export interface ValuesAnalysisData {
   /** Advertised vs. Actual Motivations: evidence the two diverge, per side. */
   supportingDivergenceEvidence?: string | null
   opposingDivergenceEvidence?: string | null
+  /** Divergence Score per side: performance of the sub-debate that advertised ≠ actual. */
+  supportingDivergenceScore?: number | null
+  opposingDivergenceScore?: number | null
   /** Answer to "What would shift these rankings?" beneath the Shared Values table. */
   whatWouldShift?: string | null
   /**
@@ -393,6 +477,7 @@ export interface AssumptionItem {
   side: string
   statement: string
   strength: string
+  score?: number | null
 }
 
 export interface CostBenefitData {
@@ -416,12 +501,15 @@ export interface CompromiseItem {
   sharedPremise?: string | null
   synthesis?: string | null
   whyDifficult?: string | null
+  /** Score: share of both sides' interests this compromise satisfies. */
+  score?: number | null
 }
 
 export interface ObstacleItem {
   id: number
   side: string
   description: string
+  score?: number | null
 }
 
 export interface BiasItem {
@@ -429,6 +517,7 @@ export interface BiasItem {
   side: string
   biasType: string
   description: string | null
+  score?: number | null
 }
 
 export interface MediaItem {
@@ -477,12 +566,14 @@ export interface LegalItem {
   side: string
   description: string
   jurisdiction: string | null
+  score?: number | null
 }
 
 export interface MappingItem {
   id: number
   direction: string
   side: string
+  score?: number | null
   parentBelief: { id: number; slug: string; statement: string }
   childBelief: { id: number; slug: string; statement: string }
 }

--- a/templates/belief-analysis-template.html
+++ b/templates/belief-analysis-template.html
@@ -1,7 +1,7 @@
 <!-- page=Template -->
 <!-- content-type=text/html -->
 <!--
-  ===== ISE BELIEF PAGE MASTER TEMPLATE (April 2026 redesign) =====
+  ===== ISE BELIEF PAGE MASTER TEMPLATE (July 2026 revision) =====
   Canonical rules: see docs/BELIEF_PAGE_RULES.md.
   This template is the source of truth for section order and structure. It is
   mirrored by the React implementation in src/app/beliefs/[slug]/page.tsx and the
@@ -11,7 +11,7 @@
 
   HARD RULES (every generation must follow):
     1. NO summary / background / hook / overview at the top. Header metadata, then
-       straight to Argument Trees.
+       the Scorecard readout, then straight to Argument Trees.
     2. Definitions go LAST, never first.
     3. Argument cells are short claim labels. Each cell = the claim, the single most
        famous supporting quote inline (italic, small), then the submitter as ~Name.
@@ -20,99 +20,349 @@
     5. No broken links. Use plain text if the target page doesn't exist.
     6. Score cells stay blank until real sub-argument scoring exists. No "+0" placeholders.
     7. Supporters and Opponents get symmetric structure everywhere.
+    8. Every table sorts by Score, descending — rows enter and rank only by the
+       performance of their pro/con sub-arguments, never by editorial placement.
+       In the ISE software each table shows its top rows and collapses the rest
+       until expanded.
 
   CANONICAL SECTION ORDER:
     Header (Belief / metadata / Beliefs this supports)
-    1.  Argument Trees (scored two-sided table + Net Belief Score)
-    2.  Evidence Ledger (two-sided: Supporting / Weakening)
-    3.  Conflict Resolution Framework
-        a. Shared Values, Different Rankings
+    0.  Scorecard (Net Belief Score / Bottom line / Strongest pro+con / What would
+        move this score most) + "How to read this page" box
+    1.  Argument Trees (scored two-sided table: Argument/Score/Link/Imp/Impact,
+        Pro+Con totals, Net Belief Score)
+    2.  Evidence Ledger (two-sided: Supporting / Weakening, Type/Link/Impact)
+    3.  Objective Criteria (Criterion / How to Measure / Reading That Would
+        Strengthen / Reading That Would Weaken / Latest Reading / Score)
+    4.  Falsifiability Test (Evidence That Would Strengthen+Score / Weaken+Score)
+        + Testable Predictions (Prediction / Follows If / Timeframe / Verification
+        Method / Result So Far / Score)
+    5.  Logical Anatomy & Foundational Assumptions (logical form, Component
+        Claims table, Assumptions by Side with Scores)
+    6.  Cost-Benefit Analysis (Benefits table + Costs table: Claim / Category /
+        Magnitude / Likelihood % / Expected Value, per-category subtotals), then
+        Short vs. Long-Term Impacts (with Scores)
+    7.  Conflict Resolution Framework
+        a. Shared Values, Different Rankings (with Score)
         b. Likely Interests of Supporters
         c. Likely Interests of Opponents
-        d. Shared and Conflicting Interests (Shared Interests + Primary Conflict Pair)
-        e. Advertised vs. Actual Motivations
-        f. Dispute Types
-        g. Primary Obstacles to Resolution
-    4.  Objective Criteria
-    5.  Falsifiability Test + Testable Predictions
-    6.  Foundational Assumptions
-    7.  Cost-Benefit Analysis (+ Short vs. Long-Term + Best Compromise Solutions)
-    8.  Biases
-    9.  Media Resources
-    10. Legal Framework
-    11. General to Specific Belief Mapping
-    12. Similar Beliefs
-    13. Definitions (LAST before Contribute)
-    14. Contribute / footer
+        d. Shared and Conflicting Interests (Shared Interests with Score +
+           Primary Conflict Pair)
+        e. Best Compromise Solutions (with Score: interests satisfied)
+        f. Advertised vs. Actual Motivations (with Divergence Score)
+        g. Dispute Types (with Score)
+        h. Primary Obstacles to Resolution (with Scores)
+        i. Biases (with Scores)
+    8.  Media Resources (two-sided: Resource / Type / Score)
+    9.  Legal Framework (Supporting+Score / Complicating+Score)
+    10. General to Specific Belief Mapping (Support+Score / Oppose+Score)
+    11. Similar Beliefs (More Extreme+Score / More Moderate+Score)
+    12. Definitions (Term / Definition / Score) — LAST before footer
+    13. Contribute / footer
 -->
 <p style="text-align: right;"><a href="/w/page/21957696/Colorado%20Should">Home</a> &rsaquo;  <a href="/w/page/159323433/One%20Page%20Per%20Topic">Topics</a> &rsaquo;  [Category] &rsaquo;  [This Belief]</p>
 <div style="font-family: 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #333;">
+<p style="display: none;">AUTHORING RULES (hidden text; leave in place, readers never see this): state the belief in positive form so the page headlines the supported claim. Every argument cell must be a complete, atomic proposition whose pro/con direction is evident from the cell alone. Never fill a score cell for an empty item. All scores stay [bracketed] until the ReasonRank engine computes them. Every table sorts by score, descending; rows enter and rank only by the performance of their pro/con sub-arguments, never by editorial placement. Arguments fail logically and go in the tree; evidence fails empirically and goes in the ledger.</p>
 <h1>Belief: [Insert Belief Statement Here]</h1>
-<p style="text-align: right; font-size: 11px; color: #999; margin: 0 0 12px 0;"><a href="/beliefs%20grouped%20and%20eventually%20sorted%20along%20the%20the%20positivity%20continuum">Topic</a>: [Category] &gt; [Subcategory] &middot; Dewey [Number] &middot; Positivity [Scale -100% to +100%] &middot; Net Belief Score [To be calculated] &middot; Related: [Related belief 1] | [Related belief 2]</p>
-<p style="font-size: 13px;"><strong>&#128279; Beliefs this supports:</strong> [Belief 1] | [Belief 2]</p>
-
-<h1>&#128269; <a href="/Reasons">Argument Trees</a></h1>
-<p style="font-size: 13px;">Each argument is a belief with its own page. Scores are recursive: Argument Score &times; <a href="/w/page/159338766/Linkage%20Scores">Linkage</a> &times; <a href="/importance%20score">Importance</a> = Impact. Pro and con impacts sum to the Net Belief Score.</p>
+<p style="text-align: right; font-size: 11px; color: #999; margin: 0 0 12px 0;"><a href="/beliefs%20grouped%20and%20eventually%20sorted%20along%20the%20the%20positivity%20continuum">Topic</a>: [Category] &gt; [Subcategory] &middot; Dewey [Number] &middot; Positivity [Scale -100% to +100%] &middot; Related: [Related belief 1] | [Related belief 2]</p>
+<p style="font-size: 13px;"><strong>🔗 Beliefs this supports:</strong> [Belief 1] | [Belief 2]</p>
+<h2>📋 Scorecard</h2>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<tbody>
+<tr>
+<td style="background-color: #f0f3f6;" width="25%"><strong>Net Belief Score</strong></td>
+<td width="75%"><strong>[NETSCORE]</strong> &middot; Pro [PROTOTAL] vs. Con [CONTOTAL] &middot; <span style="font-size: 12px; color: #555;">brackets = placeholders until <a href="/w/page/159300543/ReasonRank">ReasonRank</a> computes live scores</span></td>
+</tr>
+<tr style="background-color: #f9f9f9;">
+<td style="background-color: #f0f3f6;"><strong>Bottom line</strong></td>
+<td>[One-sentence verdict, scoped to what the argument tree below actually supports. No bigger claim than the leaves can carry.]</td>
+</tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Strongest pro / con</strong></td>
+<td>[Best pro argument] &middot; [Best con argument]</td>
+</tr>
+<tr style="background-color: #f9f9f9;">
+<td style="background-color: #f0f3f6;"><strong>What would move this score most</strong></td>
+<td>[The single piece of evidence that would most change the verdict; see Falsifiability Test below]</td>
+</tr>
+</tbody>
+</table>
+<p style="font-size: 13px; padding: 8px; background-color: #f0f3f6; border: 1px solid #ccc;"><strong>How to read this page:</strong> nothing here is placed by editorial choice. Every row in every table is itself a claim, and its Score is the <a href="/w/page/159300543/ReasonRank">ReasonRank</a> performance of the pro/con sub-debate about that claim, computed recursively down to the evidence. Every table sorts by Score, best content first; in the ISE software each table shows its top rows and collapses the rest until expanded. [Bracketed] numbers are hand-estimated placeholders until the engine ships, and score cells stay blank until real content exists to score. This wiki can&rsquo;t sort tables live; the Score columns are the data contract that lets the software sort, filter, and collapse every table automatically.</p>
+<p>&nbsp;</p>
+<h1>🔍 <a href="/Reasons">Argument Trees</a></h1>
+<p style="font-size: 13px;">Each argument is a belief with its own page. Scores are recursive: Argument Score &times; <a href="/w/page/159338766/Linkage%20Scores">Linkage</a> &times; <a href="/importance%20score">Importance</a> = Impact. Pro and con impacts sum to the Net Belief Score. A true-but-irrelevant argument scores high on truth and near zero on linkage, so it contributes nothing.</p>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
 <tr>
-<th style="background-color: #e6ffe6; text-align: center; font-size: 15px;" colspan="4">&#9989; Reasons to Agree</th> <th style="background-color: #ffe6e6; text-align: center; font-size: 15px;" colspan="4">&#10060; Reasons to Disagree</th>
+<th style="background-color: #e6ffe6; text-align: center; font-size: 15px;" colspan="5">✅ Reasons to Agree</th> <th style="background-color: #ffe6e6; text-align: center; font-size: 15px;" colspan="5">❌ Reasons to Disagree</th>
 </tr>
 <tr style="background-color: #f0f3f6; font-size: 12px;">
-<th width="25%">Argument</th> <th width="6%">Score</th> <th width="6%"><a href="/w/page/159338766/Linkage%20Scores">Link</a></th> <th width="7%">Impact</th> <th width="25%">Argument</th> <th width="6%">Score</th> <th width="6%"><a href="/w/page/159338766/Linkage%20Scores">Link</a></th> <th width="7%">Impact</th>
+<th width="22%">Argument</th> <th width="5%">Score</th> <th width="5%"><a href="/w/page/159338766/Linkage%20Scores">Link</a></th> <th width="5%"><a href="/importance%20score">Imp</a></th> <th width="6%">Impact</th> <th width="22%">Argument</th> <th width="5%">Score</th> <th width="5%"><a href="/w/page/159338766/Linkage%20Scores">Link</a></th> <th width="5%"><a href="/importance%20score">Imp</a></th> <th width="6%">Impact</th>
 </tr>
 </thead>
 <tbody>
-<!-- CELL CONVENTION: each argument cell = the claim, then the single most famous supporting quote integrated inline (italic, small), then the submitter as ~Name linked to their page. If several people made the same argument, feature the most famous quote as primary and list other names after it. No separate quotes section. -->
-<tr><td>[Claim]. <span style="font-size:12px; color:#555;"><em>"[most famous quote]"</em></span> ~<a href="/w/page/21958819/Myclob">Name</a></td><td align="center">[S]</td><td align="center">[L]</td><td align="center">[I]</td><td>[Claim]. ~<a href="/w/page/21958819/Myclob">Name</a></td><td align="center">[S]</td><td align="center">[L]</td><td align="center">[I]</td></tr>
+<tr>
+<td>[Claim]. <span style="font-size: 12px; color: #555;"><em>"[most famous quote]"</em></span> ~<a href="/w/page/21958819/Myclob">Name</a></td>
+<td align="center">[S]</td>
+<td align="center">[L]</td>
+<td align="center">[M]</td>
+<td align="center">[I]</td>
+<td>[Claim]. ~<a href="/w/page/21958819/Myclob">Name</a></td>
+<td align="center">[S]</td>
+<td align="center">[L]</td>
+<td align="center">[M]</td>
+<td align="center">[I]</td>
+</tr>
 <tr style="background-color: #f0f0f0; font-style: italic; color: #666;">
-<td colspan="3" align="right"><strong>Pro Total:</strong></td>
+<td colspan="4" align="right"><strong>Pro Total:</strong></td>
 <td align="center">[PROTOTAL]</td>
-<td colspan="3" align="right"><strong>Con Total:</strong></td>
+<td colspan="4" align="right"><strong>Con Total:</strong></td>
 <td align="center">[CONTOTAL]</td>
 </tr>
 </tbody>
 </table>
-<p style="font-size: 13px; padding: 8px; background-color: #f0f3f6; border: 1px solid #ccc;"><strong>Net Belief Score: [NETSCORE].</strong> [NETINTERP]</p>
-
+<p style="font-size: 13px; padding: 8px; background-color: #f0f3f6; border: 1px solid #ccc;"><strong>Net Belief Score = Pro Total + Con Total = [NETSCORE].</strong> [NETINTERP]</p>
 <hr />
 <br />
-<h1>&#128202; <a href="/w/page/159353568/Evidence">Evidence Ledger</a></h1>
-<p style="font-size: 13px;"><em>Key: <strong>T1</strong>=Peer-reviewed/Official, <strong>T2</strong>=Expert/Institutional, <strong>T3</strong>=Journalism/Surveys, <strong>T4</strong>=Opinion/Anecdote</em></p>
+<h1>📊 <a href="/w/page/159353568/Evidence">Evidence Ledger</a></h1>
+<p style="font-size: 13px;"><em>Key: <strong>T1</strong>=Peer-reviewed/Official, <strong>T2</strong>=Expert/Institutional, <strong>T3</strong>=Journalism/Surveys, <strong>T4</strong>=Opinion/Anecdote. Format each item as: Finding (Producer, Year). Evidence is data that can fail empirically; a reason that can only fail logically is an argument and belongs in the tree above, not here.</em></p>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
 <tr>
-<th style="background-color: #e6ffe6; text-align: center; font-size: 15px;" colspan="4">&#9989; Supporting Evidence</th> <th style="background-color: #ffe6e6; text-align: center; font-size: 15px;" colspan="4">&#10060; Weakening Evidence</th>
+<th style="background-color: #e6ffe6; text-align: center; font-size: 15px;" colspan="4">✅ Supporting Evidence</th> <th style="background-color: #ffe6e6; text-align: center; font-size: 15px;" colspan="4">❌ Weakening Evidence</th>
 </tr>
 <tr style="background-color: #f0f3f6; font-size: 12px;">
-<th width="22%">Evidence</th> <th width="7%">Type</th> <th width="7%"><a href="/w/page/159338766/Linkage%20Scores">Link</a></th> <th width="7%">Impact</th> <th width="22%">Evidence</th> <th width="7%">Type</th> <th width="7%"><a href="/w/page/159338766/Linkage%20Scores">Link</a></th> <th width="7%">Impact</th>
+<th width="22%">Evidence (Producer, Year)</th> <th width="7%">Type</th> <th width="7%"><a href="/w/page/159338766/Linkage%20Scores">Link</a></th> <th width="7%">Impact</th> <th width="22%">Evidence (Producer, Year)</th> <th width="7%">Type</th> <th width="7%"><a href="/w/page/159338766/Linkage%20Scores">Link</a></th> <th width="7%">Impact</th>
 </tr>
 </thead>
 <tbody>
-<tr><td>&nbsp;</td><td align="center">T1</td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td>&nbsp;</td><td align="center">T1</td><td align="center">&nbsp;</td><td align="center">&nbsp;</td></tr>
+<tr>
+<td>&nbsp;</td>
+<td align="center">T1</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">T1</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
 </tbody>
 </table>
 <br />
-<h1>&#129309; <a href="/w/page/156186840/automate%20conflict%20resolution">Conflict Resolution</a> Framework</h1>
-<p style="font-size: 13px;">Both sides of most debates share the same <a href="/w/page/21956745/American%20values">values</a>. They disagree about how to <strong>rank</strong> them, and that ranking shifts based on perceived <a href="/w/page/156187122/cost-benefit%20analysis">costs, benefits</a>, and <a href="/Likelihood">likelihood of success</a>. See <a href="/w/page/159323067/Brainstorming%20Interests%20for%20Policy%20Debates">Interest Scoring Methodology</a> and <a href="/w/page/159323043/Focusing%20on%20Interests%2C%20Not%20Positions">Focusing on Interests, Not Positions</a>.</p>
-<h2>&#9878; <a href="/w/page/162560400/Values%20of%20those%20who%20agree%20and%20disagree">Shared Values, Different Rankings</a></h2>
+<h1>🎯 <a href="/Objective%20criteria%20scores">Objective Criteria</a></h1>
+<p style="font-size: 13px;">These are the measurements that would settle this debate if both sides committed to them in advance. Pick the standard first, then check the result: that is what keeps the verdict tied to the world instead of to whoever argues loudest. The best criteria are specific enough that supporters and opponents would predict <em>different</em> readings. A criterion both sides expect to come out the same way tests nothing. See <a href="/w/page/159323070/Applying%20%22Getting%20to%20Yes%22%20Principles">Applying "Getting to Yes" Principles</a>.</p>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="20%">Criterion</th> <th width="24%">How to Measure</th> <th width="17%">Reading That Would Strengthen</th> <th width="17%">Reading That Would Weaken</th> <th width="14%">Latest Reading</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<br />
+<h1>🧪 Falsifiability Test</h1>
+<p style="font-size: 13px;">Evidence rarely proves or disproves anything outright; it strengthens or weakens. List the strongest realistic score-movers in each direction, and be as specific as a bet: what result, from what kind of source, by when? Each row&rsquo;s Score is the performance of its own pro/con sub-debate: if this evidence appeared, would it actually move this belief?</p>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="42%">Evidence That Would Strengthen</th> <th width="8%">Score</th> <th width="42%">Evidence That Would Weaken</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+<tr style="background-color: #f9f9f9;">
+<td style="font-size: 12px; color: #555;" colspan="4"><em>If no realistic evidence could falsify this belief, say so here and note what that implies about the strength of the claim.</em></td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<h2>🔮 Testable Predictions</h2>
+<p style="font-size: 13px;">If this belief is true, what should the world show us that it would not show us otherwise? If it is false, what should we see instead? A belief that predicts nothing cannot be evaluated, only asserted. Each prediction that comes true or fails feeds back into the belief score above.</p>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="30%">Prediction</th> <th width="10%">Follows If&hellip;</th> <th width="12%">Timeframe</th> <th width="26%">Verification Method</th> <th width="14%">Result So Far</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[If this belief is true, we should observe&hellip;]</td>
+<td align="center">True</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+<tr style="background-color: #f9f9f9;">
+<td>[If this belief is false, we should observe&hellip;]</td>
+<td align="center">False</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<br />
+<h1>💡 <a href="/Assumptions">Logical Anatomy &amp; Foundational Assumptions</a></h1>
+<p style="font-size: 13px;">A belief statement that reads as one claim is usually several claims wearing one sentence. Split it into its parts, type each part, surface what it silently assumes, and mark which parts are load-bearing. If the belief is a chain of ANDs, it is exactly as strong as its weakest load-bearing part.</p>
+<p style="font-size: 13px;"><strong>Logical form:</strong> [This belief] = [Part 1] AND [Part 2] AND ([Part 3] OR [Part 4])</p>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6; font-size: 12px;">
+<th width="30%">Component Claim (stated or implied)</th> <th width="14%">Type</th> <th width="12%">Stated?</th> <th width="18%">If this part is false, does the belief survive?</th> <th width="18%">Unstated assumptions this part relies on</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>&nbsp;</td>
+<td align="center">[Empirical / Causal / Definitional / Normative]</td>
+<td align="center">[Stated / Implied]</td>
+<td align="center">[No = load-bearing]</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<h2>Assumptions by Side</h2>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="42%">Required to Accept This Belief</th> <th width="8%">Score</th> <th width="42%">Required to Reject This Belief</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<br />
+<h1>⚖ <a href="/w/page/156187122/cost-benefit%20analysis">Cost-Benefit Analysis</a></h1>
+<p style="font-size: 13px;">Every cost and benefit is itself a debatable claim with its own argument tree, and every row must survive three questions: compared to what, measured in what units, and how likely? Magnitude is an estimate in explicit units. Likelihood is computed from how that claim&rsquo;s pro and con arguments score, never assigned by gut. Expected Value = Magnitude &times; Likelihood. Keep unlike categories (dollars, life-years, people-hours, freedom) in separate rows and subtotal only within a category; converting across categories is itself a debatable claim, so if you do it, state the conversion out loud (e.g., the value of a statistical life). Method per the canonical <a href="/w/page/156187122/cost-benefit%20analysis">cost-benefit analysis</a> page and Sunstein&rsquo;s <em>The Cost-Benefit Revolution</em>.</p>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr>
+<th style="background-color: #e6ffe6; text-align: center; font-size: 15px;" colspan="5">✅ Benefits</th>
+</tr>
+<tr style="background-color: #f0f3f6; font-size: 12px;">
+<th width="34%">Benefit Claim (links to its own page)</th> <th width="16%">Category (Units)</th> <th width="16%">Magnitude</th> <th width="14%">Likelihood %</th> <th width="20%">Expected Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>&nbsp;</td>
+<td align="center">[dollars / life-years / hours / freedom]</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+<tr style="background-color: #f0f0f0; font-style: italic; color: #666;">
+<td colspan="4" align="right"><strong>Subtotal (within each category only):</strong></td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr>
+<th style="background-color: #ffe6e6; text-align: center; font-size: 15px;" colspan="5">❌ Costs and Risks</th>
+</tr>
+<tr style="background-color: #f0f3f6; font-size: 12px;">
+<th width="34%">Cost Claim (links to its own page)</th> <th width="16%">Category (Units)</th> <th width="16%">Magnitude</th> <th width="14%">Likelihood %</th> <th width="20%">Expected Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>&nbsp;</td>
+<td align="center">[dollars / life-years / hours / freedom]</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+<tr style="background-color: #f0f0f0; font-style: italic; color: #666;">
+<td colspan="4" align="right"><strong>Subtotal (within each category only):</strong></td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<h2>🎯 Short vs. Long-Term Impacts</h2>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="42%">Short-Term (0-2 Years)</th> <th width="8%">Score</th> <th width="42%">Long-Term (5+ Years)</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<br />
+<h1>🤝 <a href="/w/page/156186840/automate%20conflict%20resolution">Conflict Resolution</a> Framework</h1>
+<p style="font-size: 13px;">Both sides of most debates share the same <a href="/w/page/21956745/American%20values">values</a>. They disagree about how to <strong>rank</strong> them, and that ranking shifts based on perceived <a href="/w/page/156187122/cost-benefit%20analysis">costs, benefits</a>, and <a href="/Likelihood">likelihood of success</a>. The conflict readout below is the scored cost-benefit trees above, read sideways. See <a href="/w/page/159323067/Brainstorming%20Interests%20for%20Policy%20Debates">Interest Scoring Methodology</a> and <a href="/w/page/159323043/Focusing%20on%20Interests%2C%20Not%20Positions">Focusing on Interests, Not Positions</a>.</p>
+<h2>⚖ <a href="/w/page/162560400/Values%20of%20those%20who%20agree%20and%20disagree">Shared Values, Different Rankings</a></h2>
 <p style="font-size: 13px;">Both sides hold these <a href="/w/page/21956745/American%20values">values</a>. The disagreement is about priority order, not whether each value matters. Rankings shift when new <a href="/w/page/159353568/Evidence">evidence</a> changes perceived <a href="/w/page/156187122/cost-benefit%20analysis">costs/benefits</a> or <a href="/Likelihood">likelihood of success</a>. The value the two sides rank most differently usually is the primary conflict pair scored further below.</p>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #f0f3f6;">
-<th width="28%"><a href="/w/page/21956745/American%20values">Value</a></th> <th width="12%">Supporter Rank</th> <th width="12%">Opponent Rank</th> <th width="48%">Why Rankings Differ on This Issue</th>
+<th width="24%"><a href="/w/page/21956745/American%20values">Value</a></th> <th width="10%">Supporter Rank</th> <th width="10%">Opponent Rank</th> <th width="40%">Why Rankings Differ on This Issue</th> <th width="8%">Score</th>
 </tr>
 </thead>
 <tbody>
-<tr><td><a href="/w/page/21956745/American%20values">[Value 1]</a></td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td>&nbsp;</td></tr>
-<tr style="background-color: #f9f9f9;"><td><a href="/w/page/21956745/American%20values">[Value 2]</a></td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td><a href="/w/page/21956745/American%20values">[Value 3]</a></td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td>&nbsp;</td></tr>
-<tr style="background-color: #f0f3f6;"><td colspan="4"><strong>What would shift these rankings?</strong> [What evidence, cost-benefit findings, or likelihood changes would cause either side to re-rank?]</td></tr>
+<tr>
+<td><a href="/w/page/21956745/American%20values">[Value 1]</a></td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+<tr style="background-color: #f9f9f9;">
+<td><a href="/w/page/21956745/American%20values">[Value 2]</a></td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+<tr>
+<td><a href="/w/page/21956745/American%20values">[Value 3]</a></td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+<tr style="background-color: #f0f3f6;">
+<td colspan="5"><strong>What would shift these rankings?</strong> [What evidence, cost-benefit findings, or likelihood changes would cause either side to re-rank?]</td>
+</tr>
 </tbody>
 </table>
-<h2>&nbsp;</h2>
-<h2>&#128161; <a href="/w/page/159301140/Interests">Likely Interests of Supporters</a></h2>
-<p style="font-size: 13px;">Sorted by estimated prevalence. <a href="/w/page/159338766/Linkage%20Scores">Linkage Confidence</a> measures how sure we are this is actually why they support this belief. <a href="/w/page/159323067/Brainstorming%20Interests%20for%20Policy%20Debates">Validity</a> measures how legitimate the interest is. For the deepest treatment build a dedicated <a href="/w/page/159301140/Interests">Interest Analysis</a> page and link it here.</p>
+<p>&nbsp;</p>
+<h2>💡 <a href="/w/page/159301140/Interests">Likely Interests of Supporters</a></h2>
+<p style="font-size: 13px;">Sorted by estimated prevalence. <a href="/w/page/159338766/Linkage%20Scores">Linkage Confidence</a> measures how sure we are this is actually why they support this belief. <a href="/w/page/159323067/Brainstorming%20Interests%20for%20Policy%20Debates">Validity</a> measures how legitimate the interest is, determined by argument and objective criteria, never by which side has more power. For the deepest treatment build a dedicated <a href="/w/page/159301140/Interests">Interest Analysis</a> page and link it here.</p>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #e6ffe6;">
@@ -120,12 +370,26 @@
 </tr>
 </thead>
 <tbody>
-<tr><td>&nbsp;</td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>
-<tr style="background-color: #f9f9f9; font-style: italic;"><td><em>Pretextual / Low-validity (if any)</em></td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td style="color: #c0392b;" align="center"><strong>0-20</strong></td><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+</tr>
+<tr style="background-color: #f9f9f9; font-style: italic;">
+<td><em>Pretextual / Low-validity (if any)</em></td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td style="color: #c0392b;" align="center"><strong>0-20</strong></td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+</tr>
 </tbody>
 </table>
-<h2>&nbsp;</h2>
-<h2>&#128161; <a href="/w/page/159301140/Interests">Likely Interests of Opponents</a></h2>
+<p>&nbsp;</p>
+<h2>💡 <a href="/w/page/159301140/Interests">Likely Interests of Opponents</a></h2>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #ffe6e6;">
@@ -133,142 +397,282 @@
 </tr>
 </thead>
 <tbody>
-<tr><td>&nbsp;</td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>
-<tr style="background-color: #f9f9f9; font-style: italic;"><td><em>Pretextual / Low-validity (if any)</em></td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td style="color: #c0392b;" align="center"><strong>0-20</strong></td><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+</tr>
+<tr style="background-color: #f9f9f9; font-style: italic;">
+<td><em>Pretextual / Low-validity (if any)</em></td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td style="color: #c0392b;" align="center"><strong>0-20</strong></td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+</tr>
 </tbody>
 </table>
-<h2>&nbsp;</h2>
-<h2>&#128279; <a href="/w/page/159301140/Interests">Shared and Conflicting Interests</a></h2>
+<p>&nbsp;</p>
+<h2>🔗 <a href="/w/page/159301140/Interests">Shared and Conflicting Interests</a></h2>
 <h3>Shared Interests (foundation for <a href="/w/page/162560439/Compromise">compromise</a>)</h3>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #e6ffe6;"><th width="40%">Shared Interest</th> <th width="12%">Validity</th> <th width="48%">Compromise direction it opens</th></tr></thead>
-<tbody><tr><td>&nbsp;</td><td align="center">&nbsp;</td><td>&nbsp;</td></tr></tbody>
-</table>
-<h3>&#9876; Primary Conflict Pair <span style="font-size: 12px; color: #555;">(the ranking difference that drives this debate)</span></h3>
-<p style="font-size: 13px;"><strong>Primary pair:</strong> [Supporter interest] vs [Opponent interest]</p>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="26%">Interest in the pair</th> <th width="18%">Standalone Validity</th> <th width="18%">Claim strength on THIS issue</th> <th width="38%">What drives its claim here</th></tr></thead>
+<thead>
+<tr style="background-color: #e6ffe6;">
+<th width="36%">Shared Interest</th> <th width="12%">Validity</th> <th width="44%">Compromise direction it opens</th> <th width="8%">Score</th>
+</tr>
+</thead>
 <tbody>
-<tr><td><strong>[Supporter interest]</strong></td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td>&nbsp;</td></tr>
-<tr style="background-color: #f9f9f9;"><td><strong>[Opponent interest]</strong></td><td align="center">&nbsp;</td><td align="center">&nbsp;</td><td>&nbsp;</td></tr>
+<tr>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
 </tbody>
 </table>
-<h2>&nbsp;</h2>
-<h2>&#127917; <a href="/Obstacles%20to%20Resolution">Advertised vs. Actual Motivations</a></h2>
+<h3>⚔ Primary Conflict Pair <span style="font-size: 12px; color: #555;">(the ranking difference that drives this debate)</span></h3>
+<p style="font-size: 13px;"><strong>Primary pair:</strong> [Supporter interest] vs [Opponent interest]. Standalone Validity (how legitimate the interest is in general) and Claim Strength (how much it supports this position) are different numbers; conflating them is a scoring error.</p>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="25%">&nbsp;</th> <th width="37%">Supporters</th> <th width="38%">Opponents</th></tr></thead>
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="26%">Interest in the pair</th> <th width="18%">Standalone Validity</th> <th width="18%">Claim strength on THIS issue</th> <th width="38%">What drives its claim here</th>
+</tr>
+</thead>
 <tbody>
-<tr><td style="background-color: #f0f3f6;"><strong>Advertised reason</strong></td><td valign="top">&nbsp;</td><td valign="top">&nbsp;</td></tr>
-<tr><td style="background-color: #f0f3f6;"><strong>Actual driver (if different)</strong></td><td valign="top">&nbsp;</td><td valign="top">&nbsp;</td></tr>
-<tr><td style="background-color: #f0f3f6;"><strong>Evidence for divergence</strong></td><td valign="top">&nbsp;</td><td valign="top">&nbsp;</td></tr>
+<tr>
+<td><strong>[Supporter interest]</strong></td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td>&nbsp;</td>
+</tr>
+<tr style="background-color: #f9f9f9;">
+<td><strong>[Opponent interest]</strong></td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td>&nbsp;</td>
+</tr>
 </tbody>
 </table>
-<h2>&nbsp;</h2>
-<h2>&#9878; Dispute Types</h2>
+<p>&nbsp;</p>
+<h2>🤝 <a href="/w/page/162560439/Compromise">Best Compromise Solutions</a></h2>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="20%">Dispute Type</th> <th width="40%">The Specific Disagreement</th> <th width="40%">Evidence That Would Move Both Sides</th></tr></thead>
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="28%">Shared Premise Both Sides Accept</th> <th width="30%">Proposed Synthesis</th> <th width="28%">Why This Is Difficult</th> <th width="14%">Score (interests satisfied)</th>
+</tr>
+</thead>
 <tbody>
-<tr><td><strong>Empirical</strong></td><td>&nbsp;</td><td>&nbsp;</td></tr>
-<tr style="background-color: #f9f9f9;"><td><strong>Definitional</strong></td><td>&nbsp;</td><td>&nbsp;</td></tr>
-<tr><td><strong>Values</strong></td><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr>
+<td valign="top">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
 </tbody>
 </table>
-<h2>&nbsp;</h2>
-<h2>&#128683; <a href="/Obstacles%20to%20Resolution">Primary Obstacles to Resolution</a></h2>
+<p>&nbsp;</p>
+<h2>🎭 <a href="/Obstacles%20to%20Resolution">Advertised vs. Actual Motivations</a></h2>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">Obstacles for Supporters</th> <th width="50%">Obstacles for Opponents</th></tr></thead>
-<tbody><tr><td valign="top">&nbsp;</td><td valign="top">&nbsp;</td></tr></tbody>
-</table>
-<br />
-<h1>&#127919; <a href="/Objective%20criteria%20scores">Objective Criteria</a></h1>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="35%">Criterion</th> <th width="30%">How to Measure</th> <th width="15%">Current Status</th> <th width="20%">Target</th></tr></thead>
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="25%">&nbsp;</th> <th width="37%">Supporters</th> <th width="38%">Opponents</th>
+</tr>
+</thead>
 <tbody>
-<tr><td>&nbsp;</td><td>&nbsp;</td><td align="center">&nbsp;</td><td align="center">&nbsp;</td></tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Advertised reason</strong></td>
+<td valign="top">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+</tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Actual driver (if different)</strong></td>
+<td valign="top">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+</tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Evidence for divergence</strong></td>
+<td valign="top">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+</tr>
+<tr style="background-color: #f9f9f9;">
+<td style="background-color: #f0f3f6;"><strong>Divergence Score</strong> <span style="font-size: 11px; color: #555;">(performance of the sub-debate that advertised &ne; actual)</span></td>
+<td align="center">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<h2>⚖ Dispute Types</h2>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="18%">Dispute Type</th> <th width="37%">The Specific Disagreement</th> <th width="37%">Evidence That Would Move Both Sides</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Empirical</strong></td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+<tr style="background-color: #f9f9f9;">
+<td><strong>Definitional</strong></td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+<tr>
+<td><strong>Values</strong></td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<h2>🚫 <a href="/Obstacles%20to%20Resolution">Primary Obstacles to Resolution</a></h2>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="42%">Obstacles for Supporters</th> <th width="8%">Score</th> <th width="42%">Obstacles for Opponents</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<h2>⚠ <a href="/w/page/21956934/bias">Biases</a></h2>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="42%">Biases Affecting Supporters</th> <th width="8%">Score</th> <th width="42%">Biases Affecting Opponents</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
 </tbody>
 </table>
 <br />
-<h1>&#128269; Falsifiability Test</h1>
+<h1>📚 <a href="/w/page/21958666/media">Media Resources</a></h1>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">Evidence That Would Confirm</th> <th width="50%">Evidence That Would Falsify</th></tr></thead>
-<tbody><tr><td valign="top"><!-- CONFIRM --></td><td valign="top"><!-- FALSIFY --></td></tr></tbody>
-</table>
-<h2>&nbsp;</h2>
-<h2>&#128302; Testable Predictions</h2>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="45%">Prediction</th> <th width="20%">Timeframe</th> <th width="35%">Verification Method</th></tr></thead>
-<tbody><tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></tbody>
-</table>
-<br />
-<h1>&#128161; <a href="/Assumptions">Foundational Assumptions</a></h1>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">Required to Accept This Belief</th> <th width="50%">Required to Reject This Belief</th></tr></thead>
-<tbody><tr><td valign="top"><!-- ACCEPT --></td><td valign="top"><!-- REJECT --></td></tr></tbody>
-</table>
-<br />
-<h1>&#9878; <a href="/w/page/156187122/cost-benefit%20analysis">Cost-Benefit Analysis</a></h1>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">Benefits</th> <th width="50%">Costs and Risks</th></tr></thead>
-<tbody><tr><td valign="top">&nbsp;</td><td valign="top">&nbsp;</td></tr></tbody>
-</table>
-<h2>&nbsp;</h2>
-<h2>&#127919; Short vs. Long-Term Impacts</h2>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">Short-Term (0-2 Years)</th> <th width="50%">Long-Term (5+ Years)</th></tr></thead>
-<tbody><tr><td valign="top">&nbsp;</td><td valign="top">&nbsp;</td></tr></tbody>
-</table>
-<h2>&nbsp;</h2>
-<h2>&#129309; <a href="/w/page/162560439/Compromise">Best Compromise Solutions</a></h2>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="33%">Shared Premise Both Sides Accept</th> <th width="34%">Proposed Synthesis</th> <th width="33%">Why This Is Difficult</th></tr></thead>
-<tbody><tr><td valign="top">&nbsp;</td><td valign="top">&nbsp;</td><td valign="top">&nbsp;</td></tr></tbody>
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th style="background-color: #e6ffe6; text-align: center;" colspan="3">Supporting the Belief</th> <th style="background-color: #ffe6e6; text-align: center;" colspan="3">Challenging or Complicating the Belief</th>
+</tr>
+<tr style="background-color: #f0f3f6; font-size: 12px;">
+<th width="30%">Resource (Author, Year)</th> <th width="12%">Type</th> <th width="8%">Score</th> <th width="30%">Resource (Author, Year)</th> <th width="12%">Type</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>&nbsp;</td>
+<td align="center">[Book / Article / Podcast / Film]</td>
+<td align="center">&nbsp;</td>
+<td>&nbsp;</td>
+<td align="center">[Book / Article / Podcast / Film]</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
 </table>
 <br />
-<h1>&#9888; <a href="/w/page/21956934/bias">Biases</a></h1>
+<h1>⚖ <a href="/Local%2C%20federal%2C%20and%20international%20laws%20that%20agree">Legal Framework</a></h1>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">Biases Affecting Supporters</th> <th width="50%">Biases Affecting Opponents</th></tr></thead>
-<tbody><tr><td valign="top"><!-- BIAS_SUP --></td><td valign="top"><!-- BIAS_OPP --></td></tr></tbody>
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="42%">Laws and Frameworks Supporting</th> <th width="8%">Score</th> <th width="42%">Laws and Constraints Complicating</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
 </table>
 <br />
-<h1>&#128218; <a href="/w/page/21958666/media">Media Resources</a></h1>
+<h1>🧮 <a href="/Belief%20Sorting">General to Specific Belief Mapping</a></h1>
+<h3>🔹 Most General (Upstream)</h3>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">Supporting the Belief</th> <th width="50%">Challenging or Complicating the Belief</th></tr></thead>
-<tbody><tr><td valign="top"><strong><a href="/Books">Books</a></strong><br />&nbsp;</td><td valign="top"><strong><a href="/Books">Books</a></strong><br />&nbsp;</td></tr></tbody>
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="42%">Support</th> <th width="8%">Score</th> <th width="42%">Oppose</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+<h3>🔹 More Specific (Downstream)</h3>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="42%">Support</th> <th width="8%">Score</th> <th width="42%">Oppose</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
 </table>
 <br />
-<h1>&#9878; <a href="/Local%2C%20federal%2C%20and%20international%20laws%20that%20agree">Legal Framework</a></h1>
+<h1>🔄 <a href="/combine%20similar%20beliefs">Similar Beliefs</a></h1>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">Laws and Frameworks Supporting</th> <th width="50%">Laws and Constraints Complicating</th></tr></thead>
-<tbody><tr><td valign="top">&nbsp;</td><td valign="top">&nbsp;</td></tr></tbody>
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="42%">More Extreme Versions</th> <th width="8%">Score</th> <th width="42%">More Moderate Versions</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+<td valign="top">&nbsp;</td>
+<td align="center">&nbsp;</td>
+</tr>
+</tbody>
 </table>
 <br />
-<h1>&#129518; <a href="/Belief%20Sorting">General to Specific Belief Mapping</a></h1>
-<h3>&#128313; Most General (Upstream)</h3>
+<h1>📖 Definitions</h1>
+<p style="font-size: 13px;">Key terms used in this analysis, defined operationally (how would you measure it?), not philosophically. For ISE-wide definitions, see <a href="/w/page/21957511/Explanation">Explanation</a>.</p>
 <table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">Support</th> <th width="50%">Oppose</th></tr></thead>
-<tbody><tr><td valign="top"><!-- UP_SUP --></td><td valign="top"><!-- UP_OPP --></td></tr></tbody>
-</table>
-<h3>&nbsp;</h3>
-<h3>&#128313; More Specific (Downstream)</h3>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">Support</th> <th width="50%">Oppose</th></tr></thead>
-<tbody><tr><td valign="top"><!-- DOWN_SUP --></td><td valign="top"><!-- DOWN_OPP --></td></tr></tbody>
-</table>
-<br />
-<h1>&#128260; <a href="/combine%20similar%20beliefs">Similar Beliefs</a></h1>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="50%">More Extreme Versions</th> <th width="50%">More Moderate Versions</th></tr></thead>
-<tbody><tr><td valign="top"><!-- EXTREME --></td><td valign="top"><!-- MODERATE --></td></tr></tbody>
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="26%">Term</th> <th width="66%">Definition Used in This Analysis</th> <th width="8%">Score</th>
+</tr>
+</thead>
+<tbody>
+</tbody>
 </table>
 <br />
-<h1>&#128214; Definitions</h1>
-<p style="font-size: 13px;">Key terms used in this analysis. For ISE-wide definitions, see <a href="/w/page/21957511/Explanation">Explanation</a>.</p>
-<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
-<thead><tr style="background-color: #f0f3f6;"><th width="30%">Term</th> <th width="70%">Definition Used in This Analysis</th></tr></thead>
-<tbody><!-- DEFS --></tbody>
-</table>
-<br />
-<h1>&#128236; Contribute</h1>
+<h1>📬 Contribute</h1>
 <p>Posted by ~<a href="/w/page/21958819/Myclob">Myclob</a>. <a href="/w/page/160433328/Contact%20Me">Contact me</a> to contribute to the Idea Stock Exchange.</p>
 <p><a href="https://github.com/myklob/ideastockexchange">View the full codebase and technical documentation on GitHub</a> to understand the scoring algorithms, contribute to development, or adapt this system for your own use.</p>
 </div>
+<p>&nbsp;</p>

--- a/tests/unit/features/belief-analysis/ranking.test.ts
+++ b/tests/unit/features/belief-analysis/ranking.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import {
+  byScoreDesc,
+  rankByScore,
+  pairBySide,
+  TABLE_TOP_LIMIT,
+} from '@/features/belief-analysis/lib/ranking'
+
+interface Row {
+  id: number
+  score: number | null
+}
+
+const row = (id: number, score: number | null): Row => ({ id, score })
+
+describe('byScoreDesc', () => {
+  it('sorts highest score first', () => {
+    const rows = [row(1, 10), row(2, 90), row(3, 40)]
+    const sorted = [...rows].sort(byScoreDesc(r => r.score))
+    expect(sorted.map(r => r.id)).toEqual([2, 3, 1])
+  })
+
+  it('puts unscored rows last, preserving their relative order', () => {
+    const rows = [row(1, null), row(2, 5), row(3, null), row(4, 80)]
+    const sorted = [...rows].sort(byScoreDesc(r => r.score))
+    expect(sorted.map(r => r.id)).toEqual([4, 2, 1, 3])
+  })
+
+  it('is stable for equal scores', () => {
+    const rows = [row(1, 50), row(2, 50), row(3, 50)]
+    const sorted = [...rows].sort(byScoreDesc(r => r.score))
+    expect(sorted.map(r => r.id)).toEqual([1, 2, 3])
+  })
+})
+
+describe('rankByScore', () => {
+  it('splits at the default limit with the top rows best-first', () => {
+    const rows = Array.from({ length: 8 }, (_, i) => row(i, i * 10))
+    const { top, rest } = rankByScore(rows, r => r.score)
+    expect(top).toHaveLength(TABLE_TOP_LIMIT)
+    expect(top[0].score).toBe(70)
+    expect(rest).toHaveLength(8 - TABLE_TOP_LIMIT)
+    expect(rest[rest.length - 1].score).toBe(0)
+  })
+
+  it('returns everything in top when under the limit', () => {
+    const { top, rest } = rankByScore([row(1, 1), row(2, 2)], r => r.score)
+    expect(top.map(r => r.id)).toEqual([2, 1])
+    expect(rest).toHaveLength(0)
+  })
+
+  it('respects a custom limit', () => {
+    const rows = [row(1, 3), row(2, 2), row(3, 1)]
+    const { top, rest } = rankByScore(rows, r => r.score, 1)
+    expect(top.map(r => r.id)).toEqual([1])
+    expect(rest.map(r => r.id)).toEqual([2, 3])
+  })
+
+  it('does not mutate the input array', () => {
+    const rows = [row(1, 1), row(2, 2)]
+    rankByScore(rows, r => r.score)
+    expect(rows.map(r => r.id)).toEqual([1, 2])
+  })
+})
+
+describe('pairBySide', () => {
+  it('pairs rows index-by-index and pads the shorter side with null', () => {
+    const pairs = pairBySide([row(1, 9), row(2, 5)], [row(3, 7)])
+    expect(pairs).toHaveLength(2)
+    expect(pairs[0]).toEqual([row(1, 9), row(3, 7)])
+    expect(pairs[1]).toEqual([row(2, 5), null])
+  })
+
+  it('returns empty for two empty sides', () => {
+    expect(pairBySide([], [])).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

Implements the new belief-page template's data contract: every table on a belief page now models its rows as **scored relationships** between the belief and the content item, sorted with the highest-scoring content at the top, showing the top few rows and collapsing the rest until expanded. Nothing is placed by editorial choice — a row's position traces to its relationship score.

## Data model (`prisma/schema.prisma` + migration)

- **Nullable `score` added to every per-row table model** that lacked one: `ValueRanking`, `InterestEntry`, `SharedInterest`, `DisputeType`, `Assumption`, `Compromise`, `Obstacle`, `BiasEntry`, `LegalEntry`, `BeliefMapping`, `Definition`, `TestablePrediction`. Null renders blank per Rule 6.
- **New row models** for tables that previously only had free-text or no home:
  - `FalsifiabilityItem` — scored strengthen/weaken score-movers
  - `ComponentClaim` — Logical Anatomy rows (type, stated/implied, load-bearing flag)
  - `CostBenefitItem` — benefit/cost claims with Category (Units), Magnitude, Likelihood, and `expectedValue = magnitude × likelihood` as the rank key, optionally linked to the claim's own belief page
  - `ImpactEntry` — scored Short vs. Long-Term impact rows
- `ValuesAnalysis` gains per-side **Divergence Scores** (advertised ≠ actual); `ObjectiveCriteria` gains strengthen/weaken **readings**; `TestablePrediction` gains `followsIf` and `resultSoFar`; `Belief` gains Scorecard fields (`bottomLine`, `scoreMover`) and `logicalForm`.

## Ranking behavior

- `fetch-belief.ts` orders **every relation by its relationship score descending, nulls last** (media by impact score, similar beliefs by equivalency score, cost/benefit rows by expected value) so unscored placeholders never bury real scores.
- New `lib/ranking.ts` helpers (`rankByScore`, `byScoreDesc`, `pairBySide`, `formatScore`) + unit tests.
- New `ExpandableRows` client component: each table renders its top 5 rows and collapses the rest behind a "Show N more lower-scoring rows" toggle.

## Page sections

- New **Scorecard** readout: Net Belief Score, Bottom line, Strongest pro/con (the top-ranked argument from each side), and What would move this score most (falls back to the top falsifiability score-mover), plus the "How to read this page" box.
- Argument Trees gain the **Imp** (Importance) column; Falsifiability Test and Testable Predictions become scored row tables; Assumptions section becomes **Logical Anatomy & Foundational Assumptions**; Cost-Benefit becomes row-based with per-category subtotals; Score columns added to values rankings, shared interests, dispute types, obstacles, biases, media, legal, mappings, similar beliefs, and definitions — all symmetric per Rule 7 and backward-compatible with `/product-reviews/[slug]` and the bespoke belief route.

## Docs kept in sync

- `docs/BELIEF_PAGE_RULES.md`: new **Rule 8 — Every Table Ranks by Relationship Score**, updated canonical section order and checklist.
- `templates/belief-analysis-template.html`: replaced with the new wiki template (Scorecard, Score columns everywhere, Logical Anatomy, row-based CBA).
- `CLAUDE.md`: fixed stale section-layout notes.

## Verification

- `npx tsc --noEmit` — 0 errors repo-wide
- `npx eslint` on all touched files — clean
- `npm test` — 206/206 passing (including 9 new ranking tests)
- Seeded dev DB and rendered `/beliefs/universal-basic-income-should-be-implemented` — HTTP 200 with all new sections present, no runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NrE26SrTeZmRk25kaJ5An

---
_Generated by [Claude Code](https://claude.ai/code/session_013NrE26SrTeZmRk25kaJ5An)_