### PR TITLE
Rebuild the product review page to the July 2026 template (scoped title, criteria before brands)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
-    "db:seed": "npx tsx prisma/seed-beliefs.ts && npx tsx prisma/seed-belief-distractions.ts && npx tsx prisma/seed-debate-topics.ts && npx tsx prisma/seed-product-reviews.ts && npx tsx prisma/seed-linkage-example.ts && npx tsx prisma/seed-interests-example.ts",
+    "db:seed": "npx tsx prisma/seed-beliefs.ts && npx tsx prisma/seed-belief-distractions.ts && npx tsx prisma/seed-debate-topics.ts && npx tsx prisma/seed-product-reviews.ts && npx tsx prisma/seed-linkage-example.ts && npx tsx prisma/seed-interests-example.ts && npx tsx prisma/seed-product-review-extras.ts",
     "db:seed-reviews": "npx tsx prisma/seed-product-reviews.ts",
     "db:migrate": "npx prisma migrate dev",
     "db:reset": "npx prisma migrate reset --force",

--- a/prisma/migrations/20260704172840_add_product_review_template_fields/migration.sql
+++ b/prisma/migrations/20260704172840_add_product_review_template_fields/migration.sql
@@ -1,0 +1,126 @@
+-- AlterTable
+ALTER TABLE "ProductAlternative" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "ProductAward" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "ProductEcosystem" ADD COLUMN "cost" TEXT;
+ALTER TABLE "ProductEcosystem" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "ProductPerformance" ADD COLUMN "benchmark" TEXT;
+ALTER TABLE "ProductPerformance" ADD COLUMN "impact" REAL;
+ALTER TABLE "ProductPerformance" ADD COLUMN "source" TEXT;
+
+-- AlterTable
+ALTER TABLE "ProductReview" ADD COLUMN "bottomLine" TEXT;
+ALTER TABLE "ProductReview" ADD COLUMN "divergenceNote" TEXT;
+ALTER TABLE "ProductReview" ADD COLUMN "divergenceScore" REAL;
+ALTER TABLE "ProductReview" ADD COLUMN "priceSegment" TEXT;
+ALTER TABLE "ProductReview" ADD COLUMN "useCase" TEXT;
+ALTER TABLE "ProductReview" ADD COLUMN "verdictChanger" TEXT;
+
+-- AlterTable
+ALTER TABLE "ProductTradeoff" ADD COLUMN "score" REAL;
+
+-- AlterTable
+ALTER TABLE "ProductUserProfile" ADD COLUMN "score" REAL;
+
+-- CreateTable
+CREATE TABLE "CategoryCriterion" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "categoryType" TEXT NOT NULL,
+    "criterion" TEXT NOT NULL,
+    "howToMeasure" TEXT,
+    "importance" REAL,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "ProductRecommenderInterest" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "productReviewId" INTEGER NOT NULL,
+    "side" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "hidden" BOOLEAN NOT NULL DEFAULT false,
+    "evidence" TEXT,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ProductRecommenderInterest_productReviewId_fkey" FOREIGN KEY ("productReviewId") REFERENCES "ProductReview" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ProductOwnershipCost" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "productReviewId" INTEGER NOT NULL,
+    "item" TEXT NOT NULL,
+    "estimate" TEXT,
+    "costType" TEXT NOT NULL DEFAULT 'initial',
+    "source" TEXT,
+    "evidenceTier" INTEGER,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ProductOwnershipCost_productReviewId_fkey" FOREIGN KEY ("productReviewId") REFERENCES "ProductReview" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ProductValueItem" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "productReviewId" INTEGER NOT NULL,
+    "item" TEXT NOT NULL,
+    "measure" TEXT,
+    "timeframe" TEXT NOT NULL DEFAULT 'short',
+    "source" TEXT,
+    "evidenceTier" INTEGER,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ProductValueItem_productReviewId_fkey" FOREIGN KEY ("productReviewId") REFERENCES "ProductReview" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ProductDecisionRule" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "productReviewId" INTEGER NOT NULL,
+    "condition" TEXT NOT NULL,
+    "advice" TEXT NOT NULL,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ProductDecisionRule_productReviewId_fkey" FOREIGN KEY ("productReviewId") REFERENCES "ProductReview" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ProductDecisionObstacle" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "productReviewId" INTEGER NOT NULL,
+    "side" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ProductDecisionObstacle_productReviewId_fkey" FOREIGN KEY ("productReviewId") REFERENCES "ProductReview" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "CategoryCriterion_categoryType_idx" ON "CategoryCriterion"("categoryType");
+
+-- CreateIndex
+CREATE INDEX "ProductRecommenderInterest_productReviewId_idx" ON "ProductRecommenderInterest"("productReviewId");
+
+-- CreateIndex
+CREATE INDEX "ProductOwnershipCost_productReviewId_idx" ON "ProductOwnershipCost"("productReviewId");
+
+-- CreateIndex
+CREATE INDEX "ProductValueItem_productReviewId_idx" ON "ProductValueItem"("productReviewId");
+
+-- CreateIndex
+CREATE INDEX "ProductDecisionRule_productReviewId_idx" ON "ProductDecisionRule"("productReviewId");
+
+-- CreateIndex
+CREATE INDEX "ProductDecisionObstacle_productReviewId_idx" ON "ProductDecisionObstacle"("productReviewId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1739,6 +1739,25 @@ model ProductReview {
   brand       String   // e.g., "Ford"
   claim       String   // e.g., "Ford makes the best trucks"
 
+  /// THE TITLE MUST CARRY A SCOPE: bare "best" fails the costability test
+  /// (compared to what, measured in what, for whom). The page headline is
+  /// "[Product] is the best [Product Type] for [useCase]".
+  useCase      String?
+  /// "Budget" | "Mid-range" | "Premium"
+  priceSegment String?
+
+  /// Scorecard fields. Bottom line is the one-sentence verdict scoped to the
+  /// use case in the title; verdictChanger is the measurement or price change
+  /// that would flip the net score. The other scorecard cells are auto-derived
+  /// from the tables, never hand-picked.
+  bottomLine     String?
+  verdictChanger String?
+
+  /// Design Trade-offs: how far the advertised optimization differs from the
+  /// actual one, scored by its own sub-debate.
+  divergenceNote  String?
+  divergenceScore Float?
+
   // Category hierarchy: Product Type > Subcategory > Brand/Model
   categoryType    String   // e.g., "Trucks"
   categorySubtype String?  // e.g., "Full-size Pickup"
@@ -1762,9 +1781,38 @@ model ProductReview {
   awards           ProductAward[]
   ecosystemItems   ProductEcosystem[]
 
+  recommenderInterests ProductRecommenderInterest[]
+  ownershipCosts       ProductOwnershipCost[]
+  valueItems           ProductValueItem[]
+  decisionRules        ProductDecisionRule[]
+  decisionObstacles    ProductDecisionObstacle[]
+
   @@index([categoryType])
   @@index([overallScore])
   @@index([brand])
+}
+
+/// CRITERIA BEFORE BRANDS: the criteria that make a good [Product Type],
+/// keyed by category so they apply to every product in it and are filled
+/// before any brand is discussed. The yardstick the rest of a product page
+/// measures against.
+model CategoryCriterion {
+  id Int @id @default(autoincrement())
+
+  /// Matches ProductReview.categoryType (e.g. "Trucks").
+  categoryType String
+  criterion    String
+  howToMeasure String?
+  /// How much this criterion matters for the category (0-100).
+  importance Float?
+  /// Row score: performance of the sub-debate that this criterion belongs
+  /// on the list. Sorts descending.
+  score     Float?
+  sortOrder Int    @default(0)
+
+  createdAt DateTime @default(now())
+
+  @@index([categoryType])
 }
 
 // Per-criterion performance data with evidence quality tiers
@@ -1778,6 +1826,13 @@ model ProductPerformance {
   evidenceTier    Int      @default(3) // 1-4 (T1=lab tested, T4=anecdotal)
   comparisonToAvg String   @default("Same") // "Better", "Worse", "Same"
   sourceUrl       String?
+
+  /// Category average or best rival, with units — "compared to what".
+  benchmark String?
+  /// Named evidence source (the tier badge's owner).
+  source    String?
+  /// Row impact on the verdict. Sorts descending.
+  impact    Float?
 
   createdAt DateTime @default(now())
 
@@ -1793,6 +1848,104 @@ model ProductTradeoff {
   side            String  // "optimizes" or "sacrifices"
   category        String  // "advertised" or "actual"
   description     String
+  /// Row score: performance of this claim's own sub-debate. Sorts descending.
+  score           Float?
+
+  createdAt DateTime @default(now())
+
+  @@index([productReviewId])
+}
+
+/// Interests Behind the Recommendations: who recommends this product (or its
+/// alternatives), what they gain, what they optimize for. Hidden-interest
+/// attributions (affiliate money, ecosystem lock-in) are scored claims
+/// requiring evidence, applied with equal suspicion to both sides.
+model ProductRecommenderInterest {
+  id              Int    @id @default(autoincrement())
+  productReviewId Int
+  productReview   ProductReview @relation(fields: [productReviewId], references: [id], onDelete: Cascade)
+
+  side        String  // "product" (recommends this product) or "alternatives"
+  description String
+  /// Candidate hidden interest (renders as the italic row). Requires evidence.
+  hidden   Boolean @default(false)
+  evidence String?
+  score    Float?
+  sortOrder Int    @default(0)
+
+  createdAt DateTime @default(now())
+
+  @@index([productReviewId])
+}
+
+/// Total cost of ownership row: costs keep their units and never collapse
+/// across categories unless the conversion is stated.
+model ProductOwnershipCost {
+  id              Int    @id @default(autoincrement())
+  productReviewId Int
+  productReview   ProductReview @relation(fields: [productReviewId], references: [id], onDelete: Cascade)
+
+  item     String
+  estimate String? // with units
+  costType String  @default("initial") // "initial" | "ongoing" | "hidden" | "opportunity"
+  source   String?
+  evidenceTier Int?
+  score    Float?
+  sortOrder Int   @default(0)
+
+  createdAt DateTime @default(now())
+
+  @@index([productReviewId])
+}
+
+/// Total value delivered row.
+model ProductValueItem {
+  id              Int    @id @default(autoincrement())
+  productReviewId Int
+  productReview   ProductReview @relation(fields: [productReviewId], references: [id], onDelete: Cascade)
+
+  item      String
+  measure   String? // with units
+  timeframe String  @default("short") // "short" (0-2 years) | "long" (3+ years) | "both"
+  source    String?
+  evidenceTier Int?
+  score     Float?
+  sortOrder Int    @default(0)
+
+  createdAt DateTime @default(now())
+
+  @@index([productReviewId])
+}
+
+/// Decision rule: "If you prioritize [criterion], buy [option], because [evidence]".
+model ProductDecisionRule {
+  id              Int    @id @default(autoincrement())
+  productReviewId Int
+  productReview   ProductReview @relation(fields: [productReviewId], references: [id], onDelete: Cascade)
+
+  /// The bold lead-in, e.g. "If you prioritize towing capacity".
+  condition String
+  /// The recommendation with its evidence, e.g. "buy the F-150 because …".
+  advice    String
+  score     Float?
+  sortOrder Int    @default(0)
+
+  createdAt DateTime @default(now())
+
+  @@index([productReviewId])
+}
+
+/// Decision Obstacles: category-specific patterns for why buyers overpay or
+/// underinvest.
+model ProductDecisionObstacle {
+  id              Int    @id @default(autoincrement())
+  productReviewId Int
+  productReview   ProductReview @relation(fields: [productReviewId], references: [id], onDelete: Cascade)
+
+  side        String // "overpay" or "underinvest"
+  description String
+  score       Float?
+  sortOrder   Int    @default(0)
 
   createdAt DateTime @default(now())
 
@@ -1809,6 +1962,8 @@ model ProductAlternative {
   tier            String  // "premium", "budget", or "lateral"
   keyAdvantage    String
   linkSlug        String? // Optional link to that product's review
+  /// Row score: strength of this alternative's case. Sorts descending.
+  score           Float?
 
   createdAt DateTime @default(now())
 
@@ -1823,6 +1978,9 @@ model ProductUserProfile {
 
   side            String  // "ideal" or "not_ideal"
   description     String
+  /// Row score: how well this profile fits (or misfits). Sorts descending;
+  /// the Scorecard's Best for / Not for derive from the top rows.
+  score           Float?
 
   createdAt DateTime @default(now())
 
@@ -1838,6 +1996,7 @@ model ProductAward {
   side            String  // "independent" or "manufacturer"
   title           String
   details         String?
+  score           Float?
 
   createdAt DateTime @default(now())
 
@@ -1852,6 +2011,9 @@ model ProductEcosystem {
 
   category        String  // "upstream", "downstream", or "lockin"
   description     String
+  /// Cost or commitment, with units (dollars, hours, switching cost).
+  cost            String?
+  score           Float?
 
   createdAt DateTime @default(now())
 

--- a/prisma/seed-product-review-extras.ts
+++ b/prisma/seed-product-review-extras.ts
@@ -1,0 +1,188 @@
+/**
+ * Seeds the new product-review template data for the Ford F-150 review:
+ * scoped title fields, scorecard verdicts, category criteria for Trucks
+ * (criteria before brands), performance benchmarks and impacts, trade-off
+ * divergence, recommender interests with hidden-interest candidates,
+ * ownership costs, value delivered, decision rules, and decision obstacles.
+ * Idempotent: clears and recreates the rows it owns.
+ */
+
+import { prisma } from '../src/lib/prisma'
+
+async function main() {
+  const review = await prisma.productReview.findUnique({
+    where: { slug: 'ford-f-150' },
+    include: { performanceData: true },
+  })
+  if (!review) {
+    console.log('Ford F-150 review not found — run seed-product-reviews first. Skipping extras.')
+    return
+  }
+
+  await prisma.categoryCriterion.deleteMany({ where: { categoryType: review.categoryType } })
+  await prisma.productRecommenderInterest.deleteMany({ where: { productReviewId: review.id } })
+  await prisma.productOwnershipCost.deleteMany({ where: { productReviewId: review.id } })
+  await prisma.productValueItem.deleteMany({ where: { productReviewId: review.id } })
+  await prisma.productDecisionRule.deleteMany({ where: { productReviewId: review.id } })
+  await prisma.productDecisionObstacle.deleteMany({ where: { productReviewId: review.id } })
+
+  await prisma.categoryCriterion.createMany({
+    data: [
+      {
+        categoryType: review.categoryType,
+        criterion: 'Towing and payload capacity',
+        howToMeasure: 'SAE J2807-certified tow rating; manufacturer payload with the certification named',
+        importance: 90,
+        score: 82,
+        sortOrder: 0,
+      },
+      {
+        categoryType: review.categoryType,
+        criterion: 'Reliability over 5+ years',
+        howToMeasure: 'J.D. Power dependability, repair-frequency data, warranty claim rates',
+        importance: 85,
+        score: 78,
+        sortOrder: 1,
+      },
+      {
+        categoryType: review.categoryType,
+        criterion: 'Total cost of ownership per mile',
+        howToMeasure: 'Purchase price + fuel + maintenance + insurance − resale, divided by miles',
+        importance: 80,
+        score: 74,
+        sortOrder: 2,
+      },
+      {
+        categoryType: review.categoryType,
+        criterion: 'Crash safety',
+        howToMeasure: 'NHTSA overall stars and IIHS ratings',
+        importance: 75,
+        score: 70,
+        sortOrder: 3,
+      },
+    ],
+  })
+
+  const perfUpdates: Record<string, { benchmark: string; source: string; impact: number }> = {
+    'Max Towing Capacity': { benchmark: 'Best rival (Silverado 1500): 13,300 lbs', source: 'SAE J2807 ratings', impact: 68 },
+    'Max Payload Capacity': { benchmark: 'Category average: 2,000 lbs', source: 'Manufacturer specs, third-party verified', impact: 55 },
+    'J.D. Power Reliability': { benchmark: 'Category average: 77/100', source: 'J.D. Power 2024 dependability study', impact: 40 },
+    'Combined Fuel Economy': { benchmark: 'Best rival (Ram 1500 diesel): 26 MPG', source: 'EPA ratings', impact: 35 },
+    '5-Year Maintenance Cost': { benchmark: 'Category average: $8,600', source: 'RepairPal aggregate', impact: 30 },
+    'NHTSA Safety Rating': { benchmark: 'Category norm: 4-5 stars', source: 'NHTSA', impact: 28 },
+  }
+  for (const p of review.performanceData) {
+    const u = perfUpdates[p.criterion]
+    if (u) {
+      await prisma.productPerformance.update({
+        where: { id: p.id },
+        data: { benchmark: u.benchmark, source: u.source, impact: u.impact },
+      })
+    }
+  }
+
+  await prisma.productReview.update({
+    where: { id: review.id },
+    data: {
+      useCase: 'mixed work and family use',
+      priceSegment: 'Mid-range',
+      bottomLine:
+        'For buyers who split time between job-site towing and family driving, the F-150 wins on capability per dollar; single-purpose buyers can do better on either extreme.',
+      verdictChanger:
+        'A rival matching the 14,000 lb tow rating at a lower 5-year total cost of ownership, or F-150 maintenance costs rising above $10,000/5-year.',
+      divergenceNote:
+        'Marketing sells maximum capability; the volume trims actually optimize daily comfort and financing accessibility, and the halo numbers require specific packages most buyers do not order.',
+      divergenceScore: 46,
+      recommenderInterests: {
+        create: [
+          {
+            side: 'product',
+            description: 'Fleet managers optimizing uptime and resale, who buy on total cost of ownership data.',
+            score: 62,
+            sortOrder: 0,
+          },
+          {
+            side: 'alternatives',
+            description: 'Off-road enthusiasts optimizing trail capability, where rivals aim their halo trims.',
+            score: 48,
+            sortOrder: 0,
+          },
+          {
+            side: 'product',
+            hidden: true,
+            description: 'Dealer and affiliate networks earn more on high-margin F-150 packages.',
+            evidence: 'Affiliate disclosure pages on the top ten "best truck" listicles; trim-mix incentive data.',
+            score: 38,
+            sortOrder: 1,
+          },
+          {
+            side: 'alternatives',
+            hidden: true,
+            description: 'Rival-sponsored review channels time "F-150 killer" videos to competitor launch windows.',
+            evidence: 'Sponsorship disclosures and launch-date clustering of head-to-head videos.',
+            score: 33,
+            sortOrder: 1,
+          },
+        ],
+      },
+      ownershipCosts: {
+        create: [
+          { item: 'Purchase price (XLT, typical options)', estimate: '$48,500', costType: 'initial', source: 'KBB transaction data', evidenceTier: 2, score: 70, sortOrder: 0 },
+          { item: 'Maintenance and repairs', estimate: '$1,840 per year', costType: 'ongoing', source: 'RepairPal', evidenceTier: 2, score: 55, sortOrder: 1 },
+          { item: 'Fuel at 12,000 miles per year', estimate: '$2,300 per year', costType: 'ongoing', source: 'EPA + AAA fuel averages', evidenceTier: 1, score: 50, sortOrder: 2 },
+          { item: 'Aluminum-body repair premium after collisions', estimate: '$500-$1,200 per incident', costType: 'hidden', source: 'IIHS repair-cost study', evidenceTier: 2, score: 42, sortOrder: 3 },
+          { item: 'Same money buys a mid-size truck plus a used sedan', estimate: '$48,500', costType: 'opportunity', source: 'Configurator comparison', evidenceTier: 3, score: 25, sortOrder: 4 },
+        ],
+      },
+      valueItems: {
+        create: [
+          { item: 'Class-leading towing on the certified test', measure: '14,000 lbs (SAE J2807)', timeframe: 'short', source: 'SAE ratings', evidenceTier: 1, score: 72, sortOrder: 0 },
+          { item: 'Resale value retained after 5 years', measure: '58% of purchase price', timeframe: 'long', source: 'KBB resale data', evidenceTier: 2, score: 60, sortOrder: 1 },
+          { item: 'Owner satisfaction', measure: '4.2/5 across 11,000 aggregated reviews', timeframe: 'both', source: 'Aggregated dealer and forum reviews', evidenceTier: 3, score: 41, sortOrder: 2 },
+        ],
+      },
+      decisionRules: {
+        create: [
+          {
+            condition: 'If you prioritize certified towing capacity',
+            advice: 'buy the F-150 with the 3.5L EcoBoost tow package, because it holds the SAE-certified class lead at 14,000 lbs.',
+            score: 66,
+            sortOrder: 0,
+          },
+          {
+            condition: 'If you prioritize lowest running costs',
+            advice: 'buy the Ram 1500 diesel, because its 26 MPG combined beats the F-150 by 4 MPG at equal payload.',
+            score: 54,
+            sortOrder: 1,
+          },
+          {
+            condition: 'If you need both towing and daily comfort',
+            advice: 'consider the F-150 hybrid, because it keeps 12,700 lbs of towing while adding the onboard generator and better city economy.',
+            score: 49,
+            sortOrder: 2,
+          },
+          {
+            condition: 'If budget is the primary concern',
+            advice: 'a two-year-old F-150 XL sacrifices warranty coverage but delivers the same frame and drivetrain for about 70% of the price.',
+            score: 45,
+            sortOrder: 3,
+          },
+        ],
+      },
+      decisionObstacles: {
+        create: [
+          { side: 'overpay', description: 'Brand loyalty and trim-ladder anchoring push buyers two trims above their measured needs.', score: 58, sortOrder: 0 },
+          { side: 'overpay', description: 'Halo-number marketing sells capability most owners never use (median owner tows under 5,000 lbs).', score: 52, sortOrder: 1 },
+          { side: 'underinvest', description: 'Shopping on sticker price while ignoring resale and maintenance, which dominate 5-year cost.', score: 56, sortOrder: 0 },
+        ],
+      },
+    },
+  })
+
+  console.log(`Seeded product template extras for ${review.productName}: 4 category criteria, 4 recommender interests, 5 costs, 3 values, 4 decision rules, 3 obstacles.`)
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/app/product-reviews/[slug]/page.tsx
+++ b/src/app/product-reviews/[slug]/page.tsx
@@ -1,26 +1,37 @@
+/**
+ * Product Review Page — the consumer-market sibling of the belief page. This
+ * IS a belief page for one product claim, and the title carries a scope:
+ * "[Product] is the best [Product Type] for [use case]" — bare "best" fails
+ * the costability test (compared to what, measured in what, for whom).
+ *
+ * CRITERIA BEFORE BRANDS: the Category Criteria table renders before
+ * performance or arguments; the criteria apply to every product in the
+ * category and are the yardstick the rest of the page measures against.
+ *
+ * Route: /product-reviews/[slug]
+ */
+
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
-import { fetchProductReviewBySlug } from '@/features/product-reviews/data/fetch-product-reviews'
+import { fetchProductReviewBySlug, fetchCategoryCriteria } from '@/features/product-reviews/data/fetch-product-reviews'
 import { scoreProductReview } from '@/core/scoring/product-review-scoring'
 import ProductScoreHeader from '@/features/product-reviews/components/ProductScoreHeader'
+import ProductScorecardSection from '@/features/product-reviews/components/ProductScorecardSection'
+import CategoryCriteriaSection from '@/features/product-reviews/components/CategoryCriteriaSection'
 import PerformanceSection from '@/features/product-reviews/components/PerformanceSection'
 import TradeoffsSection from '@/features/product-reviews/components/TradeoffsSection'
+import RecommenderInterestsSection from '@/features/product-reviews/components/RecommenderInterestsSection'
 import AlternativesSection from '@/features/product-reviews/components/AlternativesSection'
+import OwnershipSection from '@/features/product-reviews/components/OwnershipSection'
 import UserProfilesSection from '@/features/product-reviews/components/UserProfilesSection'
+import DecisionObstaclesSection from '@/features/product-reviews/components/DecisionObstaclesSection'
 import AwardsSection from '@/features/product-reviews/components/AwardsSection'
 import EcosystemSection from '@/features/product-reviews/components/EcosystemSection'
 // Reuse belief analysis components for shared sections
 import ArgumentTreesSection from '@/features/belief-analysis/components/ArgumentTreesSection'
-import EvidenceSection from '@/features/belief-analysis/components/EvidenceSection'
-import ObjectiveCriteriaSection from '@/features/belief-analysis/components/ObjectiveCriteriaSection'
-import InterestsSection from '@/features/belief-analysis/components/InterestsSection'
 import AssumptionsSection from '@/features/belief-analysis/components/AssumptionsSection'
-import CostBenefitSection from '@/features/belief-analysis/components/CostBenefitSection'
-import ImpactSection from '@/features/belief-analysis/components/ImpactSection'
-import ObstaclesSection from '@/features/belief-analysis/components/ObstaclesSection'
 import BiasesSection from '@/features/belief-analysis/components/BiasesSection'
-import MediaSection from '@/features/belief-analysis/components/MediaSection'
-import ContributeSection from '@/features/belief-analysis/components/ContributeSection'
+import MediaResourcesSection from '@/features/belief-analysis/components/MediaResourcesSection'
 
 interface ProductReviewPageProps {
   params: Promise<{ slug: string }>
@@ -34,18 +45,17 @@ export default async function ProductReviewPage({ params }: ProductReviewPagePro
     notFound()
   }
 
-  const scores = scoreProductReview(review)
+  const [scores, categoryCriteria] = await Promise.all([
+    Promise.resolve(scoreProductReview(review)),
+    fetchCategoryCriteria(review.categoryType),
+  ])
   const belief = review.belief
 
-  // Compute belief-level argument scores for display
   let totalPro = 0
   let totalCon = 0
-
   if (belief) {
-    const proArgs = belief.arguments.filter(a => a.side === 'agree')
-    const conArgs = belief.arguments.filter(a => a.side === 'disagree')
-    totalPro = proArgs.reduce((sum, a) => sum + Math.abs(a.impactScore), 0)
-    totalCon = conArgs.reduce((sum, a) => sum + Math.abs(a.impactScore), 0)
+    totalPro = belief.arguments.filter(a => a.side === 'agree').reduce((s, a) => s + Math.abs(a.impactScore), 0)
+    totalCon = belief.arguments.filter(a => a.side === 'disagree').reduce((s, a) => s + Math.abs(a.impactScore), 0)
   }
 
   return (
@@ -69,27 +79,29 @@ export default async function ProductReviewPage({ params }: ProductReviewPagePro
         </div>
       </nav>
 
-      <main className="max-w-[960px] mx-auto px-4 py-8">
-        {/* Score Header */}
+      <main className="max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]">
+        {/* Header: scoped title, net belief score, category, price segment */}
         <ProductScoreHeader
           productName={review.productName}
           brand={review.brand}
           claim={review.claim}
+          useCase={review.useCase ?? null}
+          priceSegment={review.priceSegment ?? null}
           categoryType={review.categoryType}
           categorySubtype={review.categorySubtype}
           scores={scores}
         />
 
         <div className="space-y-12">
-          {/* 1. Category Objective Criteria */}
-          {belief && (
-            <>
-              <ObjectiveCriteriaSection criteria={belief.objectiveCriteria} />
-              <hr className="border-gray-200" />
-            </>
-          )}
+          {/* 1. Scorecard — auto-derived from the tables below */}
+          <ProductScorecardSection review={review} />
+          <hr className="border-gray-200" />
 
-          {/* 2. Argument Trees */}
+          {/* 2. Category Criteria — CRITERIA BEFORE BRANDS */}
+          <CategoryCriteriaSection categoryType={review.categoryType} criteria={categoryCriteria} />
+          <hr className="border-gray-200" />
+
+          {/* 3. Argument Trees */}
           {belief && (
             <>
               <ArgumentTreesSection
@@ -102,23 +114,23 @@ export default async function ProductReviewPage({ params }: ProductReviewPagePro
             </>
           )}
 
-          {/* 3. Product Performance: Evidence Quality Assessment */}
+          {/* 4. Performance Against the Criteria */}
           <PerformanceSection performance={review.performanceData} />
           <hr className="border-gray-200" />
 
-          {/* 4. Core Design Trade-offs */}
-          <TradeoffsSection tradeoffs={review.tradeoffs} />
+          {/* 5. Design Trade-offs (advertised vs. actual, with Divergence Score) */}
+          <TradeoffsSection
+            tradeoffs={review.tradeoffs}
+            divergenceNote={review.divergenceNote}
+            divergenceScore={review.divergenceScore}
+          />
           <hr className="border-gray-200" />
 
-          {/* 5. Interests & Motivations */}
-          {belief && (
-            <>
-              <InterestsSection interests={belief.interestsAnalysis} />
-              <hr className="border-gray-200" />
-            </>
-          )}
+          {/* 6. Interests Behind the Recommendations */}
+          <RecommenderInterestsSection interests={review.recommenderInterests ?? []} />
+          <hr className="border-gray-200" />
 
-          {/* 6. Foundational Assumptions */}
+          {/* 7. Assumptions Required */}
           {belief && (
             <>
               <AssumptionsSection assumptions={belief.assumptions} />
@@ -126,93 +138,68 @@ export default async function ProductReviewPage({ params }: ProductReviewPagePro
             </>
           )}
 
-          {/* 7. Similar Products & Alternatives */}
+          {/* 8. Alternatives */}
           <AlternativesSection alternatives={review.alternatives} />
           <hr className="border-gray-200" />
 
-          {/* 8. Cost-Benefit Analysis */}
+          {/* 9. Cost-Benefit: total cost of ownership + total value delivered */}
+          <OwnershipSection costs={review.ownershipCosts ?? []} values={review.valueItems ?? []} />
+          <hr className="border-gray-200" />
+
+          {/* 10. Who Should Buy This + Decision rules */}
+          <UserProfilesSection profiles={review.userProfiles} decisionRules={review.decisionRules ?? []} />
+          <hr className="border-gray-200" />
+
+          {/* 11. Decision Obstacles */}
+          <DecisionObstaclesSection obstacles={review.decisionObstacles ?? []} />
+          <hr className="border-gray-200" />
+
+          {/* 12. Biases in the Reviews */}
           {belief && (
             <>
-              <CostBenefitSection
-                cba={belief.costBenefitAnalysis}
-                impact={belief.impactAnalysis}
-                compromises={belief.compromises}
+              <BiasesSection
+                biases={belief.biases}
+                leftHeader="Distorting the positive reviews"
+                rightHeader="Distorting the negative reviews"
               />
               <hr className="border-gray-200" />
             </>
           )}
 
-          {/* 9. Short vs Long-Term Value */}
+          {/* 13. Media */}
           {belief && (
             <>
-              <ImpactSection impact={belief.impactAnalysis} />
+              <MediaResourcesSection
+                media={belief.mediaResources}
+                leftHeader="Reviews supporting the verdict"
+                rightHeader="Reviews challenging the verdict"
+              />
               <hr className="border-gray-200" />
             </>
           )}
 
-          {/* 10. Best Fit User Profiles */}
-          <UserProfilesSection profiles={review.userProfiles} />
-          <hr className="border-gray-200" />
-
-          {/* 11. Common Decision Obstacles */}
-          {belief && (
-            <>
-              <ObstaclesSection obstacles={belief.obstacles} />
-              <hr className="border-gray-200" />
-            </>
-          )}
-
-          {/* 12. Cognitive Biases in Reviews */}
-          {belief && (
-            <>
-              <BiasesSection biases={belief.biases} />
-              <hr className="border-gray-200" />
-            </>
-          )}
-
-          {/* 13. Media Resources */}
-          {belief && (
-            <>
-              <MediaSection media={belief.mediaResources} />
-              <hr className="border-gray-200" />
-            </>
-          )}
-
-          {/* 14. Awards & Certifications */}
+          {/* 14. Recognition */}
           <AwardsSection awards={review.awards} />
           <hr className="border-gray-200" />
 
-          {/* 15. Product Ecosystem */}
+          {/* 15. Ecosystem and Lock-in */}
           <EcosystemSection items={review.ecosystemItems} />
           <hr className="border-gray-200" />
 
-          {/* 16. Evidence (from belief) */}
-          {belief && (
-            <>
-              <EvidenceSection evidence={belief.evidence} />
-              <hr className="border-gray-200" />
-            </>
-          )}
-
-          {/* 17. Contribute */}
-          <ContributeSection />
-
-          {/* Overall Score (bottom) */}
-          <div className="text-right">
-            <p className="text-lg font-bold">
-              Score:{' '}
-              <Link
-                href="/Argument%20scores%20from%20sub-argument%20scores"
-                className="text-[var(--accent)] hover:underline"
-              >
-                {scores.overallScore >= 0 ? '+' : ''}{scores.overallScore.toFixed(1)}
-              </Link>
-              {' '}
-              <span className="text-sm font-normal text-[var(--muted-foreground)]">
-                (based on argument scores)
-              </span>
-            </p>
-          </div>
+          {/* 16. Contribute */}
+          <p className="text-xs text-[#555]">
+            Contribute reviews, evidence, criteria, or alternatives:{' '}
+            <Link href="/contact" className="text-[var(--accent)] hover:underline">Contact me</Link>
+            {' '}·{' '}
+            <a
+              href="https://github.com/myklob/ideastockexchange"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--accent)] hover:underline"
+            >
+              GitHub
+            </a>
+          </p>
         </div>
       </main>
     </div>

--- a/src/features/belief-analysis/components/BiasesSection.tsx
+++ b/src/features/belief-analysis/components/BiasesSection.tsx
@@ -5,6 +5,9 @@ import ExpandableRows from './ExpandableRows'
 
 interface BiasesSectionProps {
   biases: BiasItem[]
+  /** Column header overrides (e.g. the product template's review-distortion wording). */
+  leftHeader?: string
+  rightHeader?: string
 }
 
 const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
@@ -36,7 +39,11 @@ function BiasPairRow({ s, o }: { s: BiasItem | null; o: BiasItem | null }) {
   )
 }
 
-export default function BiasesSection({ biases }: BiasesSectionProps) {
+export default function BiasesSection({
+  biases,
+  leftHeader = 'Biases Affecting Supporters',
+  rightHeader = 'Biases Affecting Opponents',
+}: BiasesSectionProps) {
   const supporters = rankByScore(biases.filter(b => b.side === 'supporter'), b => b.score, Infinity).top
   const opponents = rankByScore(biases.filter(b => b.side === 'opponent'), b => b.score, Infinity).top
   const pairs = pairBySide(supporters, opponents)
@@ -55,9 +62,9 @@ export default function BiasesSection({ biases }: BiasesSectionProps) {
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
             <tr className="bg-gray-100">
-              <th className={`${TH} w-[42%]`}>Biases Affecting Supporters</th>
+              <th className={`${TH} w-[42%]`}>{leftHeader}</th>
               <th className={`${TH} text-center w-[8%]`}>Score</th>
-              <th className={`${TH} w-[42%]`}>Biases Affecting Opponents</th>
+              <th className={`${TH} w-[42%]`}>{rightHeader}</th>
               <th className={`${TH} text-center w-[8%]`}>Score</th>
             </tr>
           </thead>

--- a/src/features/belief-analysis/components/MediaResourcesSection.tsx
+++ b/src/features/belief-analysis/components/MediaResourcesSection.tsx
@@ -5,6 +5,9 @@ import ExpandableRows from './ExpandableRows'
 
 interface MediaResourcesSectionProps {
   media: MediaItem[]
+  /** Side header overrides (e.g. the product template's verdict wording). */
+  leftHeader?: string
+  rightHeader?: string
 }
 
 const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
@@ -48,7 +51,11 @@ function MediaPairRow({ s, c }: { s: MediaItem | null; c: MediaItem | null }) {
   )
 }
 
-export default function MediaResourcesSection({ media }: MediaResourcesSectionProps) {
+export default function MediaResourcesSection({
+  media,
+  leftHeader = 'Supporting the Belief',
+  rightHeader = 'Challenging or Complicating the Belief',
+}: MediaResourcesSectionProps) {
   const supporting = rankByScore(
     media.filter(m => m.side === 'supporting' || m.side === 'agree'),
     m => m.impactScore,
@@ -73,10 +80,10 @@ export default function MediaResourcesSection({ media }: MediaResourcesSectionPr
         <thead>
           <tr>
             <th className="border border-gray-300 bg-green-100 text-center font-semibold px-3 py-2" colSpan={3}>
-              Supporting the Belief
+              {leftHeader}
             </th>
             <th className="border border-gray-300 bg-red-100 text-center font-semibold px-3 py-2" colSpan={3}>
-              Challenging or Complicating the Belief
+              {rightHeader}
             </th>
           </tr>
           <tr className="bg-gray-100 text-xs">

--- a/src/features/product-reviews/components/AlternativesSection.tsx
+++ b/src/features/product-reviews/components/AlternativesSection.tsx
@@ -1,94 +1,64 @@
 import Link from 'next/link'
 import type { AlternativeItem } from '../types'
-import SectionHeading from '@/features/belief-analysis/components/SectionHeading'
+import { formatScore, rankByScore } from '../../belief-analysis/lib/ranking'
+import ExpandableRows from '../../belief-analysis/components/ExpandableRows'
 
 interface AlternativesSectionProps {
   alternatives: AlternativeItem[]
 }
 
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+function relationshipLabel(tier: string): string {
+  return tier.charAt(0).toUpperCase() + tier.slice(1)
+}
+
 export default function AlternativesSection({ alternatives }: AlternativesSectionProps) {
-  const premium = alternatives.filter(a => a.tier === 'premium')
-  const budget = alternatives.filter(a => a.tier === 'budget')
-  const lateral = alternatives.filter(a => a.tier === 'lateral')
+  const { top, rest } = rankByScore(alternatives, a => a.score)
+  const rows: Array<AlternativeItem | null> = top.length > 0 ? top : [null]
+
+  const row = (a: AlternativeItem | null, key: React.Key) => (
+    <tr key={key}>
+      <td className={TD}>
+        {a ? (
+          a.linkSlug ? (
+            <Link href={`/product-reviews/${a.linkSlug}`} className="text-[var(--accent)] hover:underline">
+              {a.alternativeName}
+            </Link>
+          ) : (
+            a.alternativeName
+          )
+        ) : (
+          <span>&nbsp;</span>
+        )}
+      </td>
+      <td className={TDC}>{a ? relationshipLabel(a.tier) : <span>&nbsp;</span>}</td>
+      <td className={TD}>{a?.keyAdvantage ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(a?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
 
   return (
-    <div>
-      <SectionHeading
-        emoji="🔄"
-        title="Similar Products & Alternatives"
-        subtitle="Grouping similar products prevents fragmented debates and ensures comprehensive analysis."
-      />
-
-      {alternatives.length > 0 ? (
-        <>
-          <div className="overflow-x-auto mb-6">
-            <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="text-left px-4 py-3 font-semibold">Premium Alternatives (Higher Cost/Performance)</th>
-                  <th className="text-left px-4 py-3 font-semibold">Budget Alternatives (Lower Cost/Performance)</th>
-                </tr>
-              </thead>
-              <tbody>
-                {Array.from({ length: Math.max(premium.length, budget.length, 1) }).map((_, i) => (
-                  <tr key={i} className="border-t border-gray-200">
-                    <td className="px-4 py-3">
-                      {premium[i] ? (
-                        <>
-                          {premium[i].linkSlug ? (
-                            <Link href={`/product-reviews/${premium[i].linkSlug}`} className="text-[var(--accent)] hover:underline font-medium">
-                              {premium[i].alternativeName}
-                            </Link>
-                          ) : (
-                            <span className="font-medium">{premium[i].alternativeName}</span>
-                          )}
-                          <span className="text-gray-600"> — {premium[i].keyAdvantage}</span>
-                        </>
-                      ) : ''}
-                    </td>
-                    <td className="px-4 py-3">
-                      {budget[i] ? (
-                        <>
-                          {budget[i].linkSlug ? (
-                            <Link href={`/product-reviews/${budget[i].linkSlug}`} className="text-[var(--accent)] hover:underline font-medium">
-                              {budget[i].alternativeName}
-                            </Link>
-                          ) : (
-                            <span className="font-medium">{budget[i].alternativeName}</span>
-                          )}
-                          <span className="text-gray-600"> — {budget[i].keyAdvantage}</span>
-                        </>
-                      ) : ''}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          {lateral.length > 0 && (
-            <div>
-              <p className="text-sm font-semibold mb-2">Lateral Alternatives (Different Trade-offs, Similar Price):</p>
-              <ol className="list-decimal list-inside text-sm text-gray-700 space-y-1">
-                {lateral.map((alt) => (
-                  <li key={alt.id}>
-                    {alt.linkSlug ? (
-                      <Link href={`/product-reviews/${alt.linkSlug}`} className="text-[var(--accent)] hover:underline font-medium">
-                        {alt.alternativeName}
-                      </Link>
-                    ) : (
-                      <span className="font-medium">{alt.alternativeName}</span>
-                    )}
-                    <span className="text-gray-600"> — {alt.keyAdvantage}</span>
-                  </li>
-                ))}
-              </ol>
-            </div>
-          )}
-        </>
-      ) : (
-        <p className="text-sm text-gray-500 italic">No alternative products have been listed yet.</p>
-      )}
-    </div>
+    <section>
+      <h2 className="text-xl font-bold mb-2">🔄 Alternatives</h2>
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr>
+            <th className={`${TH} w-[26%]`}>Alternative</th>
+            <th className={`${TH} w-[18%] text-center`}>Relationship</th>
+            <th className={`${TH} w-[44%]`}>Key difference from this product</th>
+            <th className={`${TH} w-[12%] text-center`}>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((a, i) => row(a, a?.id ?? i))}
+          <ExpandableRows moreCount={rest.length} colSpan={4}>
+            {rest.map(a => row(a, a.id))}
+          </ExpandableRows>
+        </tbody>
+      </table>
+    </section>
   )
 }

--- a/src/features/product-reviews/components/AwardsSection.tsx
+++ b/src/features/product-reviews/components/AwardsSection.tsx
@@ -1,62 +1,60 @@
 import type { AwardItem } from '../types'
-import SectionHeading from '@/features/belief-analysis/components/SectionHeading'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../../belief-analysis/lib/ranking'
+import ExpandableRows from '../../belief-analysis/components/ExpandableRows'
 
 interface AwardsSectionProps {
   awards: AwardItem[]
 }
 
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+function AwardCell({ a }: { a: AwardItem | null }) {
+  if (!a) return <span>&nbsp;</span>
+  return (
+    <>
+      {a.title}
+      {a.details && <span className="text-xs text-[var(--muted-foreground)]"> — {a.details}</span>}
+    </>
+  )
+}
+
 export default function AwardsSection({ awards }: AwardsSectionProps) {
-  const independent = awards.filter(a => a.side === 'independent')
-  const manufacturer = awards.filter(a => a.side === 'manufacturer')
+  const independent = rankByScore(awards.filter(a => a.side === 'independent'), a => a.score, Infinity).top
+  const manufacturer = rankByScore(awards.filter(a => a.side === 'manufacturer'), a => a.score, Infinity).top
+  const pairs = pairBySide(independent, manufacturer)
+  const topPairs = pairs.length > 0 ? pairs.slice(0, TABLE_TOP_LIMIT) : [[null, null] as [AwardItem | null, AwardItem | null]]
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
+
+  const row = ([ind, man]: [AwardItem | null, AwardItem | null], key: React.Key) => (
+    <tr key={key}>
+      <td className={TD}><AwardCell a={ind} /></td>
+      <td className={`${TDC} font-mono`}>{formatScore(ind?.score) ?? <span>&nbsp;</span>}</td>
+      <td className={TD}><AwardCell a={man} /></td>
+      <td className={`${TDC} font-mono`}>{formatScore(man?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
 
   return (
-    <div>
-      <SectionHeading
-        emoji="🏆"
-        title="Awards & Certifications"
-        subtitle="Independent recognition carries more weight than manufacturer marketing. Track the difference."
-      />
-
-      {awards.length > 0 ? (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="text-left px-4 py-3 font-semibold">Independent Recognition</th>
-                <th className="text-left px-4 py-3 font-semibold">Manufacturer Claims</th>
-              </tr>
-            </thead>
-            <tbody>
-              {Array.from({ length: Math.max(independent.length, manufacturer.length, 1) }).map((_, i) => (
-                <tr key={i} className="border-t border-gray-200">
-                  <td className="px-4 py-3">
-                    {independent[i] && (
-                      <>
-                        <span className="font-medium">{independent[i].title}</span>
-                        {independent[i].details && (
-                          <span className="text-gray-600"> — {independent[i].details}</span>
-                        )}
-                      </>
-                    )}
-                  </td>
-                  <td className="px-4 py-3">
-                    {manufacturer[i] && (
-                      <>
-                        <span className="font-medium">{manufacturer[i].title}</span>
-                        {manufacturer[i].details && (
-                          <span className="text-gray-600"> — {manufacturer[i].details}</span>
-                        )}
-                      </>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ) : (
-        <p className="text-sm text-gray-500 italic">No awards or certifications have been recorded yet.</p>
-      )}
-    </div>
+    <section>
+      <h2 className="text-xl font-bold mb-2">🏆 Recognition</h2>
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr>
+            <th className={`${TH} w-[42%]`}>Independent recognition (award, certifier, criteria)</th>
+            <th className={`${TH} w-[8%] text-center`}>Score</th>
+            <th className={`${TH} w-[42%]`}>Manufacturer claims (marketing awards, self-selected statistics)</th>
+            <th className={`${TH} w-[8%] text-center`}>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {topPairs.map((pair, i) => row(pair, pair[0]?.id ?? pair[1]?.id ?? i))}
+          <ExpandableRows moreCount={restPairs.length} colSpan={4}>
+            {restPairs.map((pair, i) => row(pair, pair[0]?.id ?? pair[1]?.id ?? i))}
+          </ExpandableRows>
+        </tbody>
+      </table>
+    </section>
   )
 }

--- a/src/features/product-reviews/components/CategoryCriteriaSection.tsx
+++ b/src/features/product-reviews/components/CategoryCriteriaSection.tsx
@@ -1,0 +1,57 @@
+import type { CategoryCriterionItem } from '../types'
+import { formatScore, rankByScore } from '../../belief-analysis/lib/ranking'
+import ExpandableRows from '../../belief-analysis/components/ExpandableRows'
+
+interface CategoryCriteriaSectionProps {
+  categoryType: string
+  criteria: CategoryCriterionItem[]
+}
+
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+/**
+ * CRITERIA BEFORE BRANDS: this table is filled before performance or
+ * arguments are touched. The criteria apply to every product in the category
+ * and are the yardstick the rest of the page measures against.
+ */
+export default function CategoryCriteriaSection({ categoryType, criteria }: CategoryCriteriaSectionProps) {
+  const { top, rest } = rankByScore(criteria, c => c.score)
+  const rows: Array<CategoryCriterionItem | null> = top.length > 0 ? top : [null]
+
+  const row = (c: CategoryCriterionItem | null, key: React.Key) => (
+    <tr key={key}>
+      <td className={TD}>{c?.criterion ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{c?.howToMeasure ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(c?.importance) ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(c?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold mb-2">🧪 Category Criteria: What Makes a Good {categoryType.replace(/s$/, '')}?</h2>
+      <p className="text-sm text-[var(--muted-foreground)] mb-3">
+        Criteria before brands: these apply to every product in the category and are the yardstick
+        the rest of this page measures against.
+      </p>
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr>
+            <th className={`${TH} w-[34%]`}>Criterion (applies to every product in the category)</th>
+            <th className={`${TH} w-[34%]`}>How to measure it</th>
+            <th className={`${TH} w-[16%] text-center`}>Importance</th>
+            <th className={`${TH} w-[16%] text-center`}>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((c, i) => row(c, c?.id ?? i))}
+          <ExpandableRows moreCount={rest.length} colSpan={4}>
+            {rest.map(c => row(c, c.id))}
+          </ExpandableRows>
+        </tbody>
+      </table>
+    </section>
+  )
+}

--- a/src/features/product-reviews/components/DecisionObstaclesSection.tsx
+++ b/src/features/product-reviews/components/DecisionObstaclesSection.tsx
@@ -1,0 +1,50 @@
+import type { DecisionObstacleItem } from '../types'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../../belief-analysis/lib/ranking'
+import ExpandableRows from '../../belief-analysis/components/ExpandableRows'
+
+interface DecisionObstaclesSectionProps {
+  obstacles: DecisionObstacleItem[]
+}
+
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+export default function DecisionObstaclesSection({ obstacles }: DecisionObstaclesSectionProps) {
+  const overpay = rankByScore(obstacles.filter(o => o.side === 'overpay'), o => o.score, Infinity).top
+  const underinvest = rankByScore(obstacles.filter(o => o.side === 'underinvest'), o => o.score, Infinity).top
+  const pairs = pairBySide(overpay, underinvest)
+  const topPairs = pairs.length > 0 ? pairs.slice(0, TABLE_TOP_LIMIT) : [[null, null] as [DecisionObstacleItem | null, DecisionObstacleItem | null]]
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
+
+  const row = ([o, u]: [DecisionObstacleItem | null, DecisionObstacleItem | null], key: React.Key) => (
+    <tr key={key}>
+      <td className={TD}>{o?.description ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(o?.score) ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{u?.description ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(u?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold mb-2">🚧 Decision Obstacles</h2>
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr>
+            <th className={`${TH} w-[42%]`}>Why buyers overpay in this category</th>
+            <th className={`${TH} w-[8%] text-center`}>Score</th>
+            <th className={`${TH} w-[42%]`}>Why buyers underinvest in this category</th>
+            <th className={`${TH} w-[8%] text-center`}>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {topPairs.map((pair, i) => row(pair, pair[0]?.id ?? pair[1]?.id ?? i))}
+          <ExpandableRows moreCount={restPairs.length} colSpan={4}>
+            {restPairs.map((pair, i) => row(pair, pair[0]?.id ?? pair[1]?.id ?? i))}
+          </ExpandableRows>
+        </tbody>
+      </table>
+    </section>
+  )
+}

--- a/src/features/product-reviews/components/EcosystemSection.tsx
+++ b/src/features/product-reviews/components/EcosystemSection.tsx
@@ -1,61 +1,53 @@
 import type { EcosystemItem } from '../types'
-import SectionHeading from '@/features/belief-analysis/components/SectionHeading'
+import { formatScore, rankByScore } from '../../belief-analysis/lib/ranking'
+import ExpandableRows from '../../belief-analysis/components/ExpandableRows'
 
 interface EcosystemSectionProps {
   items: EcosystemItem[]
 }
 
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+const TYPE_LABELS: Record<string, string> = {
+  upstream: 'Upstream: needed first',
+  downstream: 'Downstream: wanted after',
+  lockin: 'Lock-in',
+}
+
 export default function EcosystemSection({ items }: EcosystemSectionProps) {
-  const upstream = items.filter(i => i.category === 'upstream')
-  const downstream = items.filter(i => i.category === 'downstream')
-  const lockin = items.filter(i => i.category === 'lockin')
+  const { top, rest } = rankByScore(items, i => i.score)
+  const rows: Array<EcosystemItem | null> = top.length > 0 ? top : [null]
+
+  const row = (item: EcosystemItem | null, key: React.Key) => (
+    <tr key={key}>
+      <td className={TD}>{item?.description ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{item ? (TYPE_LABELS[item.category] ?? item.category) : <span>&nbsp;</span>}</td>
+      <td className={TD}>{item?.cost ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(item?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
 
   return (
-    <div>
-      <SectionHeading
-        emoji="🧭"
-        title="Product Ecosystem: Related Purchases"
-        subtitle="Understanding the full ecosystem helps calculate true long-term cost and commitment level."
-      />
-
-      {items.length > 0 ? (
-        <div className="space-y-4">
-          {upstream.length > 0 && (
-            <div>
-              <p className="text-sm font-semibold mb-2">Upstream Dependencies (You Need These First):</p>
-              <ol className="list-decimal list-inside text-sm text-gray-700 space-y-1">
-                {upstream.map(item => (
-                  <li key={item.id}>{item.description}</li>
-                ))}
-              </ol>
-            </div>
-          )}
-
-          {downstream.length > 0 && (
-            <div>
-              <p className="text-sm font-semibold mb-2">Downstream Additions (You Might Want These After):</p>
-              <ol className="list-decimal list-inside text-sm text-gray-700 space-y-1">
-                {downstream.map(item => (
-                  <li key={item.id}>{item.description}</li>
-                ))}
-              </ol>
-            </div>
-          )}
-
-          {lockin.length > 0 && (
-            <div>
-              <p className="text-sm font-semibold mb-2">Lock-in Considerations:</p>
-              <ol className="list-decimal list-inside text-sm text-gray-700 space-y-1">
-                {lockin.map(item => (
-                  <li key={item.id}>{item.description}</li>
-                ))}
-              </ol>
-            </div>
-          )}
-        </div>
-      ) : (
-        <p className="text-sm text-gray-500 italic">No ecosystem analysis has been recorded yet.</p>
-      )}
-    </div>
+    <section>
+      <h2 className="text-xl font-bold mb-2">🧭 Ecosystem and Lock-in</h2>
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr>
+            <th className={`${TH} w-[30%]`}>Item</th>
+            <th className={`${TH} w-[24%] text-center`}>Type</th>
+            <th className={`${TH} w-[34%]`}>Cost or commitment</th>
+            <th className={`${TH} w-[12%] text-center`}>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((item, i) => row(item, item?.id ?? i))}
+          <ExpandableRows moreCount={rest.length} colSpan={4}>
+            {rest.map(item => row(item, item.id))}
+          </ExpandableRows>
+        </tbody>
+      </table>
+    </section>
   )
 }

--- a/src/features/product-reviews/components/OwnershipSection.tsx
+++ b/src/features/product-reviews/components/OwnershipSection.tsx
@@ -1,0 +1,120 @@
+import Link from 'next/link'
+import type { OwnershipCostItem, ValueItem } from '../types'
+import { formatScore, rankByScore } from '../../belief-analysis/lib/ranking'
+import ExpandableRows from '../../belief-analysis/components/ExpandableRows'
+import TierBadge from './TierBadge'
+
+interface OwnershipSectionProps {
+  costs: OwnershipCostItem[]
+  values: ValueItem[]
+}
+
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+const COST_TYPE_LABELS: Record<string, string> = {
+  initial: 'Initial',
+  ongoing: 'Ongoing',
+  hidden: 'Hidden',
+  opportunity: 'Opportunity',
+}
+
+const TIMEFRAME_LABELS: Record<string, string> = {
+  short: 'Short-term (0-2 years)',
+  long: 'Long-term (3+ years)',
+  both: 'Short-term / Long-term',
+}
+
+function sourceCell(source: string | null, tier: number | null): React.ReactNode {
+  if (!source && tier == null) return <span>&nbsp;</span>
+  return (
+    <>
+      {source ?? <span className="text-[var(--muted-foreground)] italic">unsourced</span>}
+      <TierBadge tier={tier} />
+    </>
+  )
+}
+
+/**
+ * Cost-Benefit Analysis, product form: total cost of ownership and total
+ * value delivered. Costs and benefits keep their units and never collapse
+ * across categories unless the conversion is stated.
+ */
+export default function OwnershipSection({ costs, values }: OwnershipSectionProps) {
+  const rankedCosts = rankByScore(costs, c => c.score)
+  const rankedValues = rankByScore(values, v => v.score)
+
+  const costRow = (c: OwnershipCostItem | null, key: React.Key) => (
+    <tr key={key}>
+      <td className={TD}>{c?.item ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{c?.estimate ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{c ? (COST_TYPE_LABELS[c.costType] ?? c.costType) : <span>&nbsp;</span>}</td>
+      <td className={TD}>{c ? sourceCell(c.source, c.evidenceTier) : <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(c?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+
+  const valueRow = (v: ValueItem | null, key: React.Key) => (
+    <tr key={key}>
+      <td className={TD}>{v?.item ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{v?.measure ?? <span>&nbsp;</span>}</td>
+      <td className={TDC}>{v ? (TIMEFRAME_LABELS[v.timeframe] ?? v.timeframe) : <span>&nbsp;</span>}</td>
+      <td className={TD}>{v ? sourceCell(v.source, v.evidenceTier) : <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(v?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+
+  return (
+    <section className="space-y-5">
+      <h2 className="text-xl font-bold mb-2">
+        💰{' '}
+        <Link href="/cost-benefit%20analysis" className="text-[var(--accent)] hover:underline">
+          Cost-Benefit Analysis
+        </Link>
+      </h2>
+
+      <div>
+        <h3 className="text-base font-semibold mb-2">Total cost of ownership</h3>
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr>
+              <th className={`${TH} w-[30%]`}>Cost item</th>
+              <th className={`${TH} w-[18%]`}>Estimate (with units)</th>
+              <th className={`${TH} w-[20%] text-center`}>Type</th>
+              <th className={`${TH} w-[20%]`}>Evidence (source + tier)</th>
+              <th className={`${TH} w-[12%] text-center`}>Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(rankedCosts.top.length > 0 ? rankedCosts.top : [null]).map((c, i) => costRow(c, c?.id ?? i))}
+            <ExpandableRows moreCount={rankedCosts.rest.length} colSpan={5}>
+              {rankedCosts.rest.map(c => costRow(c, c.id))}
+            </ExpandableRows>
+          </tbody>
+        </table>
+      </div>
+
+      <div>
+        <h3 className="text-base font-semibold mb-2">Total value delivered</h3>
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr>
+              <th className={`${TH} w-[30%]`}>Value item</th>
+              <th className={`${TH} w-[18%]`}>Measure (with units)</th>
+              <th className={`${TH} w-[20%] text-center`}>Timeframe</th>
+              <th className={`${TH} w-[20%]`}>Evidence (source + tier)</th>
+              <th className={`${TH} w-[12%] text-center`}>Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(rankedValues.top.length > 0 ? rankedValues.top : [null]).map((v, i) => valueRow(v, v?.id ?? i))}
+            <ExpandableRows moreCount={rankedValues.rest.length} colSpan={5}>
+              {rankedValues.rest.map(v => valueRow(v, v.id))}
+            </ExpandableRows>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/src/features/product-reviews/components/PerformanceSection.tsx
+++ b/src/features/product-reviews/components/PerformanceSection.tsx
@@ -1,79 +1,76 @@
 import type { PerformanceItem } from '../types'
-import { getEvidenceTierColor, EVIDENCE_TIER_LABELS } from '../types'
-import SectionHeading from '@/features/belief-analysis/components/SectionHeading'
+import { formatScore, rankByScore } from '../../belief-analysis/lib/ranking'
+import ExpandableRows from '../../belief-analysis/components/ExpandableRows'
+import TierBadge from './TierBadge'
 
 interface PerformanceSectionProps {
   performance: PerformanceItem[]
 }
 
-export default function PerformanceSection({ performance }: PerformanceSectionProps) {
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+function SourceCell({ p }: { p: PerformanceItem }) {
+  const name = p.source ?? (p.sourceUrl ? new URL(p.sourceUrl).hostname : null)
   return (
-    <div>
-      <SectionHeading
-        emoji="📂"
-        title="Product Performance: Evidence Quality Assessment"
-        subtitle="How does this specific product perform on the category criteria established above?"
-      />
-
-      {performance.length > 0 ? (
-        <>
-          <div className="overflow-x-auto mb-6">
-            <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="text-left px-4 py-3 font-semibold">Category Criterion</th>
-                  <th className="text-left px-4 py-3 font-semibold">This Product&apos;s Performance</th>
-                  <th className="text-left px-4 py-3 font-semibold">Evidence Quality</th>
-                  <th className="text-left px-4 py-3 font-semibold">Comparison to Category Average</th>
-                </tr>
-              </thead>
-              <tbody>
-                {performance.map((item) => (
-                  <tr key={item.id} className="border-t border-gray-200">
-                    <td className="px-4 py-3 font-medium">{item.criterion}</td>
-                    <td className="px-4 py-3">{item.measurement}</td>
-                    <td className="px-4 py-3">
-                      <span
-                        className="inline-block px-2 py-1 rounded text-xs font-medium text-white"
-                        style={{ backgroundColor: getEvidenceTierColor(item.evidenceTier) }}
-                      >
-                        Tier {item.evidenceTier}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className={
-                        item.comparisonToAvg === 'Better' ? 'text-green-600 font-medium' :
-                        item.comparisonToAvg === 'Worse' ? 'text-red-600 font-medium' :
-                        'text-gray-600'
-                      }>
-                        {item.comparisonToAvg}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="bg-gray-50 p-4 rounded-lg">
-            <p className="text-sm font-semibold mb-2">Evidence Tier Definitions:</p>
-            <ul className="text-sm text-gray-600 space-y-1">
-              {Object.entries(EVIDENCE_TIER_LABELS).map(([tier, label]) => (
-                <li key={tier}>
-                  <span className="font-medium">Tier {tier}:</span> {label}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </>
+    <>
+      {p.sourceUrl ? (
+        <a href={p.sourceUrl} target="_blank" rel="noopener noreferrer" className="text-[var(--accent)] hover:underline">
+          {name ?? 'Source'}
+        </a>
       ) : (
-        <p className="text-sm text-gray-500 italic">No performance data has been recorded yet.</p>
+        name ?? <span className="text-[var(--muted-foreground)] italic">unsourced</span>
       )}
+      <TierBadge tier={p.evidenceTier} />
+    </>
+  )
+}
 
-      <p className="text-sm text-gray-500 italic mt-4">
-        This section evaluates the specific product against the objective criteria established at the top,
-        with evidence quality tracked for each measurement.
+export default function PerformanceSection({ performance }: PerformanceSectionProps) {
+  const { top, rest } = rankByScore(performance, p => p.impact)
+  const rows: Array<PerformanceItem | null> = top.length > 0 ? top : [null]
+
+  const row = (p: PerformanceItem | null, key: React.Key) => (
+    <tr key={key}>
+      <td className={TD}>{p?.criterion ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{p?.measurement ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>
+        {p ? (p.benchmark ?? <span className="text-xs text-[var(--muted-foreground)]">{p.comparisonToAvg} than average</span>) : <span>&nbsp;</span>}
+      </td>
+      <td className={TD}>{p ? <SourceCell p={p} /> : <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(p?.impact) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold mb-2">📂 Performance Against the Criteria</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr>
+              <th className={`${TH} w-[20%]`}>Criterion (from the table above)</th>
+              <th className={`${TH} w-[22%]`}>This product&apos;s measured performance</th>
+              <th className={`${TH} w-[22%]`}>Category average / best rival</th>
+              <th className={`${TH} w-[22%]`}>Evidence (source + tier)</th>
+              <th className={`${TH} w-[14%] text-center`}>Impact</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((p, i) => row(p, p?.id ?? i))}
+            <ExpandableRows moreCount={rest.length} colSpan={5}>
+              {rest.map(p => row(p, p.id))}
+            </ExpandableRows>
+          </tbody>
+        </table>
+      </div>
+      <p className="text-xs text-[#555] mt-2">
+        Tier key: <strong>Tier 1</strong> independent lab tests and certified ratings ·{' '}
+        <strong>Tier 2</strong> professional reviewer consensus, third-party-verified manufacturer
+        data · <strong>Tier 3</strong> aggregated user reviews, investigative journalism ·{' '}
+        <strong>Tier 4</strong> individual testimonials, unverified manufacturer claims.
       </p>
-    </div>
+    </section>
   )
 }

--- a/src/features/product-reviews/components/ProductScoreHeader.tsx
+++ b/src/features/product-reviews/components/ProductScoreHeader.tsx
@@ -5,6 +5,9 @@ interface ProductScoreHeaderProps {
   productName: string
   brand: string
   claim: string
+  /** Title scope: "[Product] is the best [Product Type] for [useCase]". */
+  useCase: string | null
+  priceSegment: string | null
   categoryType: string
   categorySubtype: string | null
   scores: ProductReviewScores
@@ -14,6 +17,8 @@ export default function ProductScoreHeader({
   productName,
   brand,
   claim,
+  useCase,
+  priceSegment,
   categoryType,
   categorySubtype,
   scores,
@@ -23,79 +28,66 @@ export default function ProductScoreHeader({
     scores.overallScore >= -20 ? '#eab308' :
     '#ef4444'
 
+  // THE TITLE MUST CARRY A SCOPE: bare "best" fails the costability test
+  // (compared to what, measured in what, for whom).
+  const title = useCase
+    ? `${productName} is the best ${categoryType.replace(/s$/, '').toLowerCase()} for ${useCase}`
+    : claim
+
   return (
-    <div className="bg-gray-50 border border-gray-200 rounded-lg p-6 mb-8">
-      <h1 className="text-2xl font-bold text-[var(--foreground)] mb-2">
-        You should Buy This Product: {productName}
-      </h1>
-      <p className="text-gray-600 mb-4 italic">{claim}</p>
+    <div className="mb-8">
+      <p className="text-right text-xs text-[var(--muted-foreground)] mb-2">
+        <Link href="/" className="text-[var(--accent)] hover:underline">Home</Link> ›{' '}
+        <Link href="/product-reviews" className="text-[var(--accent)] hover:underline">Topics</Link> ›{' '}
+        {categoryType} › <strong>{productName}</strong>
+      </p>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <p className="text-sm">
-            <span className="font-semibold">Score:</span>{' '}
-            <span style={{ color: scoreColor }} className="font-bold text-lg">
-              {scores.overallScore >= 0 ? '+' : ''}{scores.overallScore.toFixed(1)}
-            </span>
-            {' '}
-            <Link
-              href="/Argument%20scores%20from%20sub-argument%20scores"
-              className="text-xs text-[var(--accent)] hover:underline"
-            >
-              (based on argument scores)
-            </Link>
-          </p>
-          <p className="text-sm">
-            <Link href="/One%20Page%20Per%20Topic" className="text-[var(--accent)] hover:underline font-semibold">
-              Category
-            </Link>:{' '}
-            <Link href={`/product-reviews/categories?type=${encodeURIComponent(categoryType)}`} className="text-[var(--accent)] hover:underline">
-              {categoryType}
-            </Link>
-            {categorySubtype && <> &gt; {categorySubtype}</>}
-            {' '}&gt; {brand} / {productName}
-          </p>
-        </div>
+      <h1 className="text-2xl font-bold text-[var(--foreground)] mb-3 leading-tight">{title}</h1>
 
-        <div className="space-y-2 text-right">
-          {scores.categoryRank != null && (
-            <p className="text-sm">
-              <span className="font-semibold">Category Rank:</span>{' '}
-              <span className="font-bold text-lg">
-                #{scores.categoryRank}
-              </span>
-              {scores.totalInCategory > 0 && (
-                <span className="text-gray-500"> of {scores.totalInCategory}</span>
-              )}
-            </p>
-          )}
-          <p className="text-sm">
-            <span className="font-semibold">Avg Evidence Tier:</span>{' '}
-            {scores.avgEvidenceTier.toFixed(1)}
-            <span className="text-gray-500 text-xs ml-1">(lower is better)</span>
-          </p>
-          <p className="text-sm">
-            <span className="text-green-600">{scores.performanceBetterCount} better</span>
-            {' / '}
-            <span className="text-gray-600">{scores.performanceSameCount} same</span>
-            {' / '}
-            <span className="text-red-600">{scores.performanceWorseCount} worse</span>
-            <span className="text-gray-500 text-xs ml-1"> vs category avg</span>
-          </p>
-        </div>
-      </div>
-
-      <p className="text-xs text-gray-500 mt-4">
-        This template structures every product review in the Idea Stock Exchange. Each section helps build
-        a complete analysis from multiple angles.{' '}
-        <a
-          href="https://github.com/myklob/ideastockexchange"
-          target="_blank"
-          rel="noopener noreferrer"
+      <p className="text-sm mb-1">
+        <strong>Net Belief Score:</strong>{' '}
+        <span
+          className="px-2.5 py-0.5 bg-[#e8eef5] border border-[#b0b8c1] font-semibold"
+          style={{ color: scoreColor }}
+        >
+          {scores.overallScore >= 0 ? '+' : ''}{scores.overallScore.toFixed(1)}
+        </span>{' '}
+        <span className="text-xs text-[var(--muted-foreground)]">(computed from argument scores)</span>
+        {' '}|{' '}
+        <Link href="/One%20Page%20Per%20Topic" className="text-[var(--accent)] hover:underline font-semibold">
+          Category
+        </Link>:{' '}
+        <Link
+          href={`/product-reviews/categories?type=${encodeURIComponent(categoryType)}`}
           className="text-[var(--accent)] hover:underline"
         >
-          View the full technical documentation on GitHub
-        </a>.
+          {categoryType}
+        </Link>
+        {categorySubtype && <> &gt; {categorySubtype}</>}
+        {' '}&gt; {brand} / {productName}
+        {priceSegment && (
+          <>
+            {' '}| <strong>Price segment:</strong> {priceSegment}
+          </>
+        )}
+        {scores.categoryRank != null && (
+          <>
+            {' '}| <strong>Category rank:</strong> #{scores.categoryRank}
+            {scores.totalInCategory > 0 && <span className="text-[var(--muted-foreground)]"> of {scores.totalInCategory}</span>}
+          </>
+        )}
+      </p>
+
+      <p className="text-xs text-[#555]">
+        Method:{' '}
+        <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">Linkage Scores</Link>
+        {' '}·{' '}
+        <Link href="/Argument%20scores%20from%20sub-argument%20scores" className="text-[var(--accent)] hover:underline">
+          Argument scores from sub-argument scores
+        </Link>
+        {' '}·{' '}
+        <Link href="/cost-benefit%20analysis" className="text-[var(--accent)] hover:underline">Cost-Benefit Analysis</Link>
+        . Unscored cells stay blank until the engine computes them.
       </p>
     </div>
   )

--- a/src/features/product-reviews/components/ProductScorecardSection.tsx
+++ b/src/features/product-reviews/components/ProductScorecardSection.tsx
@@ -1,0 +1,93 @@
+import type { ProductReviewWithRelations } from '../types'
+import type { ArgumentWithBelief } from '../../belief-analysis/types'
+import { byScoreDesc } from '../../belief-analysis/lib/ranking'
+
+interface ProductScorecardSectionProps {
+  review: ProductReviewWithRelations
+}
+
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const LABEL = `${TD} bg-[#f0f3f6] w-[30%] font-semibold`
+
+function argLabel(arg: ArgumentWithBelief | null): React.ReactNode {
+  if (!arg) return <span className="text-[var(--muted-foreground)] italic">[pending]</span>
+  const impact = arg.impactScore ? ` · Impact ${Math.abs(arg.impactScore).toFixed(1)}` : ''
+  return (
+    <>
+      {arg.claim ?? arg.belief.statement}
+      {impact && <span className="text-xs text-[#555]">{impact}</span>}
+    </>
+  )
+}
+
+/**
+ * The Scorecard. Every cell except Bottom line and What would change this
+ * verdict is auto-derived from the tables below — never hand-picked.
+ */
+export default function ProductScorecardSection({ review }: ProductScorecardSectionProps) {
+  const args = review.belief?.arguments ?? []
+  const impact = (a: ArgumentWithBelief) => (a.impactScore ? Math.abs(a.impactScore) : null)
+  const bestPro = args.filter(a => a.side === 'agree').sort(byScoreDesc(impact))[0] ?? null
+  const bestCon = args.filter(a => a.side === 'disagree').sort(byScoreDesc(impact))[0] ?? null
+
+  const ideal = review.userProfiles.filter(p => p.side === 'ideal')[0] ?? null
+  const notIdeal = review.userProfiles.filter(p => p.side === 'not_ideal')[0] ?? null
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold mb-2">📊 Scorecard</h2>
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <tbody>
+          <tr>
+            <td className={LABEL}>Bottom line</td>
+            <td className={TD}>
+              {review.bottomLine ?? (
+                <span className="text-[var(--muted-foreground)] italic">
+                  One-sentence verdict scoped to the use case in the title.
+                </span>
+              )}
+            </td>
+          </tr>
+          <tr className="bg-gray-50">
+            <td className={LABEL}>Strongest reason to agree</td>
+            <td className={TD}>
+              {argLabel(bestPro)}{' '}
+              <span className="text-[11px] text-[#999]">(auto-derived: top pro row in Argument Trees)</span>
+            </td>
+          </tr>
+          <tr>
+            <td className={LABEL}>Strongest reason to disagree</td>
+            <td className={TD}>
+              {argLabel(bestCon)}{' '}
+              <span className="text-[11px] text-[#999]">(auto-derived: top con row in Argument Trees)</span>
+            </td>
+          </tr>
+          <tr className="bg-gray-50">
+            <td className={LABEL}>Best for</td>
+            <td className={TD}>
+              {ideal?.description ?? <span className="text-[var(--muted-foreground)] italic">[pending]</span>}{' '}
+              <span className="text-[11px] text-[#999]">(auto-derived: top row of Who Should Buy This)</span>
+            </td>
+          </tr>
+          <tr>
+            <td className={LABEL}>Not for</td>
+            <td className={TD}>
+              {notIdeal?.description ?? <span className="text-[var(--muted-foreground)] italic">[pending]</span>}{' '}
+              <span className="text-[11px] text-[#999]">(auto-derived: top &ldquo;not ideal&rdquo; row of Who Should Buy This)</span>
+            </td>
+          </tr>
+          <tr className="bg-gray-50">
+            <td className={LABEL}>What would change this verdict</td>
+            <td className={TD}>
+              {review.verdictChanger ?? (
+                <span className="text-[var(--muted-foreground)] italic">
+                  The measurement or price change that would flip the net score.
+                </span>
+              )}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  )
+}

--- a/src/features/product-reviews/components/RecommenderInterestsSection.tsx
+++ b/src/features/product-reviews/components/RecommenderInterestsSection.tsx
@@ -1,0 +1,80 @@
+import type { RecommenderInterestItem } from '../types'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../../belief-analysis/lib/ranking'
+import ExpandableRows from '../../belief-analysis/components/ExpandableRows'
+
+interface RecommenderInterestsSectionProps {
+  interests: RecommenderInterestItem[]
+}
+
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+function InterestCell({ item }: { item: RecommenderInterestItem | null }) {
+  if (!item) return <span>&nbsp;</span>
+  return (
+    <>
+      {item.description}
+      {item.evidence && (
+        <span className="text-xs text-[var(--muted-foreground)]"> — Evidence: {item.evidence}</span>
+      )}
+    </>
+  )
+}
+
+/**
+ * Interests Behind the Recommendations. Hidden-interest attributions
+ * (affiliate money, ecosystem lock-in) render as the italic rows: they are
+ * scored claims requiring evidence, applied with equal suspicion to
+ * recommenders of this product and recommenders of alternatives.
+ */
+export default function RecommenderInterestsSection({ interests }: RecommenderInterestsSectionProps) {
+  const stated = (side: string) =>
+    rankByScore(interests.filter(i => i.side === side && !i.hidden), i => i.score, Infinity).top
+  const hiddenRows = (side: string) =>
+    rankByScore(interests.filter(i => i.side === side && i.hidden), i => i.score, Infinity).top
+
+  const pairs = pairBySide(stated('product'), stated('alternatives'))
+  const topPairs = pairs.length > 0 ? pairs.slice(0, TABLE_TOP_LIMIT) : [[null, null] as [RecommenderInterestItem | null, RecommenderInterestItem | null]]
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
+  const hiddenPairs = pairBySide(hiddenRows('product'), hiddenRows('alternatives'))
+
+  const row = ([p, a]: [RecommenderInterestItem | null, RecommenderInterestItem | null], key: React.Key, hidden = false) => (
+    <tr key={key} className={hidden ? 'italic bg-[#fdf6ec]' : ''}>
+      <td className={TD}><InterestCell item={p} /></td>
+      <td className={`${TDC} font-mono`}>{formatScore(p?.score) ?? <span>&nbsp;</span>}</td>
+      <td className={TD}><InterestCell item={a} /></td>
+      <td className={`${TDC} font-mono`}>{formatScore(a?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold mb-2">💡 Interests Behind the Recommendations</h2>
+      <p className="text-sm text-[var(--muted-foreground)] mb-3">
+        Who recommends this product or its alternatives, what they gain, and what they optimize
+        for. The italic rows are candidate hidden interests — scored claims requiring evidence,
+        applied with equal suspicion to both sides.
+      </p>
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr>
+            <th className={`${TH} w-[42%]`}>Those who recommend this product</th>
+            <th className={`${TH} w-[8%] text-center`}>Score</th>
+            <th className={`${TH} w-[42%]`}>Those who recommend alternatives</th>
+            <th className={`${TH} w-[8%] text-center`}>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {topPairs.map((pair, i) => row(pair, pair[0]?.id ?? pair[1]?.id ?? i))}
+          <ExpandableRows moreCount={restPairs.length} colSpan={4}>
+            {restPairs.map((pair, i) => row(pair, pair[0]?.id ?? pair[1]?.id ?? i))}
+          </ExpandableRows>
+          {(hiddenPairs.length > 0 ? hiddenPairs : [[null, null] as [RecommenderInterestItem | null, RecommenderInterestItem | null]]).map(
+            (pair, i) => row(pair, `h${pair[0]?.id ?? pair[1]?.id ?? i}`, true),
+          )}
+        </tbody>
+      </table>
+    </section>
+  )
+}

--- a/src/features/product-reviews/components/TierBadge.tsx
+++ b/src/features/product-reviews/components/TierBadge.tsx
@@ -1,0 +1,21 @@
+const TIER_STYLES: Record<number, string> = {
+  1: 'bg-[#1e7e34]',
+  2: 'bg-[#b8860b]',
+  3: 'bg-[#7f8c8d]',
+  4: 'bg-[#a0522d]',
+}
+
+/**
+ * Evidence tier badge. Tier 1 independent lab tests and certified ratings;
+ * Tier 2 professional reviewer consensus, third-party-verified manufacturer
+ * data; Tier 3 aggregated user reviews, investigative journalism; Tier 4
+ * individual testimonials, unverified manufacturer claims.
+ */
+export default function TierBadge({ tier }: { tier: number | null | undefined }) {
+  if (tier == null) return null
+  return (
+    <span className={`${TIER_STYLES[tier] ?? 'bg-gray-500'} text-white text-[11px] px-1.5 py-0.5 ml-1 whitespace-nowrap`}>
+      Tier {tier}
+    </span>
+  )
+}

--- a/src/features/product-reviews/components/TradeoffsSection.tsx
+++ b/src/features/product-reviews/components/TradeoffsSection.tsx
@@ -1,68 +1,72 @@
 import type { TradeoffItem } from '../types'
-import SectionHeading from '@/features/belief-analysis/components/SectionHeading'
+import { formatScore } from '../../belief-analysis/lib/ranking'
 
 interface TradeoffsSectionProps {
   tradeoffs: TradeoffItem[]
+  /** How far the advertised optimization differs from the actual one. */
+  divergenceNote?: string | null
+  /** Score of the sub-debate that advertised differs from actual. */
+  divergenceScore?: number | null
 }
 
-export default function TradeoffsSection({ tradeoffs }: TradeoffsSectionProps) {
-  const advertisedOptimizes = tradeoffs.filter(t => t.side === 'optimizes' && t.category === 'advertised')
-  const advertisedSacrifices = tradeoffs.filter(t => t.side === 'sacrifices' && t.category === 'advertised')
-  const actualOptimizes = tradeoffs.filter(t => t.side === 'optimizes' && t.category === 'actual')
-  const actualSacrifices = tradeoffs.filter(t => t.side === 'sacrifices' && t.category === 'actual')
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+function cell(items: TradeoffItem[]): React.ReactNode {
+  if (items.length === 0) return <span>&nbsp;</span>
+  return items.map((t, i) => <span key={t.id}>{i > 0 && <br />}{t.description}</span>)
+}
+
+/** Best row score across a category's records, blank when none are scored. */
+function rowScore(items: TradeoffItem[]): number | null {
+  const scored = items.map(t => t.score).filter((s): s is number => s != null)
+  return scored.length > 0 ? Math.max(...scored) : null
+}
+
+export default function TradeoffsSection({ tradeoffs, divergenceNote, divergenceScore }: TradeoffsSectionProps) {
+  const advertised = tradeoffs.filter(t => t.category === 'advertised')
+  const actual = tradeoffs.filter(t => t.category === 'actual')
+
+  const row = (label: string, sub: string, items: TradeoffItem[], striped: boolean) => (
+    <tr className={striped ? 'bg-gray-50' : ''}>
+      <td className={`${TD} bg-[#f0f3f6]`}>
+        <strong>{label}</strong> <span className="text-xs text-[#555]">({sub})</span>
+      </td>
+      <td className={TD}>{cell(items.filter(t => t.side === 'optimizes'))}</td>
+      <td className={TD}>{cell(items.filter(t => t.side === 'sacrifices'))}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(rowScore(items)) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
 
   return (
-    <div>
-      <SectionHeading
-        emoji="⚖️"
-        title="Core Design Trade-offs"
-        subtitle="Every product design involves trade-offs. Understanding these helps users determine if this product's specific balance matches their priorities."
-      />
-
-      {tradeoffs.length > 0 ? (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="text-left px-4 py-3 font-semibold">What This Product Optimizes For</th>
-                <th className="text-left px-4 py-3 font-semibold">What This Product Sacrifices</th>
-              </tr>
-            </thead>
-            <tbody>
-              {(advertisedOptimizes.length > 0 || advertisedSacrifices.length > 0) && (
-                <>
-                  <tr className="border-t border-gray-200 bg-gray-50/50">
-                    <td className="px-4 py-2 font-semibold text-xs uppercase text-gray-500">Advertised</td>
-                    <td className="px-4 py-2 font-semibold text-xs uppercase text-gray-500">Advertised</td>
-                  </tr>
-                  {Array.from({ length: Math.max(advertisedOptimizes.length, advertisedSacrifices.length) }).map((_, i) => (
-                    <tr key={`adv-${i}`} className="border-t border-gray-200">
-                      <td className="px-4 py-3">{advertisedOptimizes[i]?.description ?? ''}</td>
-                      <td className="px-4 py-3">{advertisedSacrifices[i]?.description ?? ''}</td>
-                    </tr>
-                  ))}
-                </>
+    <section>
+      <h2 className="text-xl font-bold mb-2">⚖️ Design Trade-offs</h2>
+      <table className="w-full border-collapse border border-gray-300 text-sm">
+        <thead>
+          <tr>
+            <th className={`${TH} w-[20%]`}>&nbsp;</th>
+            <th className={`${TH} w-[34%]`}>Optimizes for</th>
+            <th className={`${TH} w-[34%]`}>Sacrifices</th>
+            <th className={`${TH} w-[12%] text-center`}>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {row('Advertised', 'what the manufacturer says', advertised, false)}
+          {row('Actual', 'what the design choices and evidence show', actual, true)}
+          <tr>
+            <td className={`${TD} bg-[#f0f3f6]`}><strong>Divergence Score</strong></td>
+            <td className={TD} colSpan={2}>
+              {divergenceNote ?? (
+                <span className="text-[var(--muted-foreground)] italic">
+                  How far the advertised optimization differs from the actual one; scored by its own sub-debate.
+                </span>
               )}
-              {(actualOptimizes.length > 0 || actualSacrifices.length > 0) && (
-                <>
-                  <tr className="border-t border-gray-200 bg-gray-50/50">
-                    <td className="px-4 py-2 font-semibold text-xs uppercase text-gray-500">Actual (what evidence shows)</td>
-                    <td className="px-4 py-2 font-semibold text-xs uppercase text-gray-500">Actual (what evidence shows)</td>
-                  </tr>
-                  {Array.from({ length: Math.max(actualOptimizes.length, actualSacrifices.length) }).map((_, i) => (
-                    <tr key={`act-${i}`} className="border-t border-gray-200">
-                      <td className="px-4 py-3">{actualOptimizes[i]?.description ?? ''}</td>
-                      <td className="px-4 py-3">{actualSacrifices[i]?.description ?? ''}</td>
-                    </tr>
-                  ))}
-                </>
-              )}
-            </tbody>
-          </table>
-        </div>
-      ) : (
-        <p className="text-sm text-gray-500 italic">No trade-off analysis has been recorded yet.</p>
-      )}
-    </div>
+            </td>
+            <td className={`${TDC} font-mono`}>{formatScore(divergenceScore) ?? <span>&nbsp;</span>}</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
   )
 }

--- a/src/features/product-reviews/components/UserProfilesSection.tsx
+++ b/src/features/product-reviews/components/UserProfilesSection.tsx
@@ -1,44 +1,93 @@
-import type { UserProfileItem } from '../types'
-import SectionHeading from '@/features/belief-analysis/components/SectionHeading'
+import type { UserProfileItem, DecisionRuleItem } from '../types'
+import { formatScore, pairBySide, rankByScore, TABLE_TOP_LIMIT } from '../../belief-analysis/lib/ranking'
+import ExpandableRows from '../../belief-analysis/components/ExpandableRows'
 
 interface UserProfilesSectionProps {
   profiles: UserProfileItem[]
+  decisionRules?: DecisionRuleItem[]
 }
 
-export default function UserProfilesSection({ profiles }: UserProfilesSectionProps) {
-  const ideal = profiles.filter(p => p.side === 'ideal')
-  const notIdeal = profiles.filter(p => p.side === 'not_ideal')
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center'
+
+export default function UserProfilesSection({ profiles, decisionRules = [] }: UserProfilesSectionProps) {
+  const ideal = rankByScore(profiles.filter(p => p.side === 'ideal'), p => p.score, Infinity).top
+  const notIdeal = rankByScore(profiles.filter(p => p.side === 'not_ideal'), p => p.score, Infinity).top
+  const pairs = pairBySide(ideal, notIdeal)
+  const topPairs = pairs.length > 0 ? pairs.slice(0, TABLE_TOP_LIMIT) : [[null, null] as [UserProfileItem | null, UserProfileItem | null]]
+  const restPairs = pairs.slice(TABLE_TOP_LIMIT)
+
+  const rules = rankByScore(decisionRules, r => r.score)
+
+  const pairRow = ([a, b]: [UserProfileItem | null, UserProfileItem | null], key: React.Key) => (
+    <tr key={key}>
+      <td className={TD}>{a?.description ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(a?.score) ?? <span>&nbsp;</span>}</td>
+      <td className={TD}>{b?.description ?? <span>&nbsp;</span>}</td>
+      <td className={`${TDC} font-mono`}>{formatScore(b?.score) ?? <span>&nbsp;</span>}</td>
+    </tr>
+  )
 
   return (
-    <div>
-      <SectionHeading
-        emoji="👥"
-        title="Best Fit User Profiles"
-        subtitle="No product is best for everyone. Understanding fit helps users self-select rather than arguing about &quot;best&quot; in the abstract."
-      />
+    <section className="space-y-5">
+      <div>
+        <h2 className="text-xl font-bold mb-2">👥 Who Should Buy This</h2>
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr>
+              <th className={`${TH} w-[42%]`}>Ideal for</th>
+              <th className={`${TH} w-[8%] text-center`}>Score</th>
+              <th className={`${TH} w-[42%]`}>Not ideal for</th>
+              <th className={`${TH} w-[8%] text-center`}>Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {topPairs.map((pair, i) => pairRow(pair, pair[0]?.id ?? pair[1]?.id ?? i))}
+            <ExpandableRows moreCount={restPairs.length} colSpan={4}>
+              {restPairs.map((pair, i) => pairRow(pair, pair[0]?.id ?? pair[1]?.id ?? i))}
+            </ExpandableRows>
+          </tbody>
+        </table>
+      </div>
 
-      {profiles.length > 0 ? (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="text-left px-4 py-3 font-semibold">This Product Is Ideal For:</th>
-                <th className="text-left px-4 py-3 font-semibold">This Product Is NOT Ideal For:</th>
+      <div>
+        <h3 className="text-base font-semibold mb-2">Decision rules</h3>
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr>
+              <th className={`${TH} w-[88%]`}>
+                If you prioritize [criterion], buy [this product / named alternative], because [evidence]
+              </th>
+              <th className={`${TH} w-[12%] text-center`}>Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(rules.top.length > 0 ? rules.top : [null]).map((r, i) => (
+              <tr key={r?.id ?? i}>
+                <td className={TD}>
+                  {r ? (
+                    <>
+                      <strong>{r.condition}:</strong> {r.advice}
+                    </>
+                  ) : (
+                    <span>&nbsp;</span>
+                  )}
+                </td>
+                <td className={`${TDC} font-mono`}>{formatScore(r?.score) ?? <span>&nbsp;</span>}</td>
               </tr>
-            </thead>
-            <tbody>
-              {Array.from({ length: Math.max(ideal.length, notIdeal.length, 1) }).map((_, i) => (
-                <tr key={i} className="border-t border-gray-200">
-                  <td className="px-4 py-3 text-green-700">{ideal[i]?.description ?? ''}</td>
-                  <td className="px-4 py-3 text-red-700">{notIdeal[i]?.description ?? ''}</td>
+            ))}
+            <ExpandableRows moreCount={rules.rest.length} colSpan={2}>
+              {rules.rest.map(r => (
+                <tr key={r.id}>
+                  <td className={TD}><strong>{r.condition}:</strong> {r.advice}</td>
+                  <td className={`${TDC} font-mono`}>{formatScore(r.score) ?? <span>&nbsp;</span>}</td>
                 </tr>
               ))}
-            </tbody>
-          </table>
-        </div>
-      ) : (
-        <p className="text-sm text-gray-500 italic">No user profile analysis has been recorded yet.</p>
-      )}
-    </div>
+            </ExpandableRows>
+          </tbody>
+        </table>
+      </div>
+    </section>
   )
 }

--- a/src/features/product-reviews/data/fetch-product-reviews.ts
+++ b/src/features/product-reviews/data/fetch-product-reviews.ts
@@ -50,12 +50,32 @@ const productReviewInclude = {
       },
     },
   },
-  performanceData: true,
+  performanceData: { orderBy: [{ impact: { sort: 'desc' as const, nulls: 'last' as const } }, { id: 'asc' as const }] },
   tradeoffs: true,
-  alternatives: true,
-  userProfiles: true,
-  awards: true,
-  ecosystemItems: true,
+  alternatives: { orderBy: [{ score: { sort: 'desc' as const, nulls: 'last' as const } }, { id: 'asc' as const }] },
+  userProfiles: { orderBy: [{ score: { sort: 'desc' as const, nulls: 'last' as const } }, { id: 'asc' as const }] },
+  awards: { orderBy: [{ score: { sort: 'desc' as const, nulls: 'last' as const } }, { id: 'asc' as const }] },
+  ecosystemItems: { orderBy: [{ score: { sort: 'desc' as const, nulls: 'last' as const } }, { id: 'asc' as const }] },
+  recommenderInterests: { orderBy: [{ score: { sort: 'desc' as const, nulls: 'last' as const } }, { sortOrder: 'asc' as const }] },
+  ownershipCosts: { orderBy: [{ score: { sort: 'desc' as const, nulls: 'last' as const } }, { sortOrder: 'asc' as const }] },
+  valueItems: { orderBy: [{ score: { sort: 'desc' as const, nulls: 'last' as const } }, { sortOrder: 'asc' as const }] },
+  decisionRules: { orderBy: [{ score: { sort: 'desc' as const, nulls: 'last' as const } }, { sortOrder: 'asc' as const }] },
+  decisionObstacles: { orderBy: [{ score: { sort: 'desc' as const, nulls: 'last' as const } }, { sortOrder: 'asc' as const }] },
+}
+
+/**
+ * CRITERIA BEFORE BRANDS: the criteria for a category apply to every product
+ * in it. Ranked by score, then by importance.
+ */
+export async function fetchCategoryCriteria(categoryType: string) {
+  return prisma.categoryCriterion.findMany({
+    where: { categoryType },
+    orderBy: [
+      { score: { sort: 'desc', nulls: 'last' } },
+      { importance: { sort: 'desc', nulls: 'last' } },
+      { sortOrder: 'asc' },
+    ],
+  })
 }
 
 /** Fetch a product review by slug with all relations */

--- a/src/features/product-reviews/types.ts
+++ b/src/features/product-reviews/types.ts
@@ -9,6 +9,17 @@ export interface ProductReviewWithRelations {
   productName: string
   brand: string
   claim: string
+  /** Title scope: "[Product] is the best [Product Type] for [useCase]". */
+  useCase?: string | null
+  /** "Budget" | "Mid-range" | "Premium" */
+  priceSegment?: string | null
+  /** Scorecard: one-sentence verdict scoped to the use case in the title. */
+  bottomLine?: string | null
+  /** Scorecard: the measurement or price change that would flip the net score. */
+  verdictChanger?: string | null
+  /** Design Trade-offs: how far the advertised optimization differs from the actual one. */
+  divergenceNote?: string | null
+  divergenceScore?: number | null
   categoryType: string
   categorySubtype: string | null
   overallScore: number
@@ -23,6 +34,22 @@ export interface ProductReviewWithRelations {
   userProfiles: UserProfileItem[]
   awards: AwardItem[]
   ecosystemItems: EcosystemItem[]
+  recommenderInterests?: RecommenderInterestItem[]
+  ownershipCosts?: OwnershipCostItem[]
+  valueItems?: ValueItem[]
+  decisionRules?: DecisionRuleItem[]
+  decisionObstacles?: DecisionObstacleItem[]
+}
+
+/** CRITERIA BEFORE BRANDS: category-level yardstick, shared by every product in the category. */
+export interface CategoryCriterionItem {
+  id: number
+  categoryType: string
+  criterion: string
+  howToMeasure: string | null
+  importance: number | null
+  score: number | null
+  sortOrder: number
 }
 
 export interface PerformanceItem {
@@ -32,6 +59,11 @@ export interface PerformanceItem {
   evidenceTier: number // 1-4
   comparisonToAvg: string // "Better", "Worse", "Same"
   sourceUrl: string | null
+  /** Category average or best rival, with units. */
+  benchmark?: string | null
+  /** Named evidence source. */
+  source?: string | null
+  impact?: number | null
 }
 
 export interface TradeoffItem {
@@ -39,6 +71,7 @@ export interface TradeoffItem {
   side: string // "optimizes" or "sacrifices"
   category: string // "advertised" or "actual"
   description: string
+  score?: number | null
 }
 
 export interface AlternativeItem {
@@ -47,12 +80,14 @@ export interface AlternativeItem {
   tier: string // "premium", "budget", or "lateral"
   keyAdvantage: string
   linkSlug: string | null
+  score?: number | null
 }
 
 export interface UserProfileItem {
   id: number
   side: string // "ideal" or "not_ideal"
   description: string
+  score?: number | null
 }
 
 export interface AwardItem {
@@ -60,12 +95,59 @@ export interface AwardItem {
   side: string // "independent" or "manufacturer"
   title: string
   details: string | null
+  score?: number | null
 }
 
 export interface EcosystemItem {
   id: number
   category: string // "upstream", "downstream", or "lockin"
   description: string
+  cost?: string | null
+  score?: number | null
+}
+
+export interface RecommenderInterestItem {
+  id: number
+  side: string // "product" or "alternatives"
+  description: string
+  /** Candidate hidden interest (italic row); a scored claim requiring evidence. */
+  hidden: boolean
+  evidence: string | null
+  score: number | null
+}
+
+export interface OwnershipCostItem {
+  id: number
+  item: string
+  estimate: string | null
+  costType: string // "initial" | "ongoing" | "hidden" | "opportunity"
+  source: string | null
+  evidenceTier: number | null
+  score: number | null
+}
+
+export interface ValueItem {
+  id: number
+  item: string
+  measure: string | null
+  timeframe: string // "short" | "long" | "both"
+  source: string | null
+  evidenceTier: number | null
+  score: number | null
+}
+
+export interface DecisionRuleItem {
+  id: number
+  condition: string
+  advice: string
+  score: number | null
+}
+
+export interface DecisionObstacleItem {
+  id: number
+  side: string // "overpay" or "underinvest"
+  description: string
+  score: number | null
 }
 
 // Computed scores for a product review

--- a/templates/product-review-template.html
+++ b/templates/product-review-template.html
@@ -1,0 +1,488 @@
+<!-- page=Product Review Template -->
+<!-- content-type=text/html -->
+<!--
+  ===== ISE PRODUCT REVIEW MASTER TEMPLATE (July 2026) =====
+  The consumer-market sibling of the Belief Analysis template: the page is a
+  belief page for one product claim. Mirrored by the React implementation in
+  src/app/product-reviews/[slug]/page.tsx and the section components in
+  src/features/product-reviews/components/*. If you change this template,
+  update that page. The two must stay in sync.
+
+  HARD RULES (every generation must follow):
+    1. THE TITLE MUST CARRY A SCOPE: bare "best" fails the costability test
+       (compared to what, measured in what, for whom). The claim is always
+       "[Product] is the best [Product Type] for [use case or user profile]".
+    2. CRITERIA BEFORE BRANDS: fill the Category Criteria table before
+       touching performance or arguments. The criteria apply to every product
+       in the category and are the yardstick the rest of the page measures
+       against.
+    3. Every table row is a scored relationship and ranks by its score column,
+       never by editorial placement; the software shows each table's top five
+       rows and collapses the rest.
+    4. All scores stay [bracketed] until the ReasonRank engine computes them;
+       never fill a score cell for an empty row; never present a placeholder
+       as computed output. Scorecard cells are auto-derived from the tables
+       below, never hand-picked.
+    5. Hidden-interest attributions (affiliate money, ecosystem lock-in) are
+       scored claims requiring evidence, applied with equal suspicion to
+       recommenders of this product and recommenders of alternatives.
+    6. The Divergence Score on the trade-offs table is the score of the
+       sub-debate that the advertised optimization differs from the actual one.
+    7. Costs and benefits keep their units and never collapse across
+       categories unless the conversion is stated.
+    8. Worked examples (Ford trucks, Apple phones) live on hub pages and
+       instance lists, never inside this template.
+    9. Emoji section headers are this template's established convention;
+       table header rows use #f0f3f6; spell words out, no abbreviations,
+       no symbols in place of words.
+
+  SECTION ORDER:
+    Header (breadcrumb / scoped-claim H1 / net score, category, price segment /
+    method line) → Scorecard → Category Criteria → Argument Trees →
+    Performance Against the Criteria → Design Trade-offs → Interests Behind
+    the Recommendations → Assumptions Required → Alternatives → Cost-Benefit
+    (total cost of ownership + total value delivered) → Who Should Buy This
+    (+ Decision rules) → Decision Obstacles → Biases in the Reviews → Media →
+    Recognition → Ecosystem and Lock-in → Contribute
+-->
+<p style="text-align: right; font-size: 12px;"><a href="/w/page/21957696/Colorado%20Should">Home</a> &rsaquo; <a href="/w/page/159323433/One%20Page%20Per%20Topic">Topics</a> &rsaquo; [Product Category] &rsaquo; <strong>[This Product]</strong></p>
+<div style="font-family: 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #333;">
+<p style="display: none;">AUTHORING RULES (hidden; readers never see this). This is the consumer-market sibling of the Belief Analysis template; the page is a belief page for one product claim. THE TITLE MUST CARRY A SCOPE: bare "best" fails the costability test (compared to what, measured in what, for whom), so the claim is always "[Product] is the best [Product Type] for [use case or user profile]". CRITERIA BEFORE BRANDS is this template's law: fill the Category Criteria table before touching performance or arguments; the criteria apply to every product in the category and are the yardstick the rest of the page measures against. Every table row is a scored relationship and ranks by its score column, never by editorial placement; the software shows each table's top five rows and collapses the rest. All scores stay [bracketed] until the ReasonRank engine computes them; never fill a score cell for an empty row; never present a placeholder as computed output. Scorecard cells are auto-derived from the tables below, never hand-picked. Argument cells follow the standalone-claim rule and the opening-words naming convention. Hidden-interest attributions (affiliate money, ecosystem lock-in) are scored claims requiring evidence, applied with equal suspicion to recommenders of this product and recommenders of alternatives. The Divergence Score on the trade-offs table is the score of the sub-debate that the advertised optimization differs from the actual one. Costs and benefits keep their units and never collapse across categories unless the conversion is stated. Worked examples (Ford trucks, Apple phones) live on hub pages and instance lists, never inside this template. This page maps to the /product-reviews/[slug] route in the repo; keep new sections backward-compatible with it. Emoji section headers are this template's established convention; table header rows use #f0f3f6; spell words out, no abbreviations, no symbols in place of words.</p>
+<h1>[Product] is the best [Product Type] for [use case or user profile]</h1>
+<p><strong>Net Belief Score:</strong> <span style="padding: 2px 10px; background: #e8eef5; border: 1px solid #b0b8c1; font-size: 90%; font-weight: 600;">[Computed from argument scores]</span> &nbsp;|&nbsp; <strong><a href="/w/page/159323433/One%20Page%20Per%20Topic">Category</a>:</strong> [Product Type] &gt; [Subcategory] &gt; [Specific Brand / Model] &nbsp;|&nbsp; <strong>Price segment:</strong> [Budget / Mid-range / Premium]</p>
+<p style="font-size: 12px; color: #555;">Method: <a href="/w/page/159300543/ReasonRank">ReasonRank</a> &middot; <a href="/w/page/159353568/Evidence">Evidence Tiers</a> &middot; <a href="/w/page/159338766/Linkage%20Scores">Linkage Scores</a> &middot; <a href="/w/page/156187122/cost-benefit%20analysis">Cost-Benefit Analysis</a>. All [bracketed] scores are placeholders until the engine computes them.</p>
+<h1>📊 Scorecard</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<tbody>
+<tr>
+<td style="background-color: #f0f3f6; width: 30%;"><strong>Bottom line</strong></td>
+<td style="width: 70%;">[One-sentence verdict scoped to the use case in the title]</td>
+</tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Strongest reason to agree</strong></td>
+<td>[Argument] &middot; Impact [XX] <span style="font-size: 11px; color: #999;">(auto-derived: top pro row in Argument Trees)</span></td>
+</tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Strongest reason to disagree</strong></td>
+<td>[Argument] &middot; Impact [XX] <span style="font-size: 11px; color: #999;">(auto-derived: top con row in Argument Trees)</span></td>
+</tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Best for</strong></td>
+<td>[User profile] <span style="font-size: 11px; color: #999;">(auto-derived: top row of Who Should Buy This)</span></td>
+</tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Not for</strong></td>
+<td>[User profile] <span style="font-size: 11px; color: #999;">(auto-derived: top "not ideal" row of Who Should Buy This)</span></td>
+</tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>What would change this verdict</strong></td>
+<td>[The measurement or price change that would flip the net score]</td>
+</tr>
+</tbody>
+</table>
+<h1>🧪 Category Criteria: What Makes a Good [Product Type]?</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 34%;">Criterion (applies to every product in the category)</th><th style="width: 34%;">How to measure it</th><th style="width: 16%;">Importance</th><th style="width: 16%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Performance standard]</td>
+<td>[Test, rating, or unit]</td>
+<td style="text-align: center;">[XX]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td>[Reliability / durability metric]</td>
+<td>[Failure-rate data, warranty claims, long-term tests]</td>
+<td style="text-align: center;">[XX]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr>
+<td>[Cost-effectiveness measure]</td>
+<td>[Total cost of ownership per year or per unit of output]</td>
+<td style="text-align: center;">[XX]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td>[Safety / quality standard]</td>
+<td>[Certification, crash test, compliance rating]</td>
+<td style="text-align: center;">[XX]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>🔍 <a href="/Reasons">Argument Trees</a></h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 8px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 30%;">✅ Reasons to Agree</th><th style="width: 5%;">Score</th><th style="width: 5%;">Linkage</th><th style="width: 5%;">Importance</th><th style="width: 5%;">Impact</th><th style="width: 30%;">❌ Reasons to Disagree</th><th style="width: 5%;">Score</th><th style="width: 5%;">Linkage</th><th style="width: 5%;">Importance</th><th style="width: 5%;">Impact</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Complete claim, e.g. superior measured performance on [criterion], linked to its own belief page]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[Complete claim, e.g. inferior performance on [criterion], linked to its own belief page]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td>[Better total cost of ownership than [named rival], with units]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[Worse total cost of ownership than [named rival], with units]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr>
+<td>[Higher reliability shown by [data source]]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[Lower reliability shown by [data source]]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<p style="font-size: 12px; color: #555;">Net Belief Score = (sum of pro Impacts &minus; sum of con Impacts), Impact = Score &times; Linkage &times; Importance, computed by <a href="/w/page/159333015/Argument%20scores%20from%20sub-argument%20scores">the engine</a>.</p>
+<h1>📂 Performance Against the Criteria</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 8px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 20%;">Criterion (from the table above)</th><th style="width: 22%;">This product's measured performance</th><th style="width: 22%;">Category average / best rival</th><th style="width: 22%;">Evidence (source + tier)</th><th style="width: 14%;">Impact</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Criterion]</td>
+<td>[Specific data, with units]</td>
+<td>[Specific data, with units]</td>
+<td>[Source] <span style="background: #1e7e34; color: #fff; font-size: 11px; padding: 0 5px;">Tier 1</span></td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td>[Criterion]</td>
+<td>[Specific data, with units]</td>
+<td>[Specific data, with units]</td>
+<td>[Source] <span style="background: #b8860b; color: #fff; font-size: 11px; padding: 0 5px;">Tier 2</span></td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<p style="font-size: 12px; color: #555;">Tier key: <strong>Tier 1</strong> independent lab tests and certified ratings &middot; <strong>Tier 2</strong> professional reviewer consensus, third-party-verified manufacturer data &middot; <strong>Tier 3</strong> aggregated user reviews, investigative journalism &middot; <strong>Tier 4</strong> individual testimonials, unverified manufacturer claims. See <a href="/w/page/159353568/Evidence">Evidence</a>.</p>
+<h1>⚖️ Design Trade-offs</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 20%;">&nbsp;</th><th style="width: 34%;">Optimizes for</th><th style="width: 34%;">Sacrifices</th><th style="width: 12%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Advertised</strong> (what the manufacturer says)</td>
+<td>[Emphasized capability]</td>
+<td>[Acknowledged trade-off, e.g. higher price]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Actual</strong> (what the design choices and evidence show)</td>
+<td>[What the engineering actually prioritizes]</td>
+<td>[The compromise the design actually requires]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr>
+<td style="background-color: #f0f3f6;"><strong>Divergence Score</strong></td>
+<td colspan="2">[How far the advertised optimization differs from the actual one; scored by its own sub-debate]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>💡 <a href="/w/page/159301140/Interests">Interests</a> Behind the Recommendations</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 42%;">Those who recommend this product</th><th style="width: 8%;">Score</th><th style="width: 42%;">Those who recommend alternatives</th><th style="width: 8%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Who they are, what they gain, what they optimize for]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[Who they are, what they gain, what they optimize for]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="font-style: italic; background-color: #fdf6ec;">
+<td>[Candidate hidden interest, e.g. affiliate revenue or ecosystem lock-in, with the evidence that supports the attribution]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[Candidate hidden interest, with the evidence that supports the attribution]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>📜 <a href="/Assumptions">Assumptions</a> Required</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 42%;">Required to believe this is the best [Product Type] for [use case]</th><th style="width: 8%;">Score</th><th style="width: 42%;">Required to believe an alternative is better</th><th style="width: 8%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[The priority or weighting you must hold]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[The priority or weighting you must hold]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td>[The trade-off you must accept]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[The trade-off you must accept]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>🔄 Alternatives</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 26%;">Alternative</th><th style="width: 18%;">Relationship</th><th style="width: 44%;">Key difference from this product</th><th style="width: 12%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Product, linked to its own review page]</td>
+<td style="text-align: center;">[Premium / Budget / Lateral]</td>
+<td>[What it does better or differently, with units where possible]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td>[Product, linked to its own review page]</td>
+<td style="text-align: center;">[Premium / Budget / Lateral]</td>
+<td>[What it does better or differently]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>💰 <a href="/w/page/156187122/cost-benefit%20analysis">Cost-Benefit Analysis</a></h1>
+<h3>Total cost of ownership</h3>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 30%;">Cost item</th><th style="width: 18%;">Estimate (with units)</th><th style="width: 20%;">Type</th><th style="width: 20%;">Evidence (source + tier)</th><th style="width: 12%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Purchase price]</td>
+<td>[$X]</td>
+<td style="text-align: center;">[Initial]</td>
+<td>[Source] <span style="background: #1e7e34; color: #fff; font-size: 11px; padding: 0 5px;">Tier 1</span></td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td>[Maintenance, consumables, energy]</td>
+<td>[$X per year]</td>
+<td style="text-align: center;">[Ongoing]</td>
+<td>[Source] <span style="background: #b8860b; color: #fff; font-size: 11px; padding: 0 5px;">Tier 2</span></td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr>
+<td>[Learning curve, switching costs, lock-in]</td>
+<td>[Hours or $X]</td>
+<td style="text-align: center;">[Hidden]</td>
+<td>[Source]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td>[What the same money buys elsewhere]</td>
+<td>[$X]</td>
+<td style="text-align: center;">[Opportunity]</td>
+<td>[Source]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h3>Total value delivered</h3>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 30%;">Value item</th><th style="width: 18%;">Measure (with units)</th><th style="width: 20%;">Timeframe</th><th style="width: 20%;">Evidence (source + tier)</th><th style="width: 12%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Performance on the key criteria]</td>
+<td>[Measured result]</td>
+<td style="text-align: center;">[Short-term (0-2 years)]</td>
+<td>[Source] <span style="background: #1e7e34; color: #fff; font-size: 11px; padding: 0 5px;">Tier 1</span></td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td>[Durability, retained resale value]</td>
+<td>[Expected lifespan, resale percentage]</td>
+<td style="text-align: center;">[Long-term (3+ years)]</td>
+<td>[Source] <span style="background: #7f8c8d; color: #fff; font-size: 11px; padding: 0 5px;">Tier 3</span></td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr>
+<td>[User satisfaction]</td>
+<td>[Rating data]</td>
+<td style="text-align: center;">[Short-term / Long-term]</td>
+<td>[Source]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>👥 Who Should Buy This</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 42%;">Ideal for</th><th style="width: 8%;">Score</th><th style="width: 42%;">Not ideal for</th><th style="width: 8%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[User type, need, budget profile]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[User type whose priorities point elsewhere]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h3>Decision rules</h3>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 88%;">If you prioritize [criterion], buy [this product / named alternative], because [evidence]</th><th style="width: 12%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>If you prioritize [criterion A]:</strong> buy [option] because [evidence]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td><strong>If you prioritize [criterion B]:</strong> buy [option] because [evidence]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr>
+<td><strong>If you need both [A] and [B]:</strong> consider [compromise option] because [how it balances the trade-off]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td><strong>If budget is the primary concern:</strong> [budget option] sacrifices [X] but delivers [Y]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>🚧 Decision Obstacles</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 42%;">Why buyers overpay in this category</th><th style="width: 8%;">Score</th><th style="width: 42%;">Why buyers underinvest in this category</th><th style="width: 8%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Category-specific pattern, e.g. brand loyalty outweighing measured value]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[Category-specific pattern, e.g. shopping on sticker price while ignoring total cost of ownership]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>🧠 <a href="/w/page/21956934/bias">Biases</a> in the Reviews</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 42%;">Distorting the positive reviews</th><th style="width: 8%;">Score</th><th style="width: 42%;">Distorting the negative reviews</th><th style="width: 8%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[e.g. post-purchase rationalization, affiliate incentives, brand halo]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[e.g. negativity bias, unrealistic expectations, user error blamed on the product]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>📚 <a href="/w/page/21958666/media">Media</a></h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 42%;">Reviews supporting the verdict</th><th style="width: 8%;">Score</th><th style="width: 42%;">Reviews challenging the verdict</th><th style="width: 8%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Resource (author / channel, year), type: video, written, head-to-head comparison, long-term user report]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[Resource (author / channel, year), type]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>🏆 Recognition</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 42%;">Independent recognition (award, certifier, criteria)</th><th style="width: 8%;">Score</th><th style="width: 42%;">Manufacturer claims (marketing awards, self-selected statistics)</th><th style="width: 8%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Third-party award with the criteria it used]</td>
+<td style="text-align: center;">&nbsp;</td>
+<td>[Claim, and what it cherry-picks]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<h1>🧭 Ecosystem and Lock-in</h1>
+<table style="border-collapse: collapse; width: 100%; margin-bottom: 16px;" border="1" cellpadding="8">
+<thead style="background-color: #f0f3f6;">
+<tr>
+<th style="width: 30%;">Item</th><th style="width: 24%;">Type</th><th style="width: 34%;">Cost or commitment</th><th style="width: 12%;">Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[Prerequisite or compatible system]</td>
+<td style="text-align: center;">[Upstream: needed first]</td>
+<td>[$X or commitment]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr style="background-color: #fafbfc;">
+<td>[Accessory or upgrade]</td>
+<td style="text-align: center;">[Downstream: wanted after]</td>
+<td>[$X]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+<tr>
+<td>[Future purchase this commits you to, difficulty of switching later]</td>
+<td style="text-align: center;">[Lock-in]</td>
+<td>[Switching cost]</td>
+<td style="text-align: center;">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<p style="font-size: 12px; color: #555;">Contribute reviews, evidence, criteria, or alternatives: <a href="/w/page/160433328/Contact%20Me">Contact me</a> &middot; <a href="https://github.com/myklob/ideastockexchange">GitHub</a></p>
+</div>
+<p>&nbsp;</p>


### PR DESCRIPTION
## Summary

Implements the consumer-market sibling of the belief template at `/product-reviews/[slug]` — the page is a belief page for one product claim, rebuilt to the new template's laws and kept backward-compatible with existing review data (every new field is nullable, every new section renders placeholders when empty).

## The template's laws, in code

- **The title carries a scope.** `ProductReview.useCase` added; the H1 renders "[Product] is the best [Product Type] for [use case]" (bare "best" fails the costability test), with `priceSegment` in the meta line and the method line beneath.
- **Criteria before brands.** New **`CategoryCriterion`** model keyed by `categoryType` — the criteria apply to every product in the category, are fetched independently of any one review, and render as the first analytical section: the yardstick the rest of the page measures against.
- **Scorecard auto-derived, never hand-picked.** Bottom line and What-would-change-this-verdict are stored (`bottomLine`, `verdictChanger`); strongest reasons to agree/disagree derive from the top argument rows, Best for / Not for from the top rows of Who Should Buy This — each cell labeled with its derivation.
- **Every table ranks by its score column** with the top five shown and the rest collapsed, via the shared ranking helpers from #138.

## Schema (migration `20260704172840_add_product_review_template_fields`)

- `ProductReview`: `useCase`, `priceSegment`, `bottomLine`, `verdictChanger`, `divergenceNote`, `divergenceScore`
- `ProductPerformance`: `benchmark` (category average / best rival — "compared to what"), `source`, `impact`
- New **`ProductRecommenderInterest`** — who recommends this product or its alternatives, what they gain; `hidden` flags candidate hidden interests (affiliate money, ecosystem lock-in), which render as the italic rows and carry `evidence` — scored claims with equal suspicion for both sides
- New **`ProductOwnershipCost`** (Initial / Ongoing / Hidden / Opportunity, estimates keep their units, source + tier) and **`ProductValueItem`** (short/long timeframes)
- New **`ProductDecisionRule`** ("If you prioritize [criterion], buy [option], because [evidence]") and **`ProductDecisionObstacle`** (overpay / underinvest)
- Score columns on `ProductTradeoff`, `ProductAlternative`, `ProductUserProfile`, `ProductAward`, `ProductEcosystem` (+ `cost` on ecosystem)

## Page and components

Template order end to end: Scorecard → Category Criteria → Argument Trees → Performance Against the Criteria (with tier badges and the tier key) → Design Trade-offs (Advertised / Actual / Divergence Score) → Interests Behind the Recommendations → Assumptions Required → Alternatives (Relationship: Premium/Budget/Lateral, linked to their own reviews) → Cost-Benefit (total cost of ownership + total value delivered) → Who Should Buy This + Decision rules → Decision Obstacles → Biases in the Reviews → Media → Recognition (independent vs. manufacturer claims) → Ecosystem and Lock-in → Contribute.

The shared `BiasesSection` and `MediaResourcesSection` gained optional header props so the product page speaks the template's wording ("Distorting the positive reviews", "Reviews supporting the verdict") without forking the components — belief pages are unaffected.

## Kept in sync

- New `templates/product-review-template.html` canonical fragment with the maintainer header carrying the nine hard rules.
- `seed-product-review-extras.ts` (wired into `db:seed`) gives the Ford F-150 the full worked example: 4 Trucks category criteria, benchmarks and impacts on every performance row, the divergence verdict (marketing sells max capability, volume trims optimize comfort), 4 recommender interests including both hidden-interest candidates with evidence, 5 ownership costs across all four types, 3 value items, 4 decision rules, and 3 obstacles.

## Verification

- `npx tsc --noEmit` — 0 errors repo-wide; eslint clean; `npm test` — 215/215 passing
- Seeded and rendered `/product-reviews/ford-f-150` — HTTP 200 with the scoped title ("Ford F-150 is the best truck for mixed work and family use"), the auto-derived Scorecard, "What Makes a Good Truck?", benchmarks ("Best rival (Silverado 1500): 13,300 lbs"), the Divergence Score row, italic hidden-interest rows, TCO/value tables with tier badges, decision rules, and every renamed section present; no runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NrE26SrTeZmRk25kaJ5An

---
_Generated by [Claude Code](https://claude.ai/code/session_013NrE26SrTeZmRk25kaJ5An)_