### PR TITLE
Add the interests and motivation dashboard (ranked hypotheses, unstated candidates, ranked solutions)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
-    "db:seed": "npx tsx prisma/seed-beliefs.ts && npx tsx prisma/seed-belief-distractions.ts && npx tsx prisma/seed-debate-topics.ts && npx tsx prisma/seed-product-reviews.ts && npx tsx prisma/seed-linkage-example.ts",
+    "db:seed": "npx tsx prisma/seed-beliefs.ts && npx tsx prisma/seed-belief-distractions.ts && npx tsx prisma/seed-debate-topics.ts && npx tsx prisma/seed-product-reviews.ts && npx tsx prisma/seed-linkage-example.ts && npx tsx prisma/seed-interests-example.ts",
     "db:seed-reviews": "npx tsx prisma/seed-product-reviews.ts",
     "db:migrate": "npx prisma migrate dev",
     "db:reset": "npx prisma migrate reset --force",

--- a/prisma/migrations/20260704025818_add_interests_motivation_dashboard/migration.sql
+++ b/prisma/migrations/20260704025818_add_interests_motivation_dashboard/migration.sql
@@ -1,0 +1,56 @@
+-- AlterTable
+ALTER TABLE "InterestEntry" ADD COLUMN "linkageAccuracy" REAL;
+ALTER TABLE "InterestEntry" ADD COLUMN "prevalenceScore" REAL;
+ALTER TABLE "InterestEntry" ADD COLUMN "validityScore" REAL;
+
+-- AlterTable
+ALTER TABLE "SharedInterest" ADD COLUMN "validityScore" REAL;
+
+-- CreateTable
+CREATE TABLE "UnstatedInterestCandidate" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "beliefId" INTEGER NOT NULL,
+    "side" TEXT NOT NULL,
+    "interest" TEXT NOT NULL,
+    "behaviorExplained" TEXT NOT NULL,
+    "evidence" TEXT,
+    "score" REAL,
+    "promoted" BOOLEAN NOT NULL DEFAULT false,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "UnstatedInterestCandidate_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "InterestSolution" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "beliefId" INTEGER NOT NULL,
+    "solution" TEXT NOT NULL,
+    "description" TEXT,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "InterestSolution_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "InterestSatisfaction" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "solutionId" INTEGER NOT NULL,
+    "interestId" INTEGER NOT NULL,
+    "satisfaction" REAL NOT NULL DEFAULT 1,
+    CONSTRAINT "InterestSatisfaction_solutionId_fkey" FOREIGN KEY ("solutionId") REFERENCES "InterestSolution" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "InterestSatisfaction_interestId_fkey" FOREIGN KEY ("interestId") REFERENCES "InterestEntry" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "UnstatedInterestCandidate_beliefId_idx" ON "UnstatedInterestCandidate"("beliefId");
+
+-- CreateIndex
+CREATE INDEX "InterestSolution_beliefId_idx" ON "InterestSolution"("beliefId");
+
+-- CreateIndex
+CREATE INDEX "InterestSatisfaction_interestId_idx" ON "InterestSatisfaction"("interestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InterestSatisfaction_solutionId_interestId_key" ON "InterestSatisfaction"("solutionId", "interestId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -277,6 +277,9 @@ model Belief {
   costBenefitItems    CostBenefitItem[]  @relation("BeliefCostBenefitItems")
   impactEntries       ImpactEntry[]
 
+  unstatedInterestCandidates UnstatedInterestCandidate[]
+  interestSolutions          InterestSolution[]
+
   /// Cost/benefit rows on OTHER beliefs whose claim links to this belief's page.
   costBenefitClaimOf  CostBenefitItem[]  @relation("CostBenefitClaimBelief")
 
@@ -667,9 +670,92 @@ model InterestEntry {
   score            Float?
   sortOrder        Int     @default(0)
 
+  /// Interests-and-motivation dashboard: each interest is a competing
+  /// hypothesis about what actually drives its side. Numeric twins of the
+  /// legacy string columns; the dashboard ranks by linkageAccuracy.
+  /// Estimated share of this side actually driven by this interest (0-100).
+  prevalenceScore Float?
+  /// How well this interest explains the side's actual behavior — votes,
+  /// spending, sacrifices, what it tolerates (0-100). Talk is cheap evidence
+  /// of motive; costly action is strong evidence.
+  linkageAccuracy Float?
+  /// How legitimate the interest is, judged by objective criteria, never by
+  /// who holds it or how much power they have (0-100). The Resolution Floor
+  /// admits interests scoring >= 70.
+  validityScore   Float?
+
+  satisfactions InterestSatisfaction[]
+
   createdAt DateTime @default(now())
 
   @@index([beliefId])
+}
+
+/// One hidden-motive hypothesis on the interests dashboard. "Your real reason
+/// is X" is only sayable when X out-predicts the stated interests: each row
+/// must name the specific behavior the stated interests fail to predict,
+/// bring evidence, and take a score — applied with equal suspicion to both
+/// sides. A candidate that earns its score gets promoted into the ranked
+/// interest list.
+model UnstatedInterestCandidate {
+  id       Int    @id @default(autoincrement())
+  beliefId Int
+  belief   Belief @relation(fields: [beliefId], references: [id])
+
+  side     String // "supporter" or "opponent"
+  interest String
+  /// The specific behavior (votes, spending, sacrifices) the side's stated
+  /// interests fail to predict — the gap this hypothesis exists to explain.
+  behaviorExplained String
+  evidence          String?
+  /// Performance of the hypothesis's own pro/con sub-debate. Sorts descending.
+  score     Float?
+  /// True once the hypothesis out-predicts the alternatives and joins the
+  /// ranked interest list (rendered italic there as an unstated interest).
+  promoted  Boolean @default(false)
+  sortOrder Int     @default(0)
+
+  createdAt DateTime @default(now())
+
+  @@index([beliefId])
+}
+
+/// A candidate solution on the interests dashboard, ranked by how well it
+/// satisfies the VALID interests of both sides. Two hard rules: a solution
+/// earns nothing for satisfying an interest that failed validity, and no
+/// interest counts extra because its holders are powerful.
+model InterestSolution {
+  id       Int    @id @default(autoincrement())
+  beliefId Int
+  belief   Belief @relation(fields: [beliefId], references: [id])
+
+  solution    String
+  description String?
+  /// Overall rank: computed from the valid interests satisfied on both sides.
+  score     Float?
+  sortOrder Int    @default(0)
+
+  satisfactions InterestSatisfaction[]
+
+  createdAt DateTime @default(now())
+
+  @@index([beliefId])
+}
+
+/// Maps a solution to one interest it satisfies, per side (the side lives on
+/// the InterestEntry). Satisfaction is the fraction of the interest the
+/// solution actually meets (0-1).
+model InterestSatisfaction {
+  id         Int              @id @default(autoincrement())
+  solutionId Int
+  solution   InterestSolution @relation(fields: [solutionId], references: [id])
+  interestId Int
+  interest   InterestEntry    @relation(fields: [interestId], references: [id])
+
+  satisfaction Float @default(1)
+
+  @@unique([solutionId, interestId])
+  @@index([interestId])
 }
 
 /// One row in the Shared Interests table (foundation for compromise, new template).
@@ -683,6 +769,9 @@ model SharedInterest {
   compromiseDirection String?
   /// Row score: performance of this row's pro/con sub-debate. Sorts descending.
   score              Float?
+  /// Numeric validity (0-100). The Resolution Floor builds solutions on shared
+  /// interests scoring >= 70 on both sides.
+  validityScore      Float?
   sortOrder          Int    @default(0)
 
   createdAt DateTime @default(now())

--- a/prisma/seed-interests-example.ts
+++ b/prisma/seed-interests-example.ts
@@ -1,0 +1,162 @@
+/**
+ * Seeds a fully worked interests-and-motivation dashboard for the UBI belief:
+ * ranked interest hypotheses per side with prevalence / linkage accuracy /
+ * validity, unstated-interest candidates (one promoted), Resolution Floor
+ * validity scores on shared interests, and candidate solutions mapped to the
+ * valid interests they satisfy per side. Idempotent: clears and recreates the
+ * rows it owns.
+ */
+
+import { prisma } from '../src/lib/prisma'
+
+async function main() {
+  const belief = await prisma.belief.findUnique({
+    where: { slug: 'universal-basic-income-should-be-implemented' },
+    select: { id: true },
+  })
+  if (!belief) {
+    console.log('UBI belief not found — run seed-beliefs first. Skipping interests example.')
+    return
+  }
+  const beliefId = belief.id
+
+  await prisma.interestSatisfaction.deleteMany({ where: { solution: { beliefId } } })
+  await prisma.interestSolution.deleteMany({ where: { beliefId } })
+  await prisma.unstatedInterestCandidate.deleteMany({ where: { beliefId } })
+  await prisma.interestEntry.deleteMany({ where: { beliefId } })
+  await prisma.sharedInterest.deleteMany({ where: { beliefId } })
+
+  const mk = (
+    side: string,
+    interest: string,
+    prevalenceScore: number,
+    linkageAccuracy: number,
+    validityScore: number,
+    evidenceBasis: string,
+  ) =>
+    prisma.interestEntry.create({
+      data: { beliefId, side, interest, prevalenceScore, linkageAccuracy, validityScore, evidenceBasis },
+    })
+
+  const [secFloor, dignity, automation, taxBurden, workEthic, targeting] = await Promise.all([
+    mk('supporter', 'Economic security floor for volatile work lives', 55, 78, 88,
+      'Supporters keep backing pilots even when framed as taxpayer costs; gig-work districts overindex in support.'),
+    mk('supporter', 'Dignity: aid without means-testing bureaucracy', 30, 64, 81,
+      'Supporters also back administrative simplification bills that pay them nothing.'),
+    mk('supporter', 'Hedge against automation-driven job loss', 25, 52, 74,
+      'Support correlates with automation exposure, but so does general economic anxiety.'),
+    mk('opponent', 'Keeping the tax burden from growing', 50, 74, 76,
+      'Opposition tracks the financing plan, not the payment: flat opposition to tax-funded versions, softer on dividend-funded.'),
+    mk('opponent', 'Preserving the work-conditional social contract', 40, 66, 72,
+      'Opponents accept equally costly programs when work-conditioned (EITC expansions pass with the same voters).'),
+    mk('opponent', 'Keeping aid targeted at the neediest', 25, 48, 84,
+      'Stated often, but the same voters back universal programs like Social Security — words and votes diverge.'),
+  ])
+
+  await prisma.unstatedInterestCandidate.createMany({
+    data: [
+      {
+        beliefId,
+        side: 'opponent',
+        interest: 'Status anxiety: universal payments erase the earned/unearned distinction',
+        behaviorExplained:
+          'Opposition softens when the same cash is renamed a "dividend" for stakeholders — targeting and cost stay identical, only the status frame changes.',
+        evidence:
+          'Framing experiments show label-driven swings; opposition to equally untargeted but "earned" programs is absent.',
+        score: 58,
+        promoted: true,
+        sortOrder: 0,
+      },
+      {
+        beliefId,
+        side: 'supporter',
+        interest: 'Institutional distrust: bypassing agencies seen as hostile',
+        behaviorExplained:
+          'Supporters oppose expanding the same safety net through existing agencies, which stated interests (security, dignity) predict they would accept.',
+        evidence: 'Survey gap between cash support and equivalent in-kind expansion; distrust of caseworker discretion cited.',
+        score: 44,
+        promoted: false,
+        sortOrder: 1,
+      },
+    ],
+  })
+
+  const [floor1, floor2] = await Promise.all([
+    prisma.sharedInterest.create({
+      data: {
+        beliefId,
+        interest: 'No one who works full-time should live in poverty',
+        validityScore: 86,
+        compromiseDirection: 'Opens income-floor designs both sides can fund: wage subsidies, dividends, or negative income tax.',
+      },
+    }),
+    prisma.sharedInterest.create({
+      data: {
+        beliefId,
+        interest: 'Administrative overhead should not eat aid budgets',
+        validityScore: 78,
+        compromiseDirection: 'Opens simplification: fewer programs, automatic enrollment, cash over vouchers.',
+      },
+    }),
+  ])
+  void floor1
+  void floor2
+
+  await prisma.interestSolution.create({
+    data: {
+      beliefId,
+      solution: 'Negative income tax phased in by pilot results',
+      description: 'A cash floor that tapers with earnings, financed by consolidating overlapping programs.',
+      sortOrder: 0,
+      satisfactions: {
+        create: [
+          { interestId: secFloor.id, satisfaction: 0.9 },
+          { interestId: dignity.id, satisfaction: 0.7 },
+          { interestId: taxBurden.id, satisfaction: 0.6 },
+          { interestId: workEthic.id, satisfaction: 0.8 },
+        ],
+      },
+    },
+  })
+
+  await prisma.interestSolution.create({
+    data: {
+      beliefId,
+      solution: 'Full universal payment at subsistence level',
+      description: 'Unconditional monthly payment to every adult, tax-financed.',
+      sortOrder: 1,
+      satisfactions: {
+        create: [
+          { interestId: secFloor.id, satisfaction: 1 },
+          { interestId: dignity.id, satisfaction: 1 },
+          { interestId: automation.id, satisfaction: 0.9 },
+          { interestId: taxBurden.id, satisfaction: 0.1 },
+        ],
+      },
+    },
+  })
+
+  await prisma.interestSolution.create({
+    data: {
+      beliefId,
+      solution: 'Expand the Earned Income Tax Credit only',
+      description: 'Larger work-conditioned credit, no unconditional payment.',
+      sortOrder: 2,
+      satisfactions: {
+        create: [
+          { interestId: workEthic.id, satisfaction: 0.9 },
+          { interestId: taxBurden.id, satisfaction: 0.7 },
+          { interestId: targeting.id, satisfaction: 0.8 },
+          { interestId: secFloor.id, satisfaction: 0.4 },
+        ],
+      },
+    },
+  })
+
+  console.log(`Seeded interests dashboard for belief #${beliefId}: 6 ranked interests, 2 unstated candidates, 2 floor interests, 3 solutions.`)
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/app/beliefs/[slug]/interests/page.tsx
+++ b/src/app/beliefs/[slug]/interests/page.tsx
@@ -1,0 +1,563 @@
+/**
+ * Interests and Motivation Dashboard — answers four questions, in order:
+ *
+ * 1. What are the most likely interests actually driving each side? A ranked
+ *    list of competing hypotheses per side, not one guess.
+ * 2. Which of those interests explain the real actions — the votes, the
+ *    spending, the sacrifices — and not just the press releases? Interests
+ *    are hypotheses, behavior is the data; the attribution that best predicts
+ *    behavior wins the Linkage Accuracy. Where words and deeds diverge, the
+ *    gap is evidence that an unstated interest is driving, and naming that
+ *    hidden interest is itself a scored claim requiring evidence, applied
+ *    with equal suspicion to both sides.
+ * 3. Of the interests that are real, which are valid? Judged by objective
+ *    criteria, never by who holds them or how much power they have.
+ * 4. The payoff: what solutions satisfy the valid interests of both sides?
+ *    The ranked solutions table is the whole point of the page; everything
+ *    above it is input.
+ *
+ * Route: /beliefs/[slug]/interests
+ */
+
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+import { formatScore, TABLE_TOP_LIMIT } from '@/features/belief-analysis/lib/ranking'
+import {
+  RESOLUTION_FLOOR_VALIDITY,
+  meetsResolutionFloor,
+  rankByLinkageAccuracy,
+  resolutionFloor,
+  scoreSolution,
+} from '@/features/belief-analysis/lib/interests'
+import ExpandableRows from '@/features/belief-analysis/components/ExpandableRows'
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+function pct(value: number | null | undefined): string | null {
+  if (value == null) return null
+  return `${Math.round(value)}%`
+}
+
+function lines(text: string | null | undefined): React.ReactNode {
+  if (!text) return <span>&nbsp;</span>
+  return text.split('\n').map((l, i) => <span key={i}>{l}<br /></span>)
+}
+
+interface InterestRow {
+  id: number
+  interest: string
+  prevalence: string | null
+  validity: string | null
+  prevalenceScore: number | null
+  linkageAccuracy: number | null
+  validityScore: number | null
+}
+
+interface PromotedRow {
+  id: number
+  interest: string
+  score: number | null
+}
+
+function InterestTable({ rows, promotedRows, headerClass }: {
+  rows: InterestRow[]
+  promotedRows: PromotedRow[]
+  headerClass: string
+}) {
+  const top = rows.slice(0, TABLE_TOP_LIMIT)
+  const rest = rows.slice(TABLE_TOP_LIMIT)
+  return (
+    <table className="w-full border-collapse border border-gray-300 text-sm">
+      <thead>
+        <tr>
+          <th className={`${TH} w-[46%] ${headerClass}`}>Interest (a hypothesis about what drives this side)</th>
+          <th className={`${TH} w-[18%] text-center ${headerClass}`}>Prevalence</th>
+          <th className={`${TH} w-[18%] text-center ${headerClass}`}>Linkage Accuracy</th>
+          <th className={`${TH} w-[18%] text-center ${headerClass}`}>Validity</th>
+        </tr>
+      </thead>
+      <tbody>
+        {(top.length > 0 ? top : [null]).map((row, i) => (
+          <tr key={row?.id ?? i}>
+            <td className={TD}>{row?.interest ?? <span>&nbsp;</span>}</td>
+            <td className={`${TDC} font-mono`}>{pct(row?.prevalenceScore) ?? row?.prevalence ?? <span>&nbsp;</span>}</td>
+            <td className={`${TDC} font-mono`}>{formatScore(row?.linkageAccuracy) ?? <span>&nbsp;</span>}</td>
+            <td className={`${TDC} font-mono`}>{formatScore(row?.validityScore) ?? row?.validity ?? <span>&nbsp;</span>}</td>
+          </tr>
+        ))}
+        <ExpandableRows moreCount={rest.length} colSpan={4}>
+          {rest.map(row => (
+            <tr key={row.id}>
+              <td className={TD}>{row.interest}</td>
+              <td className={`${TDC} font-mono`}>{pct(row.prevalenceScore) ?? row.prevalence ?? <span>&nbsp;</span>}</td>
+              <td className={`${TDC} font-mono`}>{formatScore(row.linkageAccuracy) ?? <span>&nbsp;</span>}</td>
+              <td className={`${TDC} font-mono`}>{formatScore(row.validityScore) ?? row.validity ?? <span>&nbsp;</span>}</td>
+            </tr>
+          ))}
+        </ExpandableRows>
+        {promotedRows.map(c => (
+          <tr key={`u${c.id}`} className="bg-gray-50 italic">
+            <td className={TD}>
+              {c.interest}{' '}
+              <span className="text-xs text-[#555] not-italic">(unstated — promoted from the candidates table below)</span>
+            </td>
+            <td className={TDC}>&nbsp;</td>
+            <td className={`${TDC} font-mono`}>{formatScore(c.score) ?? <span>&nbsp;</span>}</td>
+            <td className={TDC}>&nbsp;</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export default async function InterestsDashboardPage({ params }: PageProps) {
+  const { slug } = await params
+  const belief = await prisma.belief.findUnique({
+    where: { slug: decodeURIComponent(slug) },
+    include: {
+      interestEntries: true,
+      interestsAnalysis: true,
+      valuesAnalysis: true,
+      sharedInterests: { orderBy: [{ validityScore: { sort: 'desc', nulls: 'last' } }, { sortOrder: 'asc' }] },
+      unstatedInterestCandidates: {
+        orderBy: [{ score: { sort: 'desc', nulls: 'last' } }, { sortOrder: 'asc' }],
+      },
+      interestSolutions: {
+        include: { satisfactions: { include: { interest: true } } },
+        orderBy: { sortOrder: 'asc' },
+      },
+    },
+  })
+
+  if (!belief) notFound()
+
+  const interests = belief.interestEntries
+  const supporters = rankByLinkageAccuracy(interests.filter(i => i.side === 'supporter' && !i.pretextual))
+  const opponents = rankByLinkageAccuracy(interests.filter(i => i.side === 'opponent' && !i.pretextual))
+
+  const candidates = belief.unstatedInterestCandidates
+  const promoted = candidates.filter(c => c.promoted)
+
+  // The payoff table: rank candidate solutions by how well they satisfy the
+  // valid interests of both sides. Computed live from the satisfactions; the
+  // stored score is only a fallback for solutions with no mapped interests.
+  const solutions = belief.interestSolutions
+    .map(s => {
+      const breakdown = scoreSolution(
+        s.satisfactions.map(sat => ({ satisfaction: sat.satisfaction, interest: sat.interest }))
+      )
+      const supporterNames = s.satisfactions
+        .filter(sat => sat.interest.side === 'supporter' && meetsResolutionFloor(sat.interest.validityScore))
+        .map(sat => sat.interest.interest)
+      const opponentNames = s.satisfactions
+        .filter(sat => sat.interest.side === 'opponent' && meetsResolutionFloor(sat.interest.validityScore))
+        .map(sat => sat.interest.interest)
+      const rankScore = s.satisfactions.length > 0 ? breakdown.total : (s.score ?? 0)
+      return { ...s, breakdown, supporterNames, opponentNames, rankScore }
+    })
+    .sort((a, b) => b.rankScore - a.rankScore)
+
+  const floor = resolutionFloor(belief.sharedInterests)
+
+  // Conflict Readout: every line is derived from the tables below.
+  const topSupporter = supporters[0] ?? null
+  const topOpponent = opponents[0] ?? null
+  const topCandidate = candidates[0] ?? null
+  const bestSolution = solutions.find(s => s.rankScore > 0) ?? null
+  const ia = belief.interestsAnalysis
+  const va = belief.valuesAnalysis
+
+  const topSolutions = solutions.slice(0, TABLE_TOP_LIMIT)
+  const restSolutions = solutions.slice(TABLE_TOP_LIMIT)
+
+  return (
+    <div className="min-h-screen bg-white">
+      <nav className="bg-white border-b border-gray-200 sticky top-0 z-50">
+        <div className="max-w-[960px] mx-auto px-4 py-3 flex items-center gap-2 text-sm">
+          <Link href="/" className="font-bold text-[var(--foreground)]">ISE</Link>
+          <span className="text-gray-400">/</span>
+          <Link href="/beliefs" className="text-blue-700 hover:underline">Beliefs</Link>
+          <span className="text-gray-400">/</span>
+          <Link href={`/beliefs/${belief.slug}`} className="text-blue-700 hover:underline truncate max-w-[280px]">
+            {belief.statement}
+          </Link>
+          <span className="text-gray-400">/</span>
+          <span className="text-gray-500">Interests and Motivation</span>
+        </div>
+      </nav>
+
+      <main className="max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]">
+        <h1 className="text-2xl font-bold leading-tight mb-4">
+          What actually drives each side of &ldquo;{belief.statement}&rdquo; — and which solutions
+          satisfy the valid interests of both?
+        </h1>
+
+        <div className="bg-[#f7f9fb] border border-[#b0b8c1] border-l-4 border-l-[#2c5282] px-4 py-3 mb-6 text-sm">
+          This page answers four questions, in order. <strong>One:</strong> the most likely
+          interests driving each side — a ranked list of competing hypotheses, not one guess.{' '}
+          <strong>Two:</strong> which interests explain the real actions, not just the press
+          releases. Interests are hypotheses, behavior is the data, and the attribution that best
+          predicts behavior wins the <strong>Linkage Accuracy</strong>: how well an interest
+          explains the group&apos;s votes, spending, sacrifices, and what it tolerates. Talk is
+          cheap evidence of motive; costly action is strong evidence. <strong>Three:</strong> of
+          the interests that are real, which are valid — judged by objective criteria, never by who
+          holds them or how much power they have. <strong>Four, the payoff:</strong> the solutions
+          that satisfy the valid interests of both sides. Positions are what people demand;
+          interests are why. The last table is the whole point of the page; everything above it is
+          input.
+        </div>
+
+        {/* ── Conflict Readout (verdict-first, auto-derived) ────────── */}
+        <section className="mb-10">
+          <h2 className="text-xl font-bold mb-2">📋 Conflict Readout</h2>
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <tbody>
+              <tr>
+                <td className={`${TD} bg-[#f0f3f6] w-1/4 font-semibold`}>Most likely driver, supporters</td>
+                <td className={TD}>
+                  {topSupporter ? (
+                    <>
+                      {topSupporter.interest}
+                      {topSupporter.linkageAccuracy != null && (
+                        <span className="text-xs text-[#555]"> · Linkage Accuracy {formatScore(topSupporter.linkageAccuracy)}</span>
+                      )}
+                    </>
+                  ) : (
+                    <span className="text-[var(--muted-foreground)] italic">[pending — computed from the ranked hypotheses below]</span>
+                  )}
+                </td>
+              </tr>
+              <tr className="bg-gray-50">
+                <td className={`${TD} bg-[#f0f3f6] font-semibold`}>Most likely driver, opponents</td>
+                <td className={TD}>
+                  {topOpponent ? (
+                    <>
+                      {topOpponent.interest}
+                      {topOpponent.linkageAccuracy != null && (
+                        <span className="text-xs text-[#555]"> · Linkage Accuracy {formatScore(topOpponent.linkageAccuracy)}</span>
+                      )}
+                    </>
+                  ) : (
+                    <span className="text-[var(--muted-foreground)] italic">[pending]</span>
+                  )}
+                </td>
+              </tr>
+              <tr>
+                <td className={`${TD} bg-[#f0f3f6] font-semibold`}>Primary conflict pair</td>
+                <td className={TD}>
+                  {ia?.primaryPairSupporter || ia?.primaryPairOpponent ? (
+                    <>{ia?.primaryPairSupporter ?? '[supporter interest]'} vs {ia?.primaryPairOpponent ?? '[opponent interest]'}</>
+                  ) : (
+                    <span className="text-[var(--muted-foreground)] italic">[pending — see the head-to-head below]</span>
+                  )}
+                </td>
+              </tr>
+              <tr className="bg-gray-50">
+                <td className={`${TD} bg-[#f0f3f6] font-semibold`}>Strongest unstated candidate</td>
+                <td className={TD}>
+                  {topCandidate ? (
+                    <>
+                      {topCandidate.interest}{' '}
+                      <span className="text-xs text-[#555]">
+                        ({topCandidate.side}s{topCandidate.score != null && <> · score {formatScore(topCandidate.score)}</>}
+                        {topCandidate.promoted && <> · promoted</>})
+                      </span>
+                    </>
+                  ) : (
+                    <span className="text-[var(--muted-foreground)] italic">[none yet — hypotheses must earn their place below]</span>
+                  )}
+                </td>
+              </tr>
+              <tr>
+                <td className={`${TD} bg-[#f0f3f6] font-semibold`}>Best solution so far</td>
+                <td className={TD}>
+                  {bestSolution ? (
+                    <>
+                      {bestSolution.solution}{' '}
+                      <span className="text-xs text-[#555]">· score {bestSolution.rankScore.toFixed(2)}</span>
+                    </>
+                  ) : (
+                    <span className="text-[var(--muted-foreground)] italic">[pending — ranked in the payoff table below]</span>
+                  )}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        {/* ── 1. Most Likely Interests: ranked competing hypotheses ──── */}
+        <section className="mb-10">
+          <h2 className="text-xl font-bold mb-2">1. Most Likely Interests, Ranked</h2>
+          <p className="text-sm text-[var(--muted-foreground)] mb-3">
+            Multiple interest hypotheses per side, sorted by Linkage Accuracy, so &ldquo;most
+            likely interest&rdquo; is a computed position, not an editor&apos;s pick. Prevalence
+            estimates what share of the side each interest actually drives. Italic rows are
+            unstated interests that earned promotion from the candidates table in section 2.
+          </p>
+          <h3 className="text-base font-semibold mb-2">Supporters</h3>
+          <div className="mb-4">
+            <InterestTable
+              rows={supporters}
+              promotedRows={promoted.filter(c => c.side === 'supporter')}
+              headerClass="bg-green-100"
+            />
+          </div>
+          <h3 className="text-base font-semibold mb-2">Opponents</h3>
+          <InterestTable
+            rows={opponents}
+            promotedRows={promoted.filter(c => c.side === 'opponent')}
+            headerClass="bg-red-100"
+          />
+        </section>
+
+        {/* ── 2. Actions over words ──────────────────────────────────── */}
+        <section className="mb-10">
+          <h2 className="text-xl font-bold mb-2">
+            2. Which Interests Explain Their Actions, Not Just Their Words?
+          </h2>
+
+          <h3 className="text-base font-semibold mb-1">Advertised versus revealed</h3>
+          <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
+            Where words and deeds diverge, the gap is evidence that an unstated interest is doing
+            the driving. A large advertised-versus-revealed gap is the opening evidence for the
+            candidates table below.
+          </p>
+          <table className="w-full border-collapse border border-gray-300 text-sm mb-5">
+            <thead>
+              <tr>
+                <th className={`${TH} w-1/4`}>&nbsp;</th>
+                <th className={`${TH} w-[37%]`}>Supporters</th>
+                <th className={`${TH} w-[38%]`}>Opponents</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className={`${TD} bg-gray-100 font-semibold`}>Advertised reason</td>
+                <td className={TD}>{lines(va?.supportingAdvertised)}</td>
+                <td className={TD}>{lines(va?.opposingAdvertised)}</td>
+              </tr>
+              <tr>
+                <td className={`${TD} bg-gray-100 font-semibold`}>Revealed driver (if different)</td>
+                <td className={TD}>{lines(va?.supportingActual)}</td>
+                <td className={TD}>{lines(va?.opposingActual)}</td>
+              </tr>
+              <tr>
+                <td className={`${TD} bg-gray-100 font-semibold`}>Evidence for the gap</td>
+                <td className={TD}>{lines(va?.supportingDivergenceEvidence)}</td>
+                <td className={TD}>{lines(va?.opposingDivergenceEvidence)}</td>
+              </tr>
+              <tr className="bg-gray-50">
+                <td className={`${TD} bg-gray-100 font-semibold`}>Divergence Score</td>
+                <td className={`${TDC} font-mono`}>{formatScore(va?.supportingDivergenceScore) ?? <span>&nbsp;</span>}</td>
+                <td className={`${TDC} font-mono`}>{formatScore(va?.opposingDivergenceScore) ?? <span>&nbsp;</span>}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h3 className="text-base font-semibold mb-1">Candidate unstated interests</h3>
+          <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
+            On the ISE, &ldquo;your real reason is X&rdquo; is only sayable when X out-predicts the
+            alternatives. Each hidden-motive hypothesis must name the specific behavior the stated
+            interests fail to predict, bring evidence, and take a score — applied with equal
+            suspicion to both sides. A candidate that earns its score is promoted into the ranked
+            list in section 1.
+          </p>
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr>
+                <th className={`${TH} w-[10%]`}>Side</th>
+                <th className={`${TH} w-[22%]`}>Candidate unstated interest</th>
+                <th className={`${TH} w-[26%]`}>Behavior it explains that stated interests do not</th>
+                <th className={`${TH} w-[24%]`}>Evidence</th>
+                <th className={`${TH} w-[8%] text-center`}>Score</th>
+                <th className={`${TH} w-[10%] text-center`}>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(candidates.length > 0 ? candidates : [null]).map((c, i) => (
+                <tr key={c?.id ?? i}>
+                  <td className={`${TDC} capitalize`}>{c ? `${c.side}s` : <span>&nbsp;</span>}</td>
+                  <td className={TD}>{c?.interest ?? <span>&nbsp;</span>}</td>
+                  <td className={TD}>{c?.behaviorExplained ?? <span>&nbsp;</span>}</td>
+                  <td className={TD}>{c?.evidence ?? <span>&nbsp;</span>}</td>
+                  <td className={`${TDC} font-mono`}>{formatScore(c?.score) ?? <span>&nbsp;</span>}</td>
+                  <td className={TDC}>
+                    {c ? (
+                      c.promoted ? <strong className="text-green-700">Promoted</strong> : 'Candidate'
+                    ) : (
+                      <span>&nbsp;</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        {/* ── 3. Validity, firewalled ────────────────────────────────── */}
+        <section className="mb-10">
+          <h2 className="text-xl font-bold mb-2">3. Of the Real Interests, Which Are Valid?</h2>
+          <p className="text-sm text-[var(--muted-foreground)] mb-3">
+            Validity is judged by objective criteria, never by who holds the interest or how much
+            power they have. Standalone Validity (how legitimate the interest is in general) and
+            Claim Strength on this issue are different numbers; conflating them is a scoring error.
+          </p>
+          <h3 className="text-base font-semibold mb-1">
+            Primary conflict pair, head to head
+          </h3>
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr>
+                <th className={`${TH} w-[26%]`}>Interest in the pair</th>
+                <th className={`${TH} w-[18%] text-center`}>Standalone Validity</th>
+                <th className={`${TH} w-[18%] text-center`}>Claim strength on THIS issue</th>
+                <th className={`${TH} w-[38%]`}>What drives its claim here</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className={TD}><strong>{ia?.primaryPairSupporter ?? <span className="text-[var(--muted-foreground)] italic font-normal">[supporter interest]</span>}</strong></td>
+                <td className={`${TDC} font-mono`}>{ia?.primaryPairSupporterValidity ?? <span>&nbsp;</span>}</td>
+                <td className={TDC}>{ia?.primaryPairSupporterClaim ?? <span>&nbsp;</span>}</td>
+                <td className={TD}>{lines(ia?.primaryPairSupporterDrives)}</td>
+              </tr>
+              <tr className="bg-gray-50">
+                <td className={TD}><strong>{ia?.primaryPairOpponent ?? <span className="text-[var(--muted-foreground)] italic font-normal">[opponent interest]</span>}</strong></td>
+                <td className={`${TDC} font-mono`}>{ia?.primaryPairOpponentValidity ?? <span>&nbsp;</span>}</td>
+                <td className={TDC}>{ia?.primaryPairOpponentClaim ?? <span>&nbsp;</span>}</td>
+                <td className={TD}>{lines(ia?.primaryPairOpponentDrives)}</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        {/* ── 4. The payoff: solutions ───────────────────────────────── */}
+        <section className="mb-10">
+          <h2 className="text-xl font-bold mb-2">4. Which Solutions Satisfy the Valid Interests of Both Sides?</h2>
+
+          <h3 className="text-base font-semibold mb-1">The Resolution Floor</h3>
+          <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
+            Shared interests with Validity of at least {RESOLUTION_FLOOR_VALIDITY} on both sides —
+            build solutions on these first. Same threshold the CompromiseEngine ships, so wiki and
+            code speak one language.
+          </p>
+          <table className="w-full border-collapse border border-gray-300 text-sm mb-5">
+            <thead>
+              <tr>
+                <th className={`${TH} w-[40%] bg-green-100`}>Shared interest</th>
+                <th className={`${TH} w-[14%] text-center bg-green-100`}>Validity</th>
+                <th className={`${TH} w-[46%] bg-green-100`}>Compromise direction it opens</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(floor.length > 0 ? floor : [null]).map((s, i) => (
+                <tr key={s?.id ?? i}>
+                  <td className={TD}>
+                    {s?.interest ?? (
+                      <span className="text-[var(--muted-foreground)] italic">
+                        No shared interests clear the floor yet — score them in the belief page&apos;s Shared Interests table.
+                      </span>
+                    )}
+                  </td>
+                  <td className={`${TDC} font-mono`}>{formatScore(s?.validityScore) ?? <span>&nbsp;</span>}</td>
+                  <td className={TD}>{lines(s?.compromiseDirection)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <h3 className="text-base font-semibold mb-1">Candidate solutions, ranked</h3>
+          <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
+            Ranked by how well each satisfies the valid interests of both sides. Two hard rules: a
+            solution earns nothing for satisfying an interest that failed validity, and no interest
+            counts extra because its holders are powerful. Lopsided solutions rank below balanced
+            ones; a solution that satisfies only one side resolves nothing.
+          </p>
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr>
+                <th className={`${TH} w-[30%]`}>Solution</th>
+                <th className={`${TH} w-[24%]`}>Valid supporter interests satisfied</th>
+                <th className={`${TH} w-[24%]`}>Valid opponent interests satisfied</th>
+                <th className={`${TH} w-[11%] text-center`}>Supporter / Opponent</th>
+                <th className={`${TH} w-[11%] text-center`}>Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(topSolutions.length > 0 ? topSolutions : [null]).map((s, i) => (
+                <tr key={s?.id ?? i}>
+                  <td className={TD}>
+                    {s ? (
+                      <>
+                        <strong>{s.solution}</strong>
+                        {s.description && (
+                          <>
+                            <br />
+                            <span className="text-xs text-[#555]">{s.description}</span>
+                          </>
+                        )}
+                      </>
+                    ) : (
+                      <span>&nbsp;</span>
+                    )}
+                  </td>
+                  <td className={TD}>{s ? (s.supporterNames.join('; ') || <span className="text-[var(--muted-foreground)] italic">none</span>) : <span>&nbsp;</span>}</td>
+                  <td className={TD}>{s ? (s.opponentNames.join('; ') || <span className="text-[var(--muted-foreground)] italic">none</span>) : <span>&nbsp;</span>}</td>
+                  <td className={`${TDC} font-mono`}>
+                    {s && s.satisfactions.length > 0
+                      ? `${s.breakdown.supporterScore.toFixed(2)} / ${s.breakdown.opponentScore.toFixed(2)}`
+                      : <span>&nbsp;</span>}
+                  </td>
+                  <td className={`${TDC} font-mono font-bold`}>
+                    {s ? (s.satisfactions.length > 0 ? s.rankScore.toFixed(2) : formatScore(s.score) ?? '') : <span>&nbsp;</span>}
+                  </td>
+                </tr>
+              ))}
+              <ExpandableRows moreCount={restSolutions.length} colSpan={5}>
+                {restSolutions.map(s => (
+                  <tr key={s.id}>
+                    <td className={TD}><strong>{s.solution}</strong></td>
+                    <td className={TD}>{s.supporterNames.join('; ') || <span className="text-[var(--muted-foreground)] italic">none</span>}</td>
+                    <td className={TD}>{s.opponentNames.join('; ') || <span className="text-[var(--muted-foreground)] italic">none</span>}</td>
+                    <td className={`${TDC} font-mono`}>{`${s.breakdown.supporterScore.toFixed(2)} / ${s.breakdown.opponentScore.toFixed(2)}`}</td>
+                    <td className={`${TDC} font-mono font-bold`}>{s.rankScore.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </ExpandableRows>
+            </tbody>
+          </table>
+        </section>
+
+        {/* ── Contribute ─────────────────────────────────────────────── */}
+        <section>
+          <h2 className="text-xl font-bold mb-2">🔬 Contribute</h2>
+          <p className="text-sm text-[var(--muted-foreground)]">
+            <Link href="/contact" className="text-[var(--accent)] hover:underline">Contact me</Link>{' '}
+            to add interest hypotheses, unstated-interest candidates with the behavior they explain,
+            or candidate solutions.{' '}
+            <a
+              href="https://github.com/myklob/ideastockexchange"
+              className="text-[var(--accent)] hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GitHub
+            </a>{' '}
+            for the scoring algorithm. Back to the{' '}
+            <Link href={`/beliefs/${belief.slug}`} className="text-[var(--accent)] hover:underline">
+              belief page
+            </Link>.
+          </p>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/app/beliefs/[slug]/page.tsx
+++ b/src/app/beliefs/[slug]/page.tsx
@@ -139,6 +139,7 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
             sharedInterests={belief.sharedInterests}
             disputeTypes={belief.disputeTypes}
             obstacles={belief.obstacles}
+            interestsDashboardHref={`/beliefs/${belief.slug}/interests`}
           />
 
           <hr className="border-gray-200" />

--- a/src/features/belief-analysis/components/ConflictResolutionSection.tsx
+++ b/src/features/belief-analysis/components/ConflictResolutionSection.tsx
@@ -19,6 +19,8 @@ interface ConflictResolutionSectionProps {
   sharedInterests: SharedInterestItem[]
   disputeTypes: DisputeTypeItem[]
   obstacles: ObstacleItem[]
+  /** Deep-dive link to the interests-and-motivation dashboard, when one exists. */
+  interestsDashboardHref?: string
 }
 
 function lines(text: string | null | undefined): React.ReactNode {
@@ -342,6 +344,7 @@ export default function ConflictResolutionSection({
   sharedInterests,
   disputeTypes,
   obstacles,
+  interestsDashboardHref,
 }: ConflictResolutionSectionProps) {
   const supporterInterests = interestEntries.filter(e => e.side === 'supporter')
   const opponentInterests = interestEntries.filter(e => e.side === 'opponent')
@@ -380,6 +383,15 @@ export default function ConflictResolutionSection({
         <p className="text-xs text-[var(--muted-foreground)] italic mb-2">
           Sorted by estimated prevalence. Linkage Confidence measures how sure we are this is actually
           why they support this belief. Validity measures how legitimate the interest is.
+          {interestsDashboardHref && (
+            <>
+              {' '}For the ranked hypotheses, unstated-interest candidates, and the solutions that
+              satisfy both sides&apos; valid interests, see the{' '}
+              <Link href={interestsDashboardHref} className="text-[var(--accent)] hover:underline not-italic">
+                full interests and motivation analysis
+              </Link>.
+            </>
+          )}
         </p>
         <InterestTable entries={supporterInterests} headerClass="bg-green-100" />
       </div>

--- a/src/features/belief-analysis/lib/interests.ts
+++ b/src/features/belief-analysis/lib/interests.ts
@@ -1,0 +1,106 @@
+/**
+ * Scoring helpers for the interests-and-motivation dashboard.
+ *
+ * The dashboard answers four questions in order: which interests most likely
+ * drive each side (ranked competing hypotheses), which best explain actual
+ * behavior (linkage accuracy — actions over words), which of the real
+ * interests are valid (judged by objective criteria, never by power), and
+ * the payoff: which solutions satisfy the valid interests of both sides.
+ */
+
+/**
+ * The Resolution Floor: solutions are built on shared interests whose
+ * validity is at least this, on both sides. Same threshold the legacy
+ * CompromiseEngine component shipped — a shared constant, not a new one.
+ */
+export const RESOLUTION_FLOOR_VALIDITY = 70
+
+export function meetsResolutionFloor(validityScore: number | null | undefined): boolean {
+  return validityScore != null && validityScore >= RESOLUTION_FLOOR_VALIDITY
+}
+
+export interface RankableInterest {
+  id: number
+  side: string // "supporter" | "opponent"
+  interest: string
+  /** Share of the side actually driven by this interest (0-100). */
+  prevalenceScore?: number | null
+  /** How well this interest explains the side's actual behavior (0-100). */
+  linkageAccuracy?: number | null
+  /** How legitimate the interest is, judged by objective criteria (0-100). */
+  validityScore?: number | null
+}
+
+/**
+ * Rank one side's interests as competing hypotheses: the attribution that
+ * best predicts behavior wins, so linkage accuracy is the sort key —
+ * "most likely interest" is a computed position, not an editor's pick.
+ * Unscored hypotheses sink (Rule 6: their cells render blank).
+ */
+export function rankByLinkageAccuracy<T extends { linkageAccuracy?: number | null }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => {
+    const la = a.linkageAccuracy
+    const lb = b.linkageAccuracy
+    if (la == null && lb == null) return 0
+    if (la == null) return 1
+    if (lb == null) return -1
+    return lb - la
+  })
+}
+
+export interface SolutionSatisfaction {
+  /** Fraction of the interest the solution actually meets (0-1). */
+  satisfaction: number
+  interest: RankableInterest
+}
+
+export interface SolutionScoreBreakdown {
+  /** Sum over VALID satisfied supporter interests: satisfaction × validity/100. */
+  supporterScore: number
+  /** Sum over VALID satisfied opponent interests: satisfaction × validity/100. */
+  opponentScore: number
+  /** Overall rank key. Zero if either side gets nothing — a solution that
+   *  satisfies only one side resolves nothing. */
+  total: number
+  /** Satisfied interests that failed validity and therefore earned nothing. */
+  excluded: RankableInterest[]
+}
+
+/**
+ * Score a candidate solution by the valid interests it satisfies, per side.
+ * Two hard rules: a solution earns nothing for satisfying an interest that
+ * failed validity (below the Resolution Floor), and no interest counts extra
+ * because its holders are powerful — validity and satisfaction are the only
+ * inputs. The total is the harmonic-style pairing of the two sides
+ * (2·S·O / (S + O)) so lopsided solutions rank below balanced ones.
+ */
+export function scoreSolution(satisfactions: SolutionSatisfaction[]): SolutionScoreBreakdown {
+  let supporterScore = 0
+  let opponentScore = 0
+  const excluded: RankableInterest[] = []
+
+  for (const { satisfaction, interest } of satisfactions) {
+    if (!meetsResolutionFloor(interest.validityScore)) {
+      excluded.push(interest)
+      continue
+    }
+    const earned = satisfaction * ((interest.validityScore as number) / 100)
+    if (interest.side === 'supporter') supporterScore += earned
+    else opponentScore += earned
+  }
+
+  const total =
+    supporterScore > 0 && opponentScore > 0
+      ? (2 * supporterScore * opponentScore) / (supporterScore + opponentScore)
+      : 0
+
+  return { supporterScore, opponentScore, total, excluded }
+}
+
+/**
+ * Shared interests that clear the Resolution Floor — the foundation
+ * solutions get built on first.
+ */
+export function resolutionFloor<T extends { validityScore?: number | null }>(shared: T[]): T[] {
+  return shared.filter(s => meetsResolutionFloor(s.validityScore))
+}

--- a/tests/unit/features/belief-analysis/interests.test.ts
+++ b/tests/unit/features/belief-analysis/interests.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import {
+  RESOLUTION_FLOOR_VALIDITY,
+  meetsResolutionFloor,
+  rankByLinkageAccuracy,
+  resolutionFloor,
+  scoreSolution,
+  type RankableInterest,
+} from '@/features/belief-analysis/lib/interests'
+
+const interest = (
+  id: number,
+  side: string,
+  validityScore: number | null,
+  linkageAccuracy: number | null = null,
+): RankableInterest => ({ id, side, interest: `interest-${id}`, validityScore, linkageAccuracy })
+
+describe('Resolution Floor', () => {
+  it('matches the legacy CompromiseEngine threshold', () => {
+    expect(RESOLUTION_FLOOR_VALIDITY).toBe(70)
+  })
+
+  it('admits validity at or above 70 and rejects below or unscored', () => {
+    expect(meetsResolutionFloor(70)).toBe(true)
+    expect(meetsResolutionFloor(90)).toBe(true)
+    expect(meetsResolutionFloor(69.9)).toBe(false)
+    expect(meetsResolutionFloor(null)).toBe(false)
+    expect(meetsResolutionFloor(undefined)).toBe(false)
+  })
+
+  it('filters shared interests to those clearing the floor', () => {
+    const shared = [{ validityScore: 85 }, { validityScore: 40 }, { validityScore: null }]
+    expect(resolutionFloor(shared)).toHaveLength(1)
+  })
+})
+
+describe('rankByLinkageAccuracy', () => {
+  it('ranks by how well the interest explains behavior, unscored last', () => {
+    const rows = [
+      interest(1, 'supporter', 80, 40),
+      interest(2, 'supporter', 80, null),
+      interest(3, 'supporter', 80, 90),
+    ]
+    expect(rankByLinkageAccuracy(rows).map(r => r.id)).toEqual([3, 1, 2])
+  })
+})
+
+describe('scoreSolution', () => {
+  it('earns nothing for interests that failed validity', () => {
+    const result = scoreSolution([
+      { satisfaction: 1, interest: interest(1, 'supporter', 40) },
+      { satisfaction: 1, interest: interest(2, 'opponent', 60) },
+    ])
+    expect(result.supporterScore).toBe(0)
+    expect(result.opponentScore).toBe(0)
+    expect(result.total).toBe(0)
+    expect(result.excluded).toHaveLength(2)
+  })
+
+  it('scores satisfaction weighted by validity for valid interests', () => {
+    const result = scoreSolution([
+      { satisfaction: 1, interest: interest(1, 'supporter', 80) },
+      { satisfaction: 0.5, interest: interest(2, 'opponent', 90) },
+    ])
+    expect(result.supporterScore).toBeCloseTo(0.8)
+    expect(result.opponentScore).toBeCloseTo(0.45)
+    expect(result.total).toBeGreaterThan(0)
+    expect(result.excluded).toHaveLength(0)
+  })
+
+  it('gives zero total to solutions that satisfy only one side', () => {
+    const result = scoreSolution([
+      { satisfaction: 1, interest: interest(1, 'supporter', 95) },
+      { satisfaction: 1, interest: interest(2, 'supporter', 95) },
+    ])
+    expect(result.supporterScore).toBeGreaterThan(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('ranks balanced solutions above lopsided ones with the same sum', () => {
+    const balanced = scoreSolution([
+      { satisfaction: 1, interest: interest(1, 'supporter', 80) },
+      { satisfaction: 1, interest: interest(2, 'opponent', 80) },
+    ])
+    const lopsided = scoreSolution([
+      { satisfaction: 1, interest: interest(1, 'supporter', 80) },
+      { satisfaction: 1, interest: interest(2, 'supporter', 80) },
+      { satisfaction: 0.25, interest: interest(3, 'opponent', 80) },
+    ])
+    expect(balanced.total).toBeGreaterThan(lopsided.total)
+  })
+
+  it('validity is the only weight — identical interests from different holders score identically', () => {
+    const a = scoreSolution([{ satisfaction: 1, interest: interest(1, 'supporter', 75) }, { satisfaction: 1, interest: interest(2, 'opponent', 75) }])
+    const b = scoreSolution([{ satisfaction: 1, interest: interest(3, 'supporter', 75) }, { satisfaction: 1, interest: interest(4, 'opponent', 75) }])
+    expect(a.total).toBe(b.total)
+  })
+})


### PR DESCRIPTION
## Summary

Implements the software side of the rebuilt interests dashboard — the three schema pieces named in the template's repo follow-up (rankable interest entries, an UnstatedInterestCandidate entity, a solution-satisfaction mapping), plus the scoring engine and a verdict-first page at `/beliefs/[slug]/interests`.

The page answers the four questions in order: **(1)** which interests most likely drive each side — a ranked field of competing hypotheses, not one guess; **(2)** which interests explain the real actions, not just the press releases — interests are hypotheses, behavior is the data, and the attribution that best predicts behavior wins the Linkage Accuracy; **(3)** which of the real interests are valid — judged by objective criteria, never by who holds them or how much power they have; **(4)** the payoff — solutions ranked by how well they satisfy the valid interests of both sides. The last table is the whole point; everything above it is input.

## Schema (migration `20260704025818_add_interests_motivation_dashboard`)

- `InterestEntry` gains numeric `prevalenceScore`, `linkageAccuracy` ("how well this interest explains the group's actual behavior: its votes, spending, sacrifices, and what it tolerates"), and `validityScore` — the rankable-hypotheses model. Legacy string columns stay as display fallbacks.
- `SharedInterest.validityScore` — makes the Resolution Floor computable.
- **`UnstatedInterestCandidate`** — a hidden-motive hypothesis must name the specific behavior the stated interests fail to predict, bring evidence, and take a score; `promoted` flags the ones that out-predicted the alternatives and joined the ranked list. Equal suspicion for both sides is structural: `side` is just a column.
- **`InterestSolution` + `InterestSatisfaction`** — solutions mapped to the interests they satisfy per side, with a satisfaction fraction per mapping.

## Scoring library (`lib/interests.ts`, 9 new unit tests)

- `RESOLUTION_FLOOR_VALIDITY = 70` — the same threshold the legacy CompromiseEngine component ships, now a shared constant with `meetsResolutionFloor` / `resolutionFloor` helpers.
- `rankByLinkageAccuracy` — "most likely interest" is a computed position, not an editor's pick.
- `scoreSolution` enforces the two hard rules in math: satisfied interests **below the validity floor earn zero** (they land in an `excluded` list), and validity × satisfaction are the **only** inputs — no power weighting is possible because holder identity never enters the function. The total pairs the two sides harmonically, so lopsided solutions rank below balanced ones and a solution satisfying only one side scores zero.

## The page

- **Conflict Readout** (verdict-first): most likely driver per side, the primary conflict pair, the strongest unstated candidate, and the best solution so far — every line derived live from the tables below, pending when unscored.
- **Section 1:** ranked hypotheses per side (Prevalence / Linkage Accuracy / Validity), sorted by Linkage Accuracy, top-five collapse, with promoted unstated interests as italic rows that can only appear by earning it in section 2.
- **Section 2 — "Which Interests Explain Their Actions, Not Just Their Words?":** the advertised-versus-revealed gap table (reusing the ValuesAnalysis divergence data, framed as the opening evidence that something unstated is driving) feeding the **candidate unstated interests** table (side / interest / behavior it explains / evidence / score / Promoted-or-Candidate status).
- **Section 3:** validity firewalled — the power firewall stated, and the Primary Conflict Pair head-to-head with Standalone Validity and Claim Strength kept as separate numbers.
- **Section 4 — the payoff:** the Resolution Floor (shared interests with Validity ≥ 70) and the **ranked solutions table** with both hard rules printed on it, per-side subtotals, and the interests each solution actually gets credit for.
- The belief page's "Likely Interests" section now links to the dashboard as its deep-dive.

## Seed

`seed-interests-example.ts` (wired into `db:seed`) populates the UBI belief with six ranked interests whose evidence lines model the actions-over-words test (e.g. opponents' "targeting" interest scores low linkage accuracy because the same voters back universal programs), two unstated candidates — the opponents' status-anxiety hypothesis promoted on framing-experiment evidence, the supporters' institutional-distrust hypothesis still a candidate — two floor-clearing shared interests, and three solutions the engine ranks live: the negative income tax wins by satisfying valid interests on both sides, the one-sided options fall behind.

## Verification

- `npx tsc --noEmit` — 0 errors repo-wide; eslint clean; `npm test` — 215/215 passing (9 new)
- Seeded and rendered `/beliefs/universal-basic-income-should-be-implemented/interests` — HTTP 200 with the readout deriving all four verdicts, the promoted candidate appearing in section 1, the floor filtering to ≥ 70, and the solutions ranked with per-side scores; belief page links through

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NrE26SrTeZmRk25kaJ5An

---
_Generated by [Claude Code](https://claude.ai/code/session_013NrE26SrTeZmRk25kaJ5An)_