### PR TITLE
Sweep the linkage page to the plain-words template revision

### DIFF
--- a/prisma/seed-linkage-example.ts
+++ b/prisma/seed-linkage-example.ts
@@ -44,36 +44,36 @@ async function main() {
         create: [
           {
             side: 'agree',
-            pattern: 'Mechanism: X causes Y through a named pathway',
+            pattern: 'Mechanism',
             statement:
-              'Cash floors directly remove the failure mode Y predicts UBI fixes: income falling below subsistence between jobs.',
+              'X leads to Y through a named pathway: cash floors directly remove the failure mode Y predicts UBI fixes, income falling below subsistence between jobs.',
             strength: 0.8,
             score: 62,
             sortOrder: 0,
           },
           {
             side: 'agree',
-            pattern: 'Scope fit: X’s domain matches Y’s domain',
+            pattern: 'Scope fit',
             statement:
-              'The pilot populations span employed, unemployed, and gig workers — the same populations the policy targets.',
+              'X and Y cover the same people: the pilot populations span employed, unemployed, and gig workers, the same populations the policy targets.',
             strength: 0.6,
             score: 41,
             sortOrder: 1,
           },
           {
             side: 'disagree',
-            pattern: 'Scope or scale mismatch',
+            pattern: 'Scope mismatch',
             statement:
-              'Pilots are temporary and non-universal; labor-supply responses to a permanent universal payment can differ in kind, not just degree.',
+              'X is about temporary, non-universal payments; labor-supply responses to a permanent universal payment can differ in kind, not just degree.',
             strength: 0.7,
             score: 55,
             sortOrder: 0,
           },
           {
             side: 'disagree',
-            pattern: 'Missing intermediate step',
+            pattern: 'Missing step',
             statement:
-              'Scaling from pilot to national program assumes financing effects (taxes or inflation) leave the measured benefits intact.',
+              'X only reaches Y if financing effects (taxes or inflation) leave the measured benefits intact. Without that step, pilot results do not get there.',
             strength: 0.5,
             score: 38,
             sortOrder: 1,

--- a/src/app/algorithms/linkage-scores/page.tsx
+++ b/src/app/algorithms/linkage-scores/page.tsx
@@ -291,7 +291,7 @@ export default function LinkageScoresPage() {
           <tbody>
             <tr>
               <td className="border border-gray-300 px-3 py-2 align-top">
-                <strong>Parent-mechanism mismatch</strong> (the Schiltz case)
+                <strong>Wrong parent</strong> (the Schiltz case)
               </td>
               <td className="border border-gray-300 px-3 py-2 align-top">
                 Chief Judge Schiltz, January 2026: ICE violated 96 court orders in 74 cases.

--- a/src/app/arguments/[id]/linkage/page.tsx
+++ b/src/app/arguments/[id]/linkage/page.tsx
@@ -1,7 +1,11 @@
 /**
- * Linkage Page — scores one edge of the argument graph: the bridge from X
- * (an argument or piece of evidence) to Y (the claim it was placed under).
- * Never the truth of X or Y themselves.
+ * Linkage Page — scores one linkage: whether X (an argument or piece of
+ * evidence) supports or weakens Y (the claim it was placed under). Never
+ * whether X or Y is true on its own.
+ *
+ * The page title IS the linkage question, in full words — no arrow notation
+ * anywhere reader-facing. The question is asked at full strength ("would it
+ * necessarily support Y?") and the Linkage Score is the answer as a degree.
  *
  * Every linkage score badge on belief pages links here. A dedicated page like
  * this exists because the connection is contested or load-bearing; routine
@@ -80,20 +84,20 @@ function FormulaBreakdown({
   depth: number
 }) {
   const attenuated = applyDepthAttenuation(score, depth)
-  const A = proWeight.toFixed(3)
-  const D = conWeight.toFixed(3)
+  const agree = proWeight.toFixed(3)
+  const disagree = conWeight.toFixed(3)
   const S = score.toFixed(3)
   const Att = attenuated.toFixed(3)
 
   return (
     <div className="bg-gray-50 border border-gray-200 rounded p-4 my-4 text-sm font-mono">
       <p className="text-gray-500 mb-1 font-sans text-xs uppercase tracking-wide">
-        Linkage Score formula: (A − D) / (A + D)
+        Linkage Score = (Agree total − Disagree total) / (Agree total + Disagree total)
       </p>
-      <p>A (supporting weight) = {A}</p>
-      <p>D (opposing weight) = {D}</p>
+      <p>Agree total = {agree}</p>
+      <p>Disagree total = {disagree}</p>
       <p>
-        LS = ({A} − {D}) / ({A} + {D}) ={' '}
+        Linkage Score = ({agree} − {disagree}) / ({agree} + {disagree}) ={' '}
         <strong className="text-blue-800">{S}</strong>
       </p>
       {depth > 0 && (
@@ -105,6 +109,24 @@ function FormulaBreakdown({
       )}
     </div>
   )
+}
+
+/**
+ * Render-time alias for pattern names stored under their pre-July-2026
+ * labels, so old rows display the current plain-words canon.
+ */
+const PATTERN_RENAMES: Record<string, string> = {
+  'Parent-mechanism mismatch': 'Wrong parent',
+  'Missing intermediate step': 'Missing step',
+  'Scope or scale mismatch': 'Scope mismatch',
+}
+
+function patternName(pattern: string | null): string | null {
+  if (!pattern) return null
+  // Older seeds stored the pattern with an inline description ("Mechanism: X
+  // causes Y through a named pathway") — keep only the name before the colon.
+  const short = pattern.split(':')[0].trim()
+  return PATTERN_RENAMES[short] ?? short
 }
 
 // ─── Rephrasings table ──────────────────────────────────────────────────────
@@ -316,7 +338,7 @@ function TwoSidedScoredTable({ leftHeader, rightHeader, left, right }: {
 
 const FAILURE_MODE_PATTERNS = [
   {
-    mode: 'Parent-mechanism mismatch',
+    mode: 'Wrong parent',
     x: '[Real, well-documented X showing actor A violating constraint type 1]',
     y: '[Y claiming actor A violates constraint type 2]',
     why: '[X and Y run through different mechanisms and belong under different parents. The fluent reading is misleading; the correct parent for X is the type-1 claim.]',
@@ -334,9 +356,9 @@ const FAILURE_MODE_PATTERNS = [
     why: '[Extrapolation requires an unstated similarity assumption.]',
   },
   {
-    mode: 'Missing intermediate step',
+    mode: 'Missing step',
     x: '[X]',
-    y: '[Y, where the chain X → A → B → Y has uncertain middle links]',
+    y: '[Y, where the chain from X to Y has uncertain middle links]',
     why: '[Each missing step compounds uncertainty. Name the steps.]',
   },
   {
@@ -400,6 +422,7 @@ export default async function LinkagePage({ params }: PageProps) {
 
   const direction = arg.side === 'agree' ? 'Supports' : 'Weakens'
   const directionVerb = arg.side === 'agree' ? 'support' : 'weaken'
+  const directionVerbs = arg.side === 'agree' ? 'supports' : 'weakens'
   const typeLabel = arg.linkageScoreType === 'ECLS'
     ? 'Evidence-to-Conclusion (ECLS)'
     : 'Argument-to-Conclusion (ACLS)'
@@ -421,8 +444,7 @@ export default async function LinkagePage({ params }: PageProps) {
       <td className={TD}>
         {la ? (
           <>
-            {la.pattern && <strong>{la.pattern}</strong>}
-            {la.pattern && <br />}
+            {la.pattern && <strong>{patternName(la.pattern)}: </strong>}
             {la.statement}
           </>
         ) : (
@@ -442,23 +464,24 @@ export default async function LinkagePage({ params }: PageProps) {
           <span className="text-gray-400">/</span>
           <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">Linkage Scores</Link>
           <span className="text-gray-400">/</span>
-          <span className="text-gray-500 truncate max-w-[340px]">{xLabel} → {arg.parentBelief.statement}</span>
+          <span className="text-gray-500 truncate max-w-[340px]">This Linkage</span>
         </div>
       </nav>
 
       <main className="max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]">
+        {/* The title IS the linkage question, in full words — never arrow
+            notation. Asked at full strength; the score answers by degree. */}
         <h1 className="text-2xl font-bold leading-tight mb-4">
-          Linkage: {xLabel} → {arg.parentBelief.statement}
+          If {xLabel} were true, would it necessarily {directionVerb}{' '}
+          {arg.parentBelief.statement}?
         </h1>
 
-        {/* Linkage proposition — a degree question, not a deductive test */}
-        <div className="bg-[#f7f9fb] border border-[#b0b8c1] border-l-4 border-l-[#2c5282] px-5 py-4 mb-4">
-          <div className="text-xs text-[#555] uppercase tracking-wider mb-1.5">Linkage proposition</div>
-          <div className="text-base leading-6">
-            If <strong>{xLabel}</strong> were true, how strongly would it{' '}
-            <strong>{directionVerb}</strong>{' '}
-            <strong>{arg.parentBelief.statement}</strong>?
-          </div>
+        <div className="bg-[#f7f9fb] border border-[#b0b8c1] border-l-4 border-l-[#2c5282] px-4 py-3 mb-4 text-sm">
+          That is the only question on this page. The <strong>Linkage Score</strong> is the answer,
+          as a degree: <strong>1.0</strong> means yes, Y must move if X is true. <strong>0</strong>{' '}
+          means no, X can be completely true and Y doesn&apos;t budge. Anything in between means
+          yes, but only if the assumptions named below hold. This page never debates whether X or Y
+          is true; each has its own page for that.
         </div>
 
         <div className="text-sm space-y-1 mb-3">
@@ -508,27 +531,29 @@ export default async function LinkagePage({ params }: PageProps) {
 
         <p className="text-xs text-[#777] mb-8">
           A dedicated page like this exists because the connection is contested or load-bearing;
-          routine linkages live as rows on the belief page. Every score is computed by{' '}
+          routine linkages live as rows on the belief page, and every Linkage cell there links to
+          its linkage page. Every score is computed by{' '}
           <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">ReasonRank</Link>{' '}
-          from the tables below, and every table ranks by its score column.
+          from the tables below; every table ranks by its score column, and each table shows its
+          top five rows and collapses the rest.
         </p>
 
         {/* ── 🔗 Linkage Arguments ─────────────────────────────────── */}
         <section className="mb-10">
           <h2 className="text-xl font-bold mb-2">🔗 Linkage Arguments</h2>
           <p className="text-sm text-[var(--muted-foreground)] mb-3">
-            Each argument below tests the bridge between X and Y, not the truth of X or Y. Reasons
-            to agree explain why the connection is direct, necessary, or unavoidable. Reasons to
-            disagree explain why the connection breaks: missing steps, mismatched scope, alternative
-            explanations, or the True But Irrelevant pattern. Rows enter and rank by their own scores.
+            Every reason below is about whether X {directionVerbs} Y, not about whether X or Y is
+            true. A claim that X is false belongs on X&apos;s page; a claim that Y is false belongs
+            on Y&apos;s page. Each cell must read as a complete statement that makes sense on its
+            own. Rows enter and rank by their own scores.
           </p>
           <div className="overflow-x-auto">
             <table className="w-full border-collapse border border-gray-300 text-sm">
               <thead>
                 <tr>
-                  <th className={`${TH} w-[42%] bg-green-100`}>✅ Reasons the linkage is strong</th>
+                  <th className={`${TH} w-[42%] bg-green-100`}>✅ Reasons to agree that X {directionVerbs} Y</th>
                   <th className={`${TH} w-[8%] text-center bg-green-50`}>Score</th>
-                  <th className={`${TH} w-[42%] bg-red-100`}>❌ Reasons the linkage is weak</th>
+                  <th className={`${TH} w-[42%] bg-red-100`}>❌ Reasons to disagree that X {directionVerbs} Y</th>
                   <th className={`${TH} w-[8%] text-center bg-red-50`}>Score</th>
                 </tr>
               </thead>
@@ -568,7 +593,9 @@ export default async function LinkagePage({ params }: PageProps) {
           />
           <p className="text-sm text-[var(--muted-foreground)] italic">
             Linkage arguments are scored by the same recursive engine as belief arguments. Each row
-            has its own argument score; the linkage score for this page is the net aggregate. See{' '}
+            has its own argument score; the Linkage Score for this page is the net aggregate of the
+            two sides, (Agree total minus Disagree total) divided by (Agree total plus Disagree
+            total), computed by the engine. The engine docs are canonical for the math. See{' '}
             <Link href="/Argument%20scores%20from%20sub-argument%20scores" className="text-[var(--accent)] hover:underline">
               Argument Scores from Sub-Argument Scores
             </Link>.
@@ -603,9 +630,12 @@ export default async function LinkagePage({ params }: PageProps) {
             rows={yRephrasings}
           />
           <p className="text-sm text-[#555]">
-            <strong>Drift</strong> is the difference between the linkage score under the rephrased
-            version and the canonical version. High drift means the linkage depends on specific
-            wording. Low drift means the linkage survives translation, which is what we want.
+            <strong>Drift</strong> is signed and computed by the engine: the linkage score under
+            the rephrased version minus the canonical linkage score. Negative drift means the
+            linkage weakens under that phrasing; positive drift means it strengthens, which is
+            common when a scope-narrowed claim links more tightly than the broad original. High
+            drift in either direction means the linkage depends on specific wording. Low drift
+            means the linkage survives translation, which is what we want.
           </p>
         </section>
 
@@ -638,11 +668,11 @@ export default async function LinkagePage({ params }: PageProps) {
               </tr>
               <tr>
                 <td className={`${TDC} font-bold`}>3</td>
-                <td className={TD}>Mechanism by which X {arg.side === 'agree' ? 'supports' : 'weakens'} Y, in one sentence</td>
+                <td className={TD}>How X {directionVerbs} Y, in one sentence</td>
                 <td className={TD}>
                   {check?.mechanismSentence ?? (
                     <span className="text-[var(--muted-foreground)] italic">
-                      If this sentence cannot be written cleanly, the linkage is probably weak.
+                      If you cannot write this sentence cleanly, X probably doesn&apos;t {directionVerb} Y.
                     </span>
                   )}
                 </td>
@@ -669,8 +699,12 @@ export default async function LinkagePage({ params }: PageProps) {
                 <td className={`${TDC} font-bold`}>5</td>
                 <td className={TD}>Flag if the estimate is below 0.7 (working heuristic)</td>
                 <td className={TD}>
-                  {flagged && (
-                    <strong className="text-red-700">Flagged. </strong>
+                  {check?.provisionalEstimate != null && (
+                    flagged ? (
+                      <strong className="text-red-700">Flagged. </strong>
+                    ) : (
+                      <strong className="text-green-700">Not flagged. </strong>
+                    )
                   )}
                   {check?.flagNote ?? (
                     <span className="text-[var(--muted-foreground)] italic">
@@ -688,9 +722,9 @@ export default async function LinkagePage({ params }: PageProps) {
           <h2 className="text-xl font-bold mb-2">🔍 Failure Mode Worked Examples</h2>
           <p className="text-sm text-[var(--muted-foreground)] mb-3">
             Linkage failures fall into recognizable patterns. Naming them creates muscle memory:
-            once you have seen a parent-mechanism mismatch dissected, you start spotting them
-            everywhere. The rows below hold examples from this linkage&apos;s own domain. Fully
-            worked examples with real names live on the canonical{' '}
+            once you have seen a wrong-parent case dissected, you start spotting them everywhere.
+            The rows below hold examples from this linkage&apos;s own domain. Fully worked examples
+            with real names live on the canonical{' '}
             <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">Linkage Scores</Link>{' '}
             page, not here, so that one contested illustration never ships inside every linkage page.
           </p>
@@ -708,7 +742,7 @@ export default async function LinkagePage({ params }: PageProps) {
                 {arg.linkageFailureExamples.length > 0
                   ? arg.linkageFailureExamples.map((f, i) => (
                       <tr key={f.id} className={i % 2 === 1 ? 'bg-gray-50' : ''}>
-                        <td className={TD}><strong>{f.failureMode}</strong></td>
+                        <td className={TD}><strong>{patternName(f.failureMode)}</strong></td>
                         <td className={TD}>{f.xText ?? <span>&nbsp;</span>}</td>
                         <td className={TD}>{f.yText ?? <span>&nbsp;</span>}</td>
                         <td className={TD}>{f.whyFails ?? <span>&nbsp;</span>}</td>
@@ -727,16 +761,18 @@ export default async function LinkagePage({ params }: PageProps) {
           </div>
         </section>
 
-        {/* ── 🧭 Beliefs This Linkage Participates In ──────────────── */}
+        {/* ── 🧭 Where Else X and Y Are Used ───────────────────────── */}
         <section className="mb-10">
-          <h2 className="text-xl font-bold mb-2">🧭 Beliefs This Linkage Participates In</h2>
+          <h2 className="text-xl font-bold mb-2">🧭 Where Else X and Y Are Used</h2>
           <p className="text-sm text-[var(--muted-foreground)] mb-3">
-            A linkage is a single edge, but the graph it lives in matters. The tables below show
-            other places X is used to support claims, and other arguments used to support Y. Both
-            tables rank by{' '}
+            A linkage is a single connection, but the graph it lives in matters. The tables below
+            show other places X is used to support claims, and other arguments used to support Y.
+            Both tables rank by{' '}
             <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">argument score</Link>,
-            descending, which counts evidence quality and logical validity. Vote ratio is a
-            secondary view, never the default and never an input to any score.
+            descending, which counts evidence quality and logical validity. Every row is itself a
+            linkage with its own page like this one; each row links to that page, so the graph is
+            navigable in both directions. Vote ratio is a secondary view, never the default and
+            never an input to any score.
           </p>
           <CrossGraphTable
             header="Other claims X is placed under"
@@ -768,9 +804,10 @@ export default async function LinkagePage({ params }: PageProps) {
         <section className="mb-10">
           <h2 className="text-xl font-bold mb-2">📜 Hidden Assumptions Required</h2>
           <p className="text-sm text-[var(--muted-foreground)] mb-3">
-            If the linkage from X to Y is below 1.0, something must be true in addition to X for Y
-            to follow. Naming those assumptions is half the work of evaluating any linkage. Each
-            assumption is itself a claim, scored by its own sub-debate. See{' '}
+            If the Linkage Score is below 1.0, something must be true in addition to X for Y to
+            follow. Naming those assumptions is half the work of evaluating any linkage: they are
+            the exact distance between this linkage and &ldquo;necessarily.&rdquo; Each assumption
+            is itself a claim, scored by its own sub-debate. See{' '}
             <Link href="/algorithms/assumptions" className="text-[var(--accent)] hover:underline">Assumptions</Link>.
           </p>
           <TwoSidedScoredTable
@@ -787,7 +824,7 @@ export default async function LinkagePage({ params }: PageProps) {
           <p className="text-sm text-[var(--muted-foreground)] mb-3">
             Motivated reasoning expresses itself most clearly through linkage placement, not through
             claims themselves. People rarely invent evidence; they place real evidence under
-            conclusions it does not support. Parent-mechanism mismatch is exactly this pattern.
+            conclusions it does not support. The wrong-parent failure mode is exactly this pattern.
             Each bias risk is a claim about this linkage&apos;s editors and evidence, scored like
             any other. See the{' '}
             <Link href="/bias" className="text-[var(--accent)] hover:underline">Bias page</Link>.
@@ -805,8 +842,13 @@ export default async function LinkagePage({ params }: PageProps) {
           <h2 className="text-xl font-bold mb-2">📖 Definitions and Scoring Concepts</h2>
           <div className="text-sm space-y-3">
             <p>
-              <strong>Linkage Score:</strong> How directly X strengthens or weakens Y. Computed as
-              Relevance × Network Strength × Contextual Fit × Uniqueness. See{' '}
+              <strong>The linkage question:</strong> If X were true, would it necessarily support
+              (or weaken) Y? Asked at full strength; answered by degree.
+            </p>
+            <p>
+              <strong>Linkage Score:</strong> The degree to which the answer to the linkage
+              question is yes. Computed as Relevance × Network Strength × Contextual Fit ×
+              Uniqueness. The engine docs are canonical for the math. See{' '}
               <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">Linkage Scores</Link>.
             </p>
             <p>
@@ -827,6 +869,10 @@ export default async function LinkagePage({ params }: PageProps) {
               <strong>Equivalency Score:</strong> How similar two phrasings of the same statement
               are. Used in the rephrasings table to test linkage robustness. See the{' '}
               <Link href="/algorithms/belief-equivalency" className="text-[var(--accent)] hover:underline">Belief Equivalency Engine</Link>.
+            </p>
+            <p>
+              <strong>Drift:</strong> The rephrasing&apos;s linkage score minus the canonical
+              linkage score, computed by the engine. Signed: negative weakens, positive strengthens.
             </p>
             <p>
               <strong>Audit lock:</strong> Linkage scores are computed from sub-arguments, never

--- a/templates/linkage-evaluation-template.html
+++ b/templates/linkage-evaluation-template.html
@@ -1,99 +1,109 @@
 <!-- page=Linkage Evaluation Template -->
 <!-- content-type=text/html -->
 <!--
-  ===== ISE LINKAGE PAGE MASTER TEMPLATE (July 2026 revision) =====
-  Scores one edge of the argument graph: the bridge from X (an argument or
-  piece of evidence) to Y (the claim it was placed under) — never the truth of
-  X or Y themselves. Mirrored by the React implementation in
+  ===== ISE LINKAGE PAGE MASTER TEMPLATE (July 2026, plain-words revision) =====
+  Scores one linkage: whether X (an argument or piece of evidence) supports or
+  weakens Y (the claim it was placed under) — never whether X or Y is true on
+  its own. Mirrored by the React implementation in
   src/app/arguments/[id]/linkage/page.tsx. If you change this template, update
   that page. The two must stay in sync.
 
   HARD RULES (every generation must follow):
-    1. Build a dedicated linkage page only when the connection is contested or
-       load-bearing; routine linkages stay as rows on the belief page.
-    2. The headline proposition asks DEGREE ("how strongly would it support or
-       weaken Y?"), never necessity. Necessity is one of the four pro-linkage
-       argument patterns, not the definition of the question.
-    3. Audit lock: linkage scores are computed from the linkage argument tree,
-       never hand-assigned as final. The Five-Step Check's provisional estimate
-       is a bracketed placement-time author bracket that the computed score
-       supersedes.
-    4. Every table row is a scored claim that ranks by its score; the linkage
-       arguments table carries Score cells like every other scored-family
-       table. Score cells stay [bracketed]/blank until computed.
-    5. Worked failure-mode examples with real names and real politics live
-       once, on the canonical Linkage Scores page (159338766) — never in this
-       template. Pattern rows here stay generic.
-    6. Spell abbreviations out at first use (Evidence-to-Conclusion (ECLS),
+    1. The page title IS the linkage question, written in full words: "If [X]
+       were true, would it necessarily [support / weaken] [Y]?" Never use arrow
+       notation anywhere on the page; no symbols in place of words.
+    2. The question is asked at full strength ("necessarily"); the Linkage
+       Score answers by degree. 1.0 = Y must move if X is true; 0 = X can be
+       completely true and Y doesn't budge; in between = yes, but only if the
+       named assumptions hold.
+    3. Bridge-framing rule: every reason cell is a complete proposition about
+       whether X supports Y, its direction evident from the cell alone. A cell
+       arguing that X or Y is true or false is misfiled and belongs on X's or
+       Y's own page.
+    4. Audit lock: linkage scores are computed from the linkage argument tree,
+       never hand-assigned as final. The Five-Step Check's provisional
+       estimate is a bracketed placement-time author bracket that the computed
+       score supersedes. The 0.7 flag threshold is a working heuristic.
+    5. Every table row ranks by its score, never by editorial placement; the
+       software shows each table's top five rows and collapses the rest.
+       Score cells stay [bracketed]/blank until computed.
+    6. The bold lead-in on each reason row is that row's pattern name (a
+       stored field, not decoration). The four patterns per side are starter
+       scaffolding, not fixed content or fixed order. Current pattern canon:
+       Mechanism / Necessity / Scope fit / Monotonicity vs. Missing step /
+       True But Irrelevant / Scope mismatch / Wrong parent.
+    7. Drift is signed: the rephrasing's linkage minus the canonical linkage.
+    8. Worked failure-mode examples with real names and real politics live
+       once, on the canonical Linkage Scores page — never in this template.
+    9. Spell abbreviations out at first use (Evidence-to-Conclusion (ECLS),
        Argument-to-Conclusion (ACLS)). Underscored [Bracketed_Tokens] are
        machine-replaceable slots.
-    7. The 0.7 flag threshold in the Five-Step Check is a working heuristic,
-       not canon; if it graduates to canon it moves to the engine docs.
 
   SECTION ORDER:
-    Header (breadcrumb / H1 / proposition box / score-type-direction line /
-    X and Y links / contribution / scope note / when-a-page-is-warranted note)
-    1. Linkage Arguments (two-sided, Score columns, four starter patterns/side)
+    Header (breadcrumb "[This Linkage]" / question-as-title H1 / answer-key
+    box / score-type-direction line / X and Y links / contribution / scope
+    note / when-a-page-is-warranted note)
+    1. Linkage Arguments ("Reasons to agree/disagree that X supports Y",
+       Score columns, four starter patterns per side)
     2. Equivalent Rephrasings (X table + Y table: equivalency, linkage under
-       phrasing, drift; low drift = survives translation)
-    3. Five-Step Linkage Check (verbatim Y, verbatim X, mechanism sentence,
-       provisional bracketed estimate + dominant factor, sub-0.7 flag)
+       phrasing, signed drift)
+    3. Five-Step Linkage Check (verbatim Y, verbatim X, how-X-supports-Y
+       sentence, provisional bracketed estimate + dominant factor,
+       Flagged / Not flagged)
     4. Failure Mode Worked Examples (generic pattern rows; real examples live
        on the Linkage Scores hub)
-    5. Beliefs This Linkage Participates In (other Ys for this X; other Xs for
-       this Y; both rank by argument score, vote ratio never the default)
-    6. Hidden Assumptions Required (hold / fail, scored)
+    5. Where Else X and Y Are Used (other Ys for this X; other Xs for this Y;
+       rank by argument score; every row links to its own linkage page)
+    6. Hidden Assumptions Required (hold / fail, scored — the exact distance
+       between this linkage and "necessarily")
     7. Bias Risks Specific to This Linkage (inflate / deflate, scored)
-    8. Definitions and Scoring Concepts (incl. audit lock)
+    8. Definitions and Scoring Concepts (the linkage question, drift, audit lock)
     9. Contribute
 -->
-<p style="text-align: right; font-size: 13px;"><a href="/w/page/21957696/Colorado%20Should">Home</a> &rsaquo; <a href="/w/page/159338766/Linkage%20Scores">Linkage Scores</a> &rsaquo; <strong>[X] &rarr; [Y]</strong></p>
+<p style="text-align: right; font-size: 13px;"><a href="/w/page/21957696/Colorado%20Should">Home</a> &rsaquo; <a href="/w/page/159338766/Linkage%20Scores">Linkage Scores</a> &rsaquo; <strong>[This Linkage]</strong></p>
 <div style="font-family: 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #333;">
-<p style="display: none;">AUTHORING RULES (hidden; readers never see this). This page scores one edge: the bridge from X to Y, never the truth of X or Y themselves. Build a dedicated linkage page only when the connection is contested or load-bearing; routine linkages stay as rows on the belief page. All scores stay [bracketed] until the ReasonRank engine computes them; never fill a score cell for an empty row. Every table row is a scored claim that ranks by its score, never by editorial placement; the numbered pattern rows in the arguments table are starter scaffolding, not fixed content or fixed order. The provisional estimate in the Five-Step Check is an author's bracket that the computed score supersedes; linkage scores are never hand-assigned as final (audit lock). Worked failure-mode examples with real names and real politics live on the canonical Linkage Scores page, never in this template; keep the pattern rows here generic. Underscored [Bracketed_Tokens] are machine-replaceable slots; spell all words out, no abbreviations in column headers.</p>
-<h1>Linkage: [X] &rarr; [Y]</h1>
-<div style="background-color: #f7f9fb; border: 1px solid #b0b8c1; border-left: 4px solid #2c5282; padding: 14px 18px; margin-bottom: 16px;">
-<div style="font-size: 85%; color: #555; text-transform: uppercase; letter-spacing: .5px; margin-bottom: 6px;">Linkage proposition</div>
-<div style="font-size: 110%; line-height: 1.5;">If <strong>[X: short-form argument or evidence statement]</strong> were true, how strongly would it <strong>[support / weaken]</strong> <strong>[Y: short-form claim statement]</strong>?</div>
-</div>
-<p><strong>Linkage Score:</strong> <span style="padding: 2px 10px; background: #e8eef5; border: 1px solid #b0b8c1; font-size: 90%; font-weight: 600;">[0.00&ndash;1.00]</span> &nbsp;|&nbsp; <strong>Type:</strong> <a href="/w/page/159338766/Linkage%20Scores">[Evidence-to-Conclusion (ECLS) / Argument-to-Conclusion (ACLS)]</a> &nbsp;|&nbsp; <strong>Direction:</strong> [Supports / Weakens]<br /><strong>Argument or Evidence X:</strong> [link to X's page once it exists] &mdash; [X full statement]<br /><strong>Claim Y:</strong> [link to Y's page once it exists] &mdash; [Y full statement]<br /><strong>Contribution to Y:</strong> [X argument score] &times; [linkage score] = [computed from <a href="/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">sub-argument scores</a>]<br /><strong>Scope note:</strong> [Optional. Use only when the linkage is easily confused with a different one between similar X and Y.]</p>
-<p style="font-size: 12px; color: #777;">A dedicated page like this exists because the connection is contested or load-bearing; routine linkages live as rows on the belief page. Every bracketed number is a placeholder until <a href="/w/page/159300543/ReasonRank">ReasonRank</a> computes live scores, and every table ranks by its score column.</p>
+<p style="display: none;">AUTHORING RULES (hidden; readers never see this). This page scores one linkage: whether X supports (or weakens) Y, never whether X or Y is true on its own. The page title IS the linkage question, written in full words; never use arrow notation anywhere on the page. The linkage question is asked at full strength: if X were true, would it necessarily [support / weaken] Y? The Linkage Score is the answer as a degree: 1.0 means yes, Y must move if X is true; 0 means no, X's truth leaves Y untouched; in between means yes, but only if the assumptions named on this page hold. BRIDGE-FRAMING RULE: every reason cell is a complete proposition about whether X supports Y, its direction evident from the cell alone; a cell arguing that X or Y is true or false is misfiled and belongs on X's or Y's own page. Build a dedicated linkage page only when the connection is contested or load-bearing; routine linkages stay as rows on the belief page, and each Linkage cell on a belief page links to its linkage page like this one. All scores stay [bracketed] until the ReasonRank engine computes them; never fill a score cell for an empty row. Every table row ranks by its score, never by editorial placement; the software shows each table's top five rows and collapses the rest. The bold lead-in on each reason row is that row's pattern name (a stored field, not decoration); the four patterns per side are starter scaffolding, not fixed content or fixed order. The provisional estimate in the Five-Step Check is an author's bracket that the computed score supersedes; linkage scores are never hand-assigned as final (audit lock). Drift is signed: the rephrasing's linkage minus the canonical linkage. Worked failure-mode examples with real names and real politics live on the canonical Linkage Scores page, never in this template; keep the pattern rows here generic. Underscored [Bracketed_Tokens] are machine-replaceable slots; spell all words out, no abbreviations and no symbols in place of words.</p>
+<h1>If [X: short-form argument or evidence statement] were true, would it necessarily [support / weaken] [Y: short-form claim statement]?</h1>
+<div style="background-color: #f7f9fb; border: 1px solid #b0b8c1; border-left: 4px solid #2c5282; padding: 10px 14px; margin-bottom: 16px; font-size: 13px;">That is the only question on this page. The <strong>Linkage Score</strong> is the answer, as a degree: <strong>1.0</strong> means yes, Y must move if X is true. <strong>0</strong> means no, X can be completely true and Y doesn't budge. Anything in between means yes, but only if the assumptions named below hold. This page never debates whether X or Y is true; each has its own page for that.</div>
+<p><strong>Linkage Score:</strong> <span style="padding: 2px 10px; background: #e8eef5; border: 1px solid #b0b8c1; font-size: 90%; font-weight: 600;">[0.00&ndash;1.00]</span> &nbsp;|&nbsp; <strong>Type:</strong> <a href="/w/page/159338766/Linkage%20Scores">[Evidence-to-Conclusion (ECLS) / Argument-to-Conclusion (ACLS)]</a> &nbsp;|&nbsp; <strong>Direction:</strong> [Supports / Weakens]<br /><strong>Argument or Evidence X:</strong> [link to X's page once it exists] &mdash; [X full statement]<br /><strong>Claim Y:</strong> [link to Y's page once it exists] &mdash; [Y full statement]<br /><strong>Contribution to Y:</strong> [X argument score] &times; [linkage score] = [computed from <a href="/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">sub-argument scores</a>]<br /><strong>Scope note:</strong> [Optional. Use only when this linkage is easily confused with a different one between similar X and Y.]</p>
+<p style="font-size: 12px; color: #777;">A dedicated page like this exists because the connection is contested or load-bearing; routine linkages live as rows on the belief page, and every Linkage cell there links to its linkage page. Every bracketed number is a placeholder until <a href="/w/page/159300543/ReasonRank">ReasonRank</a> computes live scores; every table ranks by its score column, and the software shows each table's top five rows and collapses the rest.</p>
 <p>&nbsp;</p>
 <h1>🔗 Linkage Arguments</h1>
-<p>Each argument below tests the bridge between X and Y, not the truth of X or Y. Reasons to agree explain why the connection is direct, necessary, or unavoidable. Reasons to disagree explain why the connection breaks: missing steps, mismatched scope, alternative explanations, or the True But Irrelevant pattern. The four rows per side are starter patterns; rows enter and rank by their own scores.</p>
+<p>Every reason below is about whether X supports Y, not about whether X or Y is true. A claim that X is false belongs on X's page; a claim that Y is false belongs on Y's page. Each cell must read as a complete statement that makes sense on its own. The four rows per side are starter patterns; rows enter and rank by their own scores.</p>
 <table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="0">
 <thead>
 <tr style="background-color: #f0f3f6;">
-<th style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: left; width: 42%;">✅ Reasons the linkage is strong</th> <th style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center; width: 8%;">Score</th> <th style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: left; width: 42%;">❌ Reasons the linkage is weak</th> <th style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center; width: 8%;">Score</th>
+<th style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: left; width: 42%;">✅ Reasons to agree that X [supports / weakens] Y</th> <th style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center; width: 8%;">Score</th> <th style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: left; width: 42%;">❌ Reasons to disagree that X [supports / weakens] Y</th> <th style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center; width: 8%;">Score</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Mechanism: X causes Y through a named pathway</strong><br /> [1-3 sentences naming the causal or logical mechanism. The bridge from X to Y is direct, with few intermediate steps.]</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Mechanism:</strong> X leads to Y through a named pathway: [state the causal or logical mechanism in 1-3 sentences]. The bridge is direct, with few steps in between.</td>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center;">&nbsp;</td>
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Missing intermediate step</strong><br /> [1-3 sentences identifying what hidden assumption must be true for X to support Y.]</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Missing step:</strong> X only reaches Y if [hidden assumption] is also true. Without that step, X doesn't get there.</td>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center;">&nbsp;</td>
 </tr>
 <tr style="background-color: #fafbfc;">
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Necessity: if X is true, Y must be strengthened</strong><br /> [Explain why no plausible scenario allows X to be true while Y stays unchanged.]</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Necessity:</strong> There is no realistic way for X to be true without Y getting stronger: [explain why every route from X ends at Y].</td>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center;">&nbsp;</td>
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>True But Irrelevant: X is true but does not bear on Y</strong><br /> [Identify why X, even granted as fact, does not move the needle on Y. This is the most common linkage failure mode.]</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>True But Irrelevant:</strong> X can be completely true and Y doesn't budge: [why X has nothing to do with Y]. The most common linkage failure.</td>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center;">&nbsp;</td>
 </tr>
 <tr>
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Scope fit: X's domain matches Y's domain</strong><br /> [Population, timeframe, and context align between X and Y.]</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Scope fit:</strong> X and Y cover the same people, place, and time, so nothing has to be stretched: [show the match].</td>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center;">&nbsp;</td>
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Scope or scale mismatch</strong><br /> [X is from a different population, scale, or time period than Y. Extrapolation fails.]</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Scope mismatch:</strong> X is about a different population, scale, or time than Y. Stretching it across that gap requires an assumption nobody has stated.</td>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center;">&nbsp;</td>
 </tr>
 <tr style="background-color: #fafbfc;">
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Monotonicity: more X means more Y, consistently</strong><br /> [The relationship doesn't reverse direction at any plausible value of X.]</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Monotonicity:</strong> More X consistently means more Y: [the relationship holds across the whole range and never flips].</td>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center;">&nbsp;</td>
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Parent-mechanism mismatch</strong><br /> [X belongs under a different parent claim than Y. The fluent reading is misleading. See Failure Mode Worked Examples below.]</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>Wrong parent:</strong> X really supports a different claim than Y: [name the claim it actually supports]. It sounds like it fits here, but it doesn't. See Failure Mode Worked Examples below.</td>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; text-align: center;">&nbsp;</td>
 </tr>
 </tbody>
 </table>
-<p><em>Linkage arguments are scored by the same recursive engine as belief arguments. Each row above has its own argument score; the linkage score for this page is the net aggregate. See <a href="/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">Argument Scores from Sub-Argument Scores</a>.</em></p>
+<p><em>Linkage arguments are scored by the same recursive engine as belief arguments. Each row above has its own argument score; the Linkage Score for this page is the net aggregate of the two sides, (Agree total minus Disagree total) divided by (Agree total plus Disagree total), computed by the engine. The engine docs are canonical for the math. See <a href="/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">Argument Scores from Sub-Argument Scores</a>.</em></p>
 <p>&nbsp;</p>
 <h1>📝 Equivalent Rephrasings</h1>
 <p>If the same linkage holds across multiple phrasings of X and Y, it is logically robust. If it only holds under one phrasing, the linkage is rhetorical, not logical. Equivalency scores come from the <a href="/w/page/21956921/Beliefs">Belief Equivalency Engine</a>; if a rephrasing produces a substantially different linkage score, the linkage is fragile and that fragility itself is informative.</p>
@@ -201,7 +211,7 @@
 </tr>
 </tbody>
 </table>
-<p style="font-size: 90%; color: #555;"><strong>Drift</strong> is the difference between the linkage score under the rephrased version and the canonical version. High drift means the linkage depends on specific wording. Low drift means the linkage survives translation, which is what we want.</p>
+<p style="font-size: 90%; color: #555;"><strong>Drift</strong> is signed and computed by the engine: the linkage score under the rephrased version minus the canonical linkage score. Negative drift means the linkage weakens under that phrasing; positive drift means it strengthens, which is common when a scope-narrowed claim links more tightly than the broad original. High drift in either direction means the linkage depends on specific wording. Low drift means the linkage survives translation, which is what we want.</p>
 <p>&nbsp;</p>
 <h1>✅ Five-Step Linkage Check</h1>
 <p>Every placement of evidence under a claim, or argument under a parent argument, should pass through these five steps. This forces transparency: a linkage score is only as defensible as the check that produced it. The user-facing forcing function is the prompt "linkage check before placing," which interrupts fluent restructuring and demands an explicit walk-through.</p>
@@ -224,8 +234,8 @@
 </tr>
 <tr>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>3</strong></td>
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;">Mechanism by which X supports Y, in one sentence</td>
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;">[If you cannot write this sentence cleanly, the linkage is probably weak.]</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;">How X supports Y, in one sentence</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;">[If you cannot write this sentence cleanly, X probably doesn't support Y.]</td>
 </tr>
 <tr style="background-color: #fafbfc;">
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>4</strong></td>
@@ -235,13 +245,13 @@
 <tr>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>5</strong></td>
 <td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;">Flag if the estimate is below 0.7 (working heuristic)</td>
-<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;">[If flagged, the action is to find better evidence rather than reach with what is at hand.]</td>
+<td style="border: 1px solid #b0b8c1; padding: 8px 10px; vertical-align: top;"><strong>[Flagged / Not flagged]</strong>. [If flagged, the action is to find better evidence rather than reach with what is at hand.]</td>
 </tr>
 </tbody>
 </table>
 <p>&nbsp;</p>
 <h1>🔍 Failure Mode Worked Examples</h1>
-<p>Linkage failures fall into recognizable patterns. Naming them creates muscle memory: once you have seen a parent-mechanism mismatch dissected, you start spotting them everywhere. The rows below define the pattern shapes; fill them with examples from this linkage's own domain. Fully worked examples with real names live on the canonical <a href="/w/page/159338766/Linkage%20Scores">Linkage Scores</a> page, not in this template, so that one contested illustration never ships inside every page built from it.</p>
+<p>Linkage failures fall into recognizable patterns. Naming them creates muscle memory: once you have seen a wrong-parent case dissected, you start spotting them everywhere. The rows below define the pattern shapes; fill them with examples from this linkage's own domain. Fully worked examples with real names live on the canonical <a href="/w/page/159338766/Linkage%20Scores">Linkage Scores</a> page, not in this template, so that one contested illustration never ships inside every page built from it.</p>
 <table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="0">
 <thead>
 <tr style="background-color: #f0f3f6;">
@@ -250,7 +260,7 @@
 </thead>
 <tbody>
 <tr>
-<td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;"><strong>Parent-mechanism mismatch</strong></td>
+<td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;"><strong>Wrong parent</strong></td>
 <td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;">[Real, well-documented X showing actor A violating constraint type 1]</td>
 <td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;">[Y claiming actor A violates constraint type 2]</td>
 <td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;">[X and Y run through different mechanisms and belong under different parents. The fluent reading is misleading; the correct parent for X is the type-1 claim.]</td>
@@ -268,9 +278,9 @@
 <td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;">[Extrapolation requires an unstated similarity assumption.]</td>
 </tr>
 <tr style="background-color: #fafbfc;">
-<td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;"><strong>Missing intermediate step</strong></td>
+<td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;"><strong>Missing step</strong></td>
 <td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;">[X]</td>
-<td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;">[Y, where the chain X &rarr; A &rarr; B &rarr; Y has uncertain middle links]</td>
+<td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;">[Y, where the chain from X to Y has uncertain middle links]</td>
 <td style="border: 1px solid #b0b8c1; padding: 6px 8px; vertical-align: top;">[Each missing step compounds uncertainty. Name the steps.]</td>
 </tr>
 <tr>
@@ -282,8 +292,8 @@
 </tbody>
 </table>
 <p>&nbsp;</p>
-<h1>🧭 Beliefs This Linkage Participates In</h1>
-<p>A linkage is a single edge, but the graph it lives in matters. The tables below show other places X is used to support claims, and other arguments used to support Y. Both tables rank by <a href="/w/page/159300543/ReasonRank">argument score</a>, descending, which counts evidence quality and logical validity. Vote ratio is a secondary view, never the default and never an input to any score.</p>
+<h1>🧭 Where Else X and Y Are Used</h1>
+<p>A linkage is a single connection, but the graph it lives in matters. The tables below show other places X is used to support claims, and other arguments used to support Y. Both tables rank by <a href="/w/page/159300543/ReasonRank">argument score</a>, descending, which counts evidence quality and logical validity. Every row is itself a linkage with its own page like this one; in the software each row links to that page, so the graph is navigable in both directions. Vote ratio is a secondary view, never the default and never an input to any score.</p>
 <h3>Other claims X is placed under</h3>
 <p><em>Same X, different Y. Useful for spotting whether X is being applied consistently or stretched into places it does not belong.</em></p>
 <table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="0">
@@ -294,7 +304,7 @@
 </thead>
 <tbody>
 <tr>
-<td style="border: 1px solid #b0b8c1; padding: 6px 8px;">[Other Y]</td>
+<td style="border: 1px solid #b0b8c1; padding: 6px 8px;">[Other Y, linked to that linkage's page]</td>
 <td style="border: 1px solid #b0b8c1; padding: 6px 8px;">&nbsp;</td>
 <td style="border: 1px solid #b0b8c1; padding: 6px 8px;">&nbsp;</td>
 </tr>
@@ -320,7 +330,7 @@
 </thead>
 <tbody>
 <tr>
-<td style="border: 1px solid #b0b8c1; padding: 6px 8px;">[Other X]</td>
+<td style="border: 1px solid #b0b8c1; padding: 6px 8px;">[Other X, linked to that linkage's page]</td>
 <td style="border: 1px solid #b0b8c1; padding: 6px 8px;">&nbsp;</td>
 <td style="border: 1px solid #b0b8c1; padding: 6px 8px;">&nbsp;</td>
 </tr>
@@ -338,7 +348,7 @@
 </table>
 <p>&nbsp;</p>
 <h1>📜 Hidden Assumptions Required</h1>
-<p>If the linkage from X to Y is below 1.0, something must be true in addition to X for Y to follow. Naming those assumptions is half the work of evaluating any linkage. Each assumption is itself a claim, scored by its own sub-debate. See the <a href="/Assumptions">Assumptions page</a>.</p>
+<p>If the Linkage Score is below 1.0, something must be true in addition to X for Y to follow. Naming those assumptions is half the work of evaluating any linkage: they are the exact distance between this linkage and "necessarily." Each assumption is itself a claim, scored by its own sub-debate. See the <a href="/Assumptions">Assumptions page</a>.</p>
 <table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="0">
 <thead>
 <tr style="background-color: #f0f3f6;">
@@ -362,7 +372,7 @@
 </table>
 <p>&nbsp;</p>
 <h1>🧠 Bias Risks Specific to This Linkage</h1>
-<p>Motivated reasoning expresses itself most clearly through linkage placement, not through claims themselves. People rarely invent evidence; they place real evidence under conclusions it does not support. Parent-mechanism mismatch is exactly this pattern. Each bias risk is a claim about this linkage's editors and evidence, scored like any other. See the <a href="/w/page/21956934/bias">Bias page</a>.</p>
+<p>Motivated reasoning expresses itself most clearly through linkage placement, not through claims themselves. People rarely invent evidence; they place real evidence under conclusions it does not support. The wrong-parent failure mode is exactly this pattern. Each bias risk is a claim about this linkage's editors and evidence, scored like any other. See the <a href="/w/page/21956934/bias">Bias page</a>.</p>
 <table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="0">
 <thead>
 <tr style="background-color: #f0f3f6;">
@@ -386,10 +396,12 @@
 </table>
 <p>&nbsp;</p>
 <h1>📖 Definitions and Scoring Concepts</h1>
-<p><strong>Linkage Score:</strong> How directly X strengthens or weakens Y. Computed as Relevance &times; Network Strength &times; Contextual Fit &times; Uniqueness. See <a href="/w/page/159338766/Linkage%20Scores">Linkage Scores</a>.</p>
+<p><strong>The linkage question:</strong> If X were true, would it necessarily support (or weaken) Y? Asked at full strength; answered by degree.</p>
+<p><strong>Linkage Score:</strong> The degree to which the answer to the linkage question is yes. Computed as Relevance &times; Network Strength &times; Contextual Fit &times; Uniqueness. The engine docs are canonical for the math. See <a href="/w/page/159338766/Linkage%20Scores">Linkage Scores</a>.</p>
 <p><strong>Evidence-to-Conclusion (ECLS) vs. Argument-to-Conclusion (ACLS):</strong> Evidence-to-Conclusion Linkage connects a study or data point to a conclusion. Argument-to-Conclusion Linkage connects a logical claim to a conclusion. The five-step check applies to both.</p>
 <p><strong>Contribution to parent:</strong> An argument's effect on its parent claim equals Argument Score &times; Linkage Score. A perfect argument with a 0.3 linkage contributes less than a moderate argument with a 0.9 linkage. See <a href="/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">Argument scores from sub-argument scores</a>.</p>
 <p><strong>Equivalency Score:</strong> How similar two phrasings of the same statement are. Used in the rephrasings table to test linkage robustness. See the <a href="/w/page/21956921/Beliefs">Belief Equivalency Engine</a>.</p>
+<p><strong>Drift:</strong> The rephrasing's linkage score minus the canonical linkage score, computed by the engine. Signed: negative weakens, positive strengthens.</p>
 <p><strong>Audit lock:</strong> Linkage scores are computed from sub-arguments, never assigned by hand. The provisional estimate in the Five-Step Check is a placement-time bracket, not a score. If the score on this page changes, the change traces to a specific edit in the linkage argument tree above.</p>
 <p>&nbsp;</p>
 <h1>🔬 Contribute</h1>


### PR DESCRIPTION
## Summary

The wrapper catches up to the plain-language standard set on the wiki side; nothing conceptual changes from #140. Necessity stays as the question, degree stays as the answer, the bridge-framing rule stays. This is exactly the repo follow-up named in the template notes: question-as-title, the degree answer key, "Reasons to agree/disagree that X supports Y" headers, plain-words pattern texts, and the renamed pattern values with a render-time alias for rows stored under the old names.

## Changes to `/arguments/[id]/linkage`

- **The title is now the question.** The H1 reads "If [X] were true, would it necessarily [support/weaken] [Y]?" — full words, no arrow notation anywhere on the page (the breadcrumb reads "This Linkage").
- **Answer-key box** under the title: 1.0 means yes, Y must move; 0 means X can be completely true and Y doesn't budge; in between means yes, but only if the assumptions named below hold — plus the turf sentence (this page never debates whether X or Y is true; each has its own page for that).
- **Column headers are the wiki's own words:** "✅ Reasons to agree that X supports Y" / "❌ Reasons to disagree that X supports Y", direction-aware.
- **Pattern renames with a render-time alias:** "Parent-mechanism mismatch" → **Wrong parent**, "Missing intermediate step" → **Missing step** (plus "Scope or scale mismatch" → **Scope mismatch**). Rows stored under old names — including old colon-suffixed labels — display the new canon; the pattern name renders as the bold lead-in of the row's statement, matching the template's stored-field convention.
- **Section renamed** "Beliefs This Linkage Participates In" → **"Where Else X and Y Are Used"**, with the caption noting every row is itself a linkage whose cell links to its own page.
- **Five-Step Check:** step 3 becomes "How X supports Y, in one sentence" with the plain placeholder; step 5 renders an explicit **Flagged / Not flagged** verdict whenever an estimate exists.
- **Drift is documented as signed** (negative weakens, positive strengthens — common when a scope-narrowed claim links more tightly), in both the rephrasings note and a new **Drift** entry in Definitions; Definitions also gains **The linkage question** ("asked at full strength; answered by degree") and the Linkage Score is defined as the degree to which the answer is yes, with the engine docs canonical for the math.
- **Formula breakdown speaks words:** `(Agree total − Disagree total) / (Agree total + Disagree total)` instead of A/D shorthand, matching the template's spelled-out aggregate sentence.
- Failure-mode scaffolding loses its arrow ("the chain from X to Y has uncertain middle links") and the misfiled-evidence captions now say "the wrong-parent failure mode."

## Kept in sync

- `templates/linkage-evaluation-template.html` replaced with the plain-words revision, maintainer header updated to the nine hard rules (title-is-the-question / no arrows, degree answer key, bridge-framing, audit lock, score-ranked rows with top-five collapse, pattern names as stored fields, signed drift, examples live on the hub, spelled-out abbreviations).
- The hub's Schiltz worked example row renamed to **Wrong parent** (the Schiltz case).
- The seed's pattern values renamed to the short canon with rewritten plain-words statements ("X only reaches Y if financing effects… Without that step, pilot results do not get there.").

## Verification

- `npx tsc --noEmit` — 0 errors repo-wide; eslint clean; `npm test` — 206/206 passing
- Re-seeded and rendered `/arguments/2/linkage` — HTTP 200; the question renders as the H1, the answer-key box, direction-aware agree/disagree headers, "Where Else X and Y Are Used," Missing step rows, the explicit "Flagged." verdict, and **zero arrow characters anywhere in the rendered page**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NrE26SrTeZmRk25kaJ5An

---
_Generated by [Claude Code](https://claude.ai/code/session_013NrE26SrTeZmRk25kaJ5An)_