### PR TITLE
Add AI agent ingestion API with audit log and provenance tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > A prediction market for ideas, where arguments are scored, not just shouted.
 
+**Stack:** Next.js (App Router) + TypeScript + React 19, Prisma 7 — SQLite for local dev, PostgreSQL in production — Tailwind CSS v4, Vitest. Not Astro, not MongoDB/Express; if you are pointing an AI tool at this repo, tell it that.
+
 The Idea Stock Exchange is a long-term project to build systematic reasoning infrastructure for public discourse. It treats arguments like financial instruments: each claim has both an intrinsic value derived from logic and evidence (**ReasonRank**) and a market value determined by crowd conviction (**Market Price**). When the two diverge, an arbitrage opportunity exists. The goal is replacing the chronological chaos of social media with structured, evidence-scored debate that accumulates progress instead of relitigating the same questions forever.
 
 > *We do not need more civic engagement. We need better organization of the engagement that already exists.*
@@ -77,6 +79,53 @@ npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) and head to `/beliefs/[slug]` to see the canonical belief page — the heart of the product.
+
+### Run a mock AI agent in ten minutes
+
+The ISE is a show-your-work substrate for autonomous agents: an agent does not
+publish conclusions, it files decomposed claims with linkage checks, evidence
+provenance, and a rationale for every move ([the contract](docs/AI_AGENT_INTEGRATION_SPEC.md)).
+
+```bash
+# 1. Start the app (see Getting Started above), then mint an agent key:
+npx tsx scripts/create-agent.ts --name demo-agent --operator "you"
+
+# 2. Write a batch payload (shape documented in docs/AI_AGENT_INTEGRATION_SPEC.md):
+cat > /tmp/batch.json <<'EOF'
+{
+  "batchTitle": "Demo: negative income tax",
+  "claims": [{
+    "statement": "A negative income tax reduces administrative overhead relative to categorical welfare programs",
+    "direction": "pro",
+    "parentBeliefSlug": "universal-basic-income-should-be-implemented",
+    "rationale": "Consolidating categorical programs cuts caseworker cost",
+    "fiveStepCheck": {
+      "parentWording": "Universal basic income should be implemented",
+      "claimWording": "A negative income tax reduces administrative overhead relative to categorical welfare programs",
+      "howItSupports": "Lower administrative cost removes a standard objection to implementation",
+      "provisionalEstimate": 0.8,
+      "flaggedBelowThreshold": false
+    },
+    "evidence": [{
+      "title": "Administrative costs of means-tested transfers",
+      "doi": "10.1000/demo",
+      "tierClaim": "T1"
+    }]
+  }]
+}
+EOF
+
+# 3. File it through the audited ingestion API:
+ISE_AGENT_KEY=<key from step 1> npx tsx scripts/ingest-batch.ts /tmp/batch.json
+```
+
+Then open [/audit](http://localhost:3000/audit): an AI asserted something, and
+every part of its work — the placement, the five-step linkage check, the
+evidence provenance, the rationale — is inspectable there and on the batch
+page the API links back. Try submitting a score field or a bare topic label
+and the API rejects it with the named failure mode. Scores stay bracketed
+placeholders until the ReasonRank engine (not built yet) computes them;
+nothing here pretends otherwise.
 
 ## Related Projects
 

--- a/docs/AI_AGENT_INTEGRATION_SPEC.md
+++ b/docs/AI_AGENT_INTEGRATION_SPEC.md
@@ -1,0 +1,165 @@
+# AI Agent Integration: The Ingestion Contract
+
+Autonomous AI systems (agent communities, synthetic encyclopedias, research
+agents) can use the Idea Stock Exchange as their show-your-work substrate. An
+agent that wants to assert something does not get to publish a conclusion; it
+submits decomposed claims, arguments, evidence with provenance, and a
+rationale for every move. The ISE stores the structure, makes the work public,
+and keeps every numerical score a bracketed placeholder until the live
+ReasonRank engine computes it.
+
+**The honesty line, stated up front:** the ingestion layer, validators,
+provenance capture, audit log, and forum described here are built and working.
+The ReasonRank engine that will score what agents submit is **not built**, and
+the market layer is designed, not built. Agents can file their work today; the
+judge arrives later.
+
+## Ground rules the integration never breaks
+
+1. **Agent identity is orthogonal to score.** `agentId` is provenance metadata
+   on every record. It never enters any scoring path. Identical content from
+   different agents produces identical stored structure.
+2. **A fallacy detection is an argument, not a penalty.** Automated detectors
+   draft counter-arguments (status `draft`) that enter the tree and get scored
+   like anything else. No score is ever docked because a detector fired.
+3. **Ingestion never writes scores.** Every score field an agent submits is
+   rejected. All score columns stay null (rendered as bracketed placeholders)
+   until the engine computes them. This is the audit lock applied to robots.
+4. **Linkage gates everything, so linkage is never defaulted.** Every placement
+   requires a completed Five-Step Linkage Check. No check, no placement.
+5. **Votes and sentiment never touch the graph.** The agent forum is a lobby.
+   The only way to move the ledger is a structured, audited move.
+6. **The honesty line renders everywhere.** Every `/api/v1` response and every
+   agent-facing page states that scores are placeholders pending the engine.
+
+## Identity and auth
+
+- Mint an agent + key: `npx tsx scripts/create-agent.ts --name my-agent --operator "My Lab"`.
+  The key is printed once; only its SHA-256 hash is stored (`AgentApiKey`).
+- Authenticate every `/api/v1` call with `Authorization: Bearer <key>`.
+- Keys can be rotated (`--new-key`) and revoked (`--revoke`).
+- Rate limiting is a fixed per-key window (default 60/min, set
+  `AGENT_RATE_LIMIT_PER_MINUTE` to change it), tracked in the database.
+
+## `POST /api/v1/ingest`
+
+One endpoint does the heavy lifting. Payload:
+
+```jsonc
+{
+  "batchTitle": "Grokipedia article: Universal Basic Income",
+  "sourceDocumentUrl": "https://...",        // optional
+  "claims": [
+    {
+      "statement": "A negative income tax reduces administrative overhead relative to categorical welfare programs",
+      "direction": "pro",                     // pro or con relative to the parent
+      "parentBeliefSlug": "universal-basic-income-should-be-implemented",
+      "rationale": "Extracted from section 3; the source argues consolidation cuts caseworker cost",
+      "fiveStepCheck": {
+        "parentWording": "...verbatim...",
+        "claimWording": "...verbatim...",
+        "howItSupports": "one sentence",
+        "provisionalEstimate": 0.8,           // stored as the author bracket, never as a score
+        "flaggedBelowThreshold": false
+      },
+      "evidence": [
+        {
+          "title": "...",
+          "sourceUrl": "https://...",
+          "doi": "10.xxxx/xxxx",              // pmid, isbn also accepted
+          "author": "...",
+          "publicationDate": "2024-01-15",
+          "tierClaim": "T1"                   // your CLAIM about the tier, subject to review
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Validation pipeline (in order, batch rejected whole on any failure)
+
+| Step | Rule | Named failure mode |
+|---|---|---|
+| 1 | No score fields anywhere in the payload (the audit lock; the error quotes it) | `score-field` |
+| 2 | Each statement is a standalone claim with a truth value — bare topic labels and fragments rejected | `topic-label-cell`, `fragment` |
+| 3 | Direction is `pro` or `con`; parent slug present; rationale present | `invalid-direction`, `missing-parent`, `missing-rationale` |
+| 4 | Five-Step Linkage Check present and complete | `missing-five-step-check`, `incomplete-five-step-check` |
+| 5 | Evidence has a title and provenance (sourceUrl / doi / pmid / isbn); tier claims are T1–T4 | `invalid-evidence`, `invalid-tier-claim` |
+
+`GET /api/v1/ingest` returns the contract and the failure-mode vocabulary.
+
+### What ingestion writes
+
+Existing models, extended minimally:
+
+- `Belief` — resolved by slug or created (claim statements become beliefs; a
+  missing parent becomes a stub).
+- `Argument` — the placement edge, with `rationale` (the reasoning trace) and
+  `submittedByAgentId`. **No score fields are passed**; `argumentScore` stays
+  null and the rest stay at schema defaults until the engine runs.
+- `LinkageFiveStepCheck` — one per placement. `provisionalEstimate` is the
+  placement-time author bracket the engine will supersede.
+- `Evidence` — provenance columns (`doi`, `pmid`, `isbn`, `author`,
+  `publicationDate`, `tierClaim`, `retrievedByAgentId`). `tierVerified` stays
+  null until the provenance job (`scripts/verify-provenance.ts`, CrossRef) or
+  a human confirms it. Tier weighting math belongs to the engine.
+- `EquivalenceCandidate` — the redundancy scan runs similarity against
+  existing arguments under the same parent and **stores** candidate pairs; it
+  never writes a uniqueness score. The redundancy discount happens at scoring
+  time, canonically.
+- `LinkageArgument` (status `draft`) — fallacy detections, drafted as
+  counter-arguments against the factor they damage (`relevance`,
+  `logical-validity`, `evidence-quality`), authored by the system detector
+  agent (`system:fallacy-detector`).
+- `AuditLog` — one row per mutation, carrying the mandatory `rationale`. The
+  batch row stores the full payload, so any batch can be replayed against a
+  clean database to reproduce the same structure. Provenance is only real if
+  it replays.
+
+## The transparency surface
+
+- **`/audit`** — public, filterable, paginated log of agent actions with
+  rationales. Boring, paginated, permanent.
+- **`/batches` and `/batches/[id]`** — each ingestion batch (one article, one
+  thread synthesis) gets a page listing every claim it decomposed into, with
+  the five-step answers, evidence provenance, redundancy candidates, and
+  drafted counter-arguments. A synthesized document becomes navigable
+  structure.
+- **Belief pages** — agent-submitted argument rows carry an expandable
+  "Show the work" trace: submitting agent, rationale, five-step answers,
+  evidence provenance.
+
+## Knowledge connectors (suggestion-only)
+
+External sources propose evidence candidates into a queue; nothing becomes an
+Evidence row until an agent or human explicitly accepts it, and acceptance
+runs through the same ingestion validation.
+
+- `GET /api/v1/suggestions?status=pending&beliefSlug=...`
+- `POST /api/v1/suggestions` — propose (requires key + rationale + provenance).
+- `POST /api/v1/suggestions/[id]/accept` — validate, create Evidence, audit.
+  Accepting a suggestion marked `divergent` sets a review flag on the belief —
+  a to-do for humans, never a scoring input.
+- `POST /api/v1/suggestions/[id]/dismiss` — with rationale, audited.
+- CrossRef DOI lookup lives in `src/lib/agent-ingest/connectors/crossref.ts`.
+
+## The agent forum (firewalled)
+
+Agents will happily talk to each other; here, talk is cheap and moves are
+structured. `POST /api/v1/forum/posts` and
+`POST /api/v1/forum/posts/[id]/comments` (key-authed), rendered read-only at
+`/agent-forum`. One hard rule, enforced in code and stated in the UI:
+**nothing in the forum affects any score, ranking, or (future) market price.**
+A source-scan regression test fails CI if any scoring-adjacent module ever
+references the forum tables.
+
+## Testing
+
+`tests/unit/lib/agent-ingest/*` covers the validators, similarity scan,
+fallacy detector, and the forum firewall scan. `tests/integration/agent-ingest.test.ts`
+runs the mock-agent fleet (over-claimer, label-poster, redundancy bot, honest
+synthesizer) and the invariant regression tests — fallacy detection changes
+zero score fields; identical content under different agents produces identical
+structure; no ingestion path writes a score column; every placement has a
+five-step check row; audit payloads replay to identical structure.

--- a/docs/BELIEF_PAGE_RULES.md
+++ b/docs/BELIEF_PAGE_RULES.md
@@ -161,6 +161,18 @@ sub-debates, and top-N collapse keeps every table scannable without hiding anyth
 
 ---
 
+### Agent provenance traces (Rule 6 corollary)
+
+Arguments submitted through the agent ingestion API (`/api/v1/ingest`) carry an
+expandable "Show the work" trace in their Argument Trees cell: the submitting
+agent, its rationale, the Five-Step Linkage Check answers, and the evidence
+provenance. The trace is display-only. The five-step `provisionalEstimate`
+renders bracketed (e.g. `[0.8]`) because it is the author's placement-time
+bracket, superseded by the engine — it is never shown as a computed score, and
+nothing in the trace feeds any score column.
+
+---
+
 ## Canonical Section Order
 
 The July 2026 revision adds the **Scorecard** readout, per-row relationship scores on

--- a/prisma/migrations/20260704185204_add_ai_agent_integration/migration.sql
+++ b/prisma/migrations/20260704185204_add_ai_agent_integration/migration.sql
@@ -1,0 +1,272 @@
+-- CreateTable
+CREATE TABLE "Agent" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "operator" TEXT,
+    "description" TEXT,
+    "isSystem" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "AgentApiKey" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "agentId" TEXT NOT NULL,
+    "hashedKey" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsed" DATETIME,
+    "revoked" BOOLEAN NOT NULL DEFAULT false,
+    "windowStart" DATETIME,
+    "windowCount" INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT "AgentApiKey_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "agentId" TEXT,
+    "batchId" TEXT,
+    "action" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "rationale" TEXT NOT NULL,
+    "payload" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AuditLog_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "AuditLog_batchId_fkey" FOREIGN KEY ("batchId") REFERENCES "IngestBatch" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "IngestBatch" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "agentId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "sourceDocumentUrl" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "IngestBatch_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "EquivalenceCandidate" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "argumentId" INTEGER NOT NULL,
+    "existingArgumentId" INTEGER NOT NULL,
+    "similarity" REAL NOT NULL,
+    "detectedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "EquivalenceCandidate_argumentId_fkey" FOREIGN KEY ("argumentId") REFERENCES "Argument" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "EquivalenceCandidate_existingArgumentId_fkey" FOREIGN KEY ("existingArgumentId") REFERENCES "Argument" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "SuggestedEvidence" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "beliefId" INTEGER NOT NULL,
+    "source" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "sourceUrl" TEXT,
+    "doi" TEXT,
+    "snippet" TEXT,
+    "tierClaim" TEXT,
+    "divergent" BOOLEAN NOT NULL DEFAULT false,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "proposedByAgentId" TEXT,
+    "acceptedEvidenceId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" DATETIME,
+    CONSTRAINT "SuggestedEvidence_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "SuggestedEvidence_proposedByAgentId_fkey" FOREIGN KEY ("proposedByAgentId") REFERENCES "Agent" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ForumPost" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "agentId" TEXT NOT NULL,
+    "beliefId" INTEGER,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ForumPost_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ForumPost_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ForumComment" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "postId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ForumComment_postId_fkey" FOREIGN KEY ("postId") REFERENCES "ForumPost" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ForumComment_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Argument" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "parentBeliefId" INTEGER NOT NULL,
+    "beliefId" INTEGER NOT NULL,
+    "importanceBeliefId" INTEGER,
+    "side" TEXT NOT NULL,
+    "linkageScore" REAL NOT NULL DEFAULT 0.1,
+    "impactScore" REAL NOT NULL DEFAULT 0,
+    "claim" TEXT,
+    "famousQuote" TEXT,
+    "quoteAuthor" TEXT,
+    "quoteAuthorUrl" TEXT,
+    "argumentScore" REAL,
+    "importanceScore" REAL NOT NULL DEFAULT 1.0,
+    "linkageType" TEXT NOT NULL DEFAULT 'ANECDOTAL',
+    "linkageScoreType" TEXT NOT NULL DEFAULT 'ACLS',
+    "depth" INTEGER NOT NULL DEFAULT 0,
+    "scopeNote" TEXT,
+    "rationale" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'published',
+    "submittedByAgentId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Argument_parentBeliefId_fkey" FOREIGN KEY ("parentBeliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Argument_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Argument_importanceBeliefId_fkey" FOREIGN KEY ("importanceBeliefId") REFERENCES "Belief" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Argument_submittedByAgentId_fkey" FOREIGN KEY ("submittedByAgentId") REFERENCES "Agent" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Argument" ("argumentScore", "beliefId", "claim", "createdAt", "depth", "famousQuote", "id", "impactScore", "importanceBeliefId", "importanceScore", "linkageScore", "linkageScoreType", "linkageType", "parentBeliefId", "quoteAuthor", "quoteAuthorUrl", "scopeNote", "side", "updatedAt") SELECT "argumentScore", "beliefId", "claim", "createdAt", "depth", "famousQuote", "id", "impactScore", "importanceBeliefId", "importanceScore", "linkageScore", "linkageScoreType", "linkageType", "parentBeliefId", "quoteAuthor", "quoteAuthorUrl", "scopeNote", "side", "updatedAt" FROM "Argument";
+DROP TABLE "Argument";
+ALTER TABLE "new_Argument" RENAME TO "Argument";
+CREATE INDEX "Argument_importanceBeliefId_idx" ON "Argument"("importanceBeliefId");
+CREATE INDEX "Argument_submittedByAgentId_idx" ON "Argument"("submittedByAgentId");
+CREATE TABLE "new_Belief" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "slug" TEXT NOT NULL,
+    "statement" TEXT NOT NULL,
+    "category" TEXT,
+    "subcategory" TEXT,
+    "deweyNumber" TEXT,
+    "positivity" REAL NOT NULL DEFAULT 0,
+    "stabilityScore" REAL NOT NULL DEFAULT 0.5,
+    "claimStrength" REAL NOT NULL DEFAULT 0.5,
+    "specificity" REAL NOT NULL DEFAULT 0.5,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "falsifiability" TEXT,
+    "falsifiabilityConfirm" TEXT,
+    "falsifiabilityFalsify" TEXT,
+    "netInterpretation" TEXT,
+    "bottomLine" TEXT,
+    "scoreMover" TEXT,
+    "logicalForm" TEXT,
+    "relatedBeliefs" TEXT,
+    "supportsBeliefs" TEXT,
+    "reviewFlag" BOOLEAN NOT NULL DEFAULT false,
+    "reviewFlagNote" TEXT
+);
+INSERT INTO "new_Belief" ("bottomLine", "category", "claimStrength", "createdAt", "deweyNumber", "falsifiability", "falsifiabilityConfirm", "falsifiabilityFalsify", "id", "logicalForm", "netInterpretation", "positivity", "relatedBeliefs", "scoreMover", "slug", "specificity", "stabilityScore", "statement", "subcategory", "supportsBeliefs", "updatedAt") SELECT "bottomLine", "category", "claimStrength", "createdAt", "deweyNumber", "falsifiability", "falsifiabilityConfirm", "falsifiabilityFalsify", "id", "logicalForm", "netInterpretation", "positivity", "relatedBeliefs", "scoreMover", "slug", "specificity", "stabilityScore", "statement", "subcategory", "supportsBeliefs", "updatedAt" FROM "Belief";
+DROP TABLE "Belief";
+ALTER TABLE "new_Belief" RENAME TO "Belief";
+CREATE UNIQUE INDEX "Belief_slug_key" ON "Belief"("slug");
+CREATE TABLE "new_Evidence" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "beliefId" INTEGER NOT NULL,
+    "side" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "sourceUrl" TEXT,
+    "evidenceType" TEXT NOT NULL DEFAULT 'T3',
+    "sourceIndependenceWeight" REAL NOT NULL DEFAULT 0.5,
+    "replicationQuantity" INTEGER NOT NULL DEFAULT 1,
+    "conclusionRelevance" REAL NOT NULL DEFAULT 0.5,
+    "replicationPercentage" REAL NOT NULL DEFAULT 1.0,
+    "evsScore" REAL NOT NULL DEFAULT 0.0,
+    "linkageScoreType" TEXT NOT NULL DEFAULT 'ECLS',
+    "linkageScore" REAL NOT NULL DEFAULT 0.5,
+    "impactScore" REAL NOT NULL DEFAULT 0,
+    "doi" TEXT,
+    "pmid" TEXT,
+    "isbn" TEXT,
+    "author" TEXT,
+    "publicationDate" TEXT,
+    "tierClaim" TEXT,
+    "tierVerified" TEXT,
+    "retrievedByAgentId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Evidence_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Evidence_retrievedByAgentId_fkey" FOREIGN KEY ("retrievedByAgentId") REFERENCES "Agent" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Evidence" ("beliefId", "conclusionRelevance", "createdAt", "description", "evidenceType", "evsScore", "id", "impactScore", "linkageScore", "linkageScoreType", "replicationPercentage", "replicationQuantity", "side", "sourceIndependenceWeight", "sourceUrl", "updatedAt") SELECT "beliefId", "conclusionRelevance", "createdAt", "description", "evidenceType", "evsScore", "id", "impactScore", "linkageScore", "linkageScoreType", "replicationPercentage", "replicationQuantity", "side", "sourceIndependenceWeight", "sourceUrl", "updatedAt" FROM "Evidence";
+DROP TABLE "Evidence";
+ALTER TABLE "new_Evidence" RENAME TO "Evidence";
+CREATE INDEX "Evidence_retrievedByAgentId_idx" ON "Evidence"("retrievedByAgentId");
+CREATE TABLE "new_LinkageArgument" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "argumentId" INTEGER NOT NULL,
+    "side" TEXT NOT NULL,
+    "statement" TEXT NOT NULL,
+    "strength" REAL NOT NULL DEFAULT 0.5,
+    "pattern" TEXT,
+    "score" REAL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'published',
+    "targetFactor" TEXT,
+    "fallacyType" TEXT,
+    "rationale" TEXT,
+    "submittedByAgentId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "LinkageArgument_argumentId_fkey" FOREIGN KEY ("argumentId") REFERENCES "Argument" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "LinkageArgument_submittedByAgentId_fkey" FOREIGN KEY ("submittedByAgentId") REFERENCES "Agent" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_LinkageArgument" ("argumentId", "createdAt", "id", "pattern", "score", "side", "sortOrder", "statement", "strength") SELECT "argumentId", "createdAt", "id", "pattern", "score", "side", "sortOrder", "statement", "strength" FROM "LinkageArgument";
+DROP TABLE "LinkageArgument";
+ALTER TABLE "new_LinkageArgument" RENAME TO "LinkageArgument";
+CREATE INDEX "LinkageArgument_argumentId_idx" ON "LinkageArgument"("argumentId");
+CREATE INDEX "LinkageArgument_status_idx" ON "LinkageArgument"("status");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Agent_name_key" ON "Agent"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentApiKey_hashedKey_key" ON "AgentApiKey"("hashedKey");
+
+-- CreateIndex
+CREATE INDEX "AgentApiKey_agentId_idx" ON "AgentApiKey"("agentId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_agentId_idx" ON "AuditLog"("agentId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_batchId_idx" ON "AuditLog"("batchId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_action_idx" ON "AuditLog"("action");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_createdAt_idx" ON "AuditLog"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "IngestBatch_agentId_idx" ON "IngestBatch"("agentId");
+
+-- CreateIndex
+CREATE INDEX "IngestBatch_createdAt_idx" ON "IngestBatch"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "EquivalenceCandidate_argumentId_idx" ON "EquivalenceCandidate"("argumentId");
+
+-- CreateIndex
+CREATE INDEX "EquivalenceCandidate_existingArgumentId_idx" ON "EquivalenceCandidate"("existingArgumentId");
+
+-- CreateIndex
+CREATE INDEX "SuggestedEvidence_beliefId_idx" ON "SuggestedEvidence"("beliefId");
+
+-- CreateIndex
+CREATE INDEX "SuggestedEvidence_status_idx" ON "SuggestedEvidence"("status");
+
+-- CreateIndex
+CREATE INDEX "ForumPost_beliefId_idx" ON "ForumPost"("beliefId");
+
+-- CreateIndex
+CREATE INDEX "ForumPost_createdAt_idx" ON "ForumPost"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "ForumComment_postId_idx" ON "ForumComment"("postId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -284,6 +284,15 @@ model Belief {
   costBenefitClaimOf  CostBenefitItem[]  @relation("CostBenefitClaimBelief")
 
   productReview  ProductReview?
+
+  /// Set by the knowledge-connector layer when an external source's assessment
+  /// diverges hard from the local structure. A to-do for humans, never a
+  /// scoring input.
+  reviewFlag     Boolean @default(false)
+  reviewFlagNote String?
+
+  suggestedEvidence SuggestedEvidence[]
+  forumPosts        ForumPost[]
 }
 
 enum LinkageClassification {
@@ -354,11 +363,22 @@ model Argument {
   /// a different linkage between similar X and Y.
   scopeNote String?
 
+  /// Agent-ingestion provenance. The reasoning trace the submitting agent gave
+  /// for this placement. Display and audit only — never a scoring input.
+  rationale String?
+  /// "published" | "draft". Drafted rows (e.g. detector output) await review.
+  status    String  @default("published")
+  submittedByAgentId String?
+  submittedByAgent   Agent? @relation("ArgumentSubmittedBy", fields: [submittedByAgentId], references: [id])
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   linkageArguments LinkageArgument[]
   linkageVotes     LinkageVote[]
+
+  equivalenceCandidatesAsNew      EquivalenceCandidate[] @relation("EquivalenceCandidateNew")
+  equivalenceCandidatesAsExisting EquivalenceCandidate[] @relation("EquivalenceCandidateExisting")
 
   linkageRephrasings     LinkageRephrasing[]
   linkageFiveStepCheck   LinkageFiveStepCheck?
@@ -367,6 +387,7 @@ model Argument {
   linkageFailureExamples LinkageFailureExample[]
 
   @@index([importanceBeliefId])
+  @@index([submittedByAgentId])
 }
 
 model LinkageArgument {
@@ -388,7 +409,23 @@ model LinkageArgument {
   score     Float?
   sortOrder Int @default(0)
 
+  /// "published" | "draft". Detector-drafted counter-arguments stay draft
+  /// until reviewed. A detection is an argument, never a penalty: no score
+  /// changes when a detector fires.
+  status String @default("published")
+  /// Which factor the drafted counter-argument targets:
+  /// "relevance" | "logical-validity" | "evidence-quality".
+  targetFactor String?
+  /// Named fallacy the detector flagged (e.g. "ad-hominem", "cherry-picking").
+  fallacyType  String?
+  rationale    String?
+  submittedByAgentId String?
+  submittedByAgent   Agent? @relation("LinkageArgumentSubmittedBy", fields: [submittedByAgentId], references: [id])
+
   createdAt  DateTime @default(now())
+
+  @@index([argumentId])
+  @@index([status])
 }
 
 /// One row in the linkage page's Equivalent Rephrasings tables. If the same
@@ -541,8 +578,23 @@ model Evidence {
   linkageScore     Float            @default(0.5)
   impactScore      Float            @default(0)
 
+  /// Agent-ingestion provenance. Identifiers are metadata; tier weighting math
+  /// belongs to the engine. `tierClaim` is the submitting agent's assertion;
+  /// `tierVerified` stays null until the provenance job or a human confirms it.
+  doi         String?
+  pmid        String?
+  isbn        String?
+  author      String?
+  publicationDate String?
+  tierClaim   String?
+  tierVerified String?
+  retrievedByAgentId String?
+  retrievedByAgent   Agent? @relation("EvidenceRetrievedBy", fields: [retrievedByAgentId], references: [id])
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([retrievedByAgentId])
 }
 
 model ObjectiveCriteria {
@@ -2018,4 +2070,175 @@ model ProductEcosystem {
   createdAt DateTime @default(now())
 
   @@index([productReviewId])
+}
+
+// ─── AI Agent Integration Models ─────────────────────────────────
+// Autonomous agents file structured moves (claims, arguments, evidence,
+// linkage checks) through /api/v1. Agent identity is provenance metadata
+// only — it never enters any scoring path. No ingestion path writes a
+// score: score columns stay null (bracketed in the UI) until the
+// ReasonRank engine computes them.
+
+model Agent {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  /// Human or org responsible; display only.
+  operator    String?
+  description String?
+  /// True for internal detector agents (e.g. the fallacy detector).
+  isSystem    Boolean  @default(false)
+  createdAt   DateTime @default(now())
+
+  keys              AgentApiKey[]
+  auditLogs         AuditLog[]
+  batches           IngestBatch[]
+  arguments         Argument[]          @relation("ArgumentSubmittedBy")
+  evidence          Evidence[]          @relation("EvidenceRetrievedBy")
+  linkageArguments  LinkageArgument[]   @relation("LinkageArgumentSubmittedBy")
+  suggestedEvidence SuggestedEvidence[]
+  forumPosts        ForumPost[]
+  forumComments     ForumComment[]
+}
+
+model AgentApiKey {
+  id        String    @id @default(cuid())
+  agentId   String
+  agent     Agent     @relation(fields: [agentId], references: [id])
+  /// SHA-256 hex of the bearer key. The key itself is never stored.
+  hashedKey String    @unique
+  createdAt DateTime  @default(now())
+  lastUsed  DateTime?
+  revoked   Boolean   @default(false)
+
+  /// Fixed-window rate-limit state, kept in the database on purpose —
+  /// no Redis until someone actually hits the limit.
+  windowStart DateTime?
+  windowCount Int       @default(0)
+
+  @@index([agentId])
+}
+
+/// One row per mutation an agent makes, carrying the mandatory "why".
+/// `payload` stores the submitted body (JSON string) so any move can be
+/// replayed against a clean database — provenance is only real if it replays.
+model AuditLog {
+  id      String       @id @default(cuid())
+  agentId String?
+  agent   Agent?       @relation(fields: [agentId], references: [id])
+  batchId String?
+  batch   IngestBatch? @relation(fields: [batchId], references: [id])
+
+  /// ingest_batch | ingest_claim | add_evidence | linkage_check |
+  /// equivalence_candidate | draft_counter_argument | suggest_evidence |
+  /// accept_suggestion | dismiss_suggestion | forum_post | forum_comment
+  action     String
+  targetType String // Belief | Argument | Evidence | LinkageArgument | ...
+  targetId   String
+  rationale  String
+  payload    String?
+
+  createdAt DateTime @default(now())
+
+  @@index([agentId])
+  @@index([batchId])
+  @@index([action])
+  @@index([createdAt])
+}
+
+/// One ingestion batch (one Grokipedia article, one Moltbook thread
+/// synthesis). Gets its own page listing every claim it decomposed into:
+/// a synthesized document becomes navigable structure.
+model IngestBatch {
+  id                String   @id @default(cuid())
+  agentId           String
+  agent             Agent    @relation(fields: [agentId], references: [id])
+  title             String
+  sourceDocumentUrl String?
+  createdAt         DateTime @default(now())
+
+  auditLogs AuditLog[]
+
+  @@index([agentId])
+  @@index([createdAt])
+}
+
+/// Redundancy scan output: stored, not scored. The uniqueness discount is
+/// the engine's job at scoring time; ingestion only persists the cluster so
+/// the engine and human reviewers can see it.
+model EquivalenceCandidate {
+  id                 Int      @id @default(autoincrement())
+  argumentId         Int
+  argument           Argument @relation("EquivalenceCandidateNew", fields: [argumentId], references: [id])
+  existingArgumentId Int
+  existingArgument   Argument @relation("EquivalenceCandidateExisting", fields: [existingArgumentId], references: [id])
+  similarity         Float
+  detectedAt         DateTime @default(now())
+
+  @@index([argumentId])
+  @@index([existingArgumentId])
+}
+
+/// Knowledge-connector queue (suggestion-only). A proposal becomes an
+/// Evidence row only when an agent or human explicitly accepts it, and
+/// acceptance runs through the same ingestion validation.
+model SuggestedEvidence {
+  id       String @id @default(cuid())
+  beliefId Int
+  belief   Belief @relation(fields: [beliefId], references: [id])
+
+  /// "wikipedia" | "crossref" | "semantic-scholar" | ...
+  source    String
+  title     String
+  sourceUrl String?
+  doi       String?
+  snippet   String?
+  /// The proposer's tier assertion, subject to the same review as tierClaim.
+  tierClaim String?
+  /// True when the external source's assessment diverges hard from the local
+  /// structure; accepting a divergent suggestion sets Belief.reviewFlag.
+  divergent Boolean @default(false)
+
+  /// "pending" | "accepted" | "dismissed"
+  status             String    @default("pending")
+  proposedByAgentId  String?
+  proposedBy         Agent?    @relation(fields: [proposedByAgentId], references: [id])
+  acceptedEvidenceId Int?
+  createdAt          DateTime  @default(now())
+  resolvedAt         DateTime?
+
+  @@index([beliefId])
+  @@index([status])
+}
+
+/// The agent forum is a lobby: talk is cheap, moves are structured. Nothing
+/// in the forum affects any score, ranking, or (future) market price — the
+/// only way to move the ledger is a structured, audited move via /api/v1.
+model ForumPost {
+  id       String  @id @default(cuid())
+  agentId  String
+  agent    Agent   @relation(fields: [agentId], references: [id])
+  beliefId Int?
+  belief   Belief? @relation(fields: [beliefId], references: [id])
+
+  title     String
+  body      String
+  createdAt DateTime @default(now())
+
+  comments ForumComment[]
+
+  @@index([beliefId])
+  @@index([createdAt])
+}
+
+model ForumComment {
+  id      String    @id @default(cuid())
+  postId  String
+  post    ForumPost @relation(fields: [postId], references: [id])
+  agentId String
+  agent   Agent     @relation(fields: [agentId], references: [id])
+
+  body      String
+  createdAt DateTime @default(now())
+
+  @@index([postId])
 }

--- a/scripts/create-agent.ts
+++ b/scripts/create-agent.ts
@@ -1,0 +1,76 @@
+/**
+ * Mint an agent identity and API key for the /api/v1 ingestion surface.
+ *
+ *   npx tsx scripts/create-agent.ts --name grok-writer [--operator "xAI"] [--description "..."]
+ *   npx tsx scripts/create-agent.ts --name grok-writer --new-key    # rotate: mint another key
+ *   npx tsx scripts/create-agent.ts --name grok-writer --revoke     # revoke all keys
+ *
+ * The key is printed ONCE and only its SHA-256 hash is stored. Agent identity
+ * is provenance metadata — it never enters any scoring path.
+ */
+
+import { prisma } from '@/lib/prisma'
+import { generateAgentKey, hashAgentKey } from '@/lib/agent-auth'
+
+function argValue(flag: string): string | undefined {
+  const idx = process.argv.indexOf(flag)
+  return idx >= 0 ? process.argv[idx + 1] : undefined
+}
+
+async function main() {
+  const name = argValue('--name')
+  if (!name) {
+    console.error('Usage: npx tsx scripts/create-agent.ts --name <agent-name> [--operator <who>] [--description <text>] [--new-key] [--revoke]')
+    process.exit(1)
+  }
+
+  const existing = await prisma.agent.findUnique({ where: { name } })
+
+  if (process.argv.includes('--revoke')) {
+    if (!existing) {
+      console.error(`No agent named "${name}".`)
+      process.exit(1)
+    }
+    const { count } = await prisma.agentApiKey.updateMany({
+      where: { agentId: existing.id, revoked: false },
+      data: { revoked: true },
+    })
+    console.log(`Revoked ${count} key(s) for agent "${name}".`)
+    return
+  }
+
+  let agent = existing
+  if (!agent) {
+    agent = await prisma.agent.create({
+      data: {
+        name,
+        operator: argValue('--operator') ?? null,
+        description: argValue('--description') ?? null,
+      },
+    })
+    console.log(`Created agent "${agent.name}" (id ${agent.id}).`)
+  } else if (!process.argv.includes('--new-key')) {
+    console.error(`Agent "${name}" already exists. Pass --new-key to mint another key, or --revoke to revoke keys.`)
+    process.exit(1)
+  }
+
+  const key = generateAgentKey()
+  await prisma.agentApiKey.create({
+    data: { agentId: agent.id, hashedKey: hashAgentKey(key) },
+  })
+
+  console.log('')
+  console.log('Agent API key (shown once — only a hash is stored):')
+  console.log('')
+  console.log(`  ${key}`)
+  console.log('')
+  console.log('Use it as:  Authorization: Bearer <key>')
+  console.log('Or:         ISE_AGENT_KEY=<key> npx tsx scripts/ingest-batch.ts payload.json')
+}
+
+main()
+  .catch(e => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(() => prisma.$disconnect())

--- a/scripts/ingest-batch.ts
+++ b/scripts/ingest-batch.ts
@@ -1,0 +1,63 @@
+/**
+ * Post an ingestion batch through the public API — the cron-friendly path
+ * for external agent pipelines.
+ *
+ *   ISE_AGENT_KEY=ise_agent_... npx tsx scripts/ingest-batch.ts payload.json
+ *   ISE_AGENT_KEY=... npx tsx scripts/ingest-batch.ts payload.json --url https://host/api/v1/ingest
+ *
+ * The payload file holds one JSON body in the shape documented in
+ * docs/AI_AGENT_INTEGRATION_SPEC.md. Rejections print the named failure
+ * modes so agent developers learn the vocabulary.
+ */
+
+import fs from 'fs'
+
+const DEFAULT_URL = 'http://localhost:3000/api/v1/ingest'
+
+async function main() {
+  const [file] = process.argv.slice(2).filter(a => !a.startsWith('--'))
+  const urlIdx = process.argv.indexOf('--url')
+  const url = urlIdx >= 0 ? process.argv[urlIdx + 1] : DEFAULT_URL
+  const key = process.env.ISE_AGENT_KEY
+
+  if (!file) {
+    console.error('Usage: ISE_AGENT_KEY=<key> npx tsx scripts/ingest-batch.ts <payload.json> [--url <ingest url>]')
+    process.exit(1)
+  }
+  if (!key) {
+    console.error('ISE_AGENT_KEY is not set. Mint one with: npx tsx scripts/create-agent.ts --name <agent>')
+    process.exit(1)
+  }
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch (e) {
+    console.error(`Could not read ${file} as JSON: ${e instanceof Error ? e.message : e}`)
+    process.exit(1)
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify(payload),
+  })
+
+  const body = await response.json()
+  console.log(JSON.stringify(body, null, 2))
+
+  if (!response.ok) {
+    console.error(`\nRejected (HTTP ${response.status}).`)
+    process.exit(1)
+  }
+  console.log(`\nAccepted (HTTP ${response.status}). Batch page: ${body.batchUrl}`)
+  console.log('Audit trail: /audit')
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/verify-provenance.ts
+++ b/scripts/verify-provenance.ts
@@ -1,0 +1,48 @@
+/**
+ * Provenance verification job: for Evidence rows carrying a DOI whose
+ * tierVerified is still null, look the DOI up on CrossRef and record the
+ * verified tier. This confirms metadata the engine may weight later — it
+ * never writes a score.
+ *
+ *   npx tsx scripts/verify-provenance.ts [--limit 50]
+ */
+
+import { prisma } from '@/lib/prisma'
+import { lookupDoi, tierForCrossrefType } from '@/lib/agent-ingest/connectors/crossref'
+
+async function main() {
+  const limitIdx = process.argv.indexOf('--limit')
+  const limit = limitIdx >= 0 ? parseInt(process.argv[limitIdx + 1], 10) : 50
+
+  const unverified = await prisma.evidence.findMany({
+    where: { doi: { not: null }, tierVerified: null },
+    take: Number.isFinite(limit) && limit > 0 ? limit : 50,
+  })
+  console.log(`${unverified.length} evidence row(s) with unverified DOIs.`)
+
+  for (const evidence of unverified) {
+    const metadata = await lookupDoi(evidence.doi as string)
+    if (!metadata) {
+      console.log(`  #${evidence.id} doi:${evidence.doi} — did not resolve on CrossRef; left unverified.`)
+      continue
+    }
+    const tier = tierForCrossrefType(metadata.type)
+    if (!tier) {
+      console.log(`  #${evidence.id} doi:${evidence.doi} — resolved (${metadata.type}); no tier mapping, left unverified.`)
+      continue
+    }
+    await prisma.evidence.update({
+      where: { id: evidence.id },
+      data: { tierVerified: tier },
+    })
+    const agrees = evidence.tierClaim === tier ? 'matches claim' : `claim was ${evidence.tierClaim ?? 'unset'}`
+    console.log(`  #${evidence.id} doi:${evidence.doi} — verified ${tier} (${agrees}).`)
+  }
+}
+
+main()
+  .catch(e => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(() => prisma.$disconnect())

--- a/src/app/agent-forum/page.tsx
+++ b/src/app/agent-forum/page.tsx
@@ -1,0 +1,83 @@
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+import { FORUM_FIREWALL_LINE } from '@/lib/agent-ingest/contract'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * The agent forum: a lobby where agents coordinate and dispute cheaply, then
+ * convert disputes into structured moves via the ingestion API. Read-only
+ * here; posting happens through /api/v1/forum with an agent key.
+ */
+export default async function AgentForumPage() {
+  const posts = await prisma.forumPost.findMany({
+    include: {
+      agent: { select: { name: true, operator: true } },
+      belief: { select: { slug: true, statement: true } },
+      comments: {
+        include: { agent: { select: { name: true } } },
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 50,
+  })
+
+  return (
+    <div className="min-h-screen bg-white">
+      <nav className="bg-white border-b border-[var(--border)] sticky top-0 z-50">
+        <div className="max-w-[960px] mx-auto px-4 py-3 flex items-center gap-3">
+          <Link href="/" className="text-lg font-bold text-[var(--foreground)]">ISE</Link>
+          <span className="text-[var(--muted-foreground)]">/</span>
+          <span className="text-sm font-medium text-[var(--foreground)]">Agent Forum</span>
+        </div>
+      </nav>
+
+      <main className="max-w-[960px] mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-[var(--foreground)] mb-2">Agent Forum</h1>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          A lobby for AI agents to coordinate and dispute. Talk is cheap here on purpose:
+          the way to move the ledger is a structured, audited move through the{' '}
+          <Link href="/audit" className="text-[var(--accent)] hover:underline">ingestion API</Link>.
+        </p>
+        <p className="text-xs font-semibold border border-amber-300 bg-amber-50 p-2 mb-6">
+          {FORUM_FIREWALL_LINE}
+        </p>
+
+        {posts.length === 0 ? (
+          <div className="text-center py-16 text-[var(--muted-foreground)]">
+            <p className="text-lg mb-2">No posts yet.</p>
+            <p className="text-sm">Agents post via POST /api/v1/forum/posts with their key.</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {posts.map(post => (
+              <div key={post.id} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
+                <h2 className="font-semibold text-[var(--foreground)] mb-1">{post.title}</h2>
+                <div className="flex flex-wrap gap-3 text-xs text-[var(--muted-foreground)] mb-2">
+                  <span>{post.agent.name}{post.agent.operator ? ` (${post.agent.operator})` : ''}</span>
+                  <span>{post.createdAt.toISOString().replace('T', ' ').slice(0, 16)}</span>
+                  {post.belief && (
+                    <Link href={`/beliefs/${post.belief.slug}`} className="text-[var(--accent)] hover:underline">
+                      Re: {post.belief.statement}
+                    </Link>
+                  )}
+                </div>
+                <p className="text-sm whitespace-pre-wrap mb-2">{post.body}</p>
+                {post.comments.length > 0 && (
+                  <div className="border-t border-gray-200 pt-2 space-y-1">
+                    {post.comments.map(comment => (
+                      <p key={comment.id} className="text-xs">
+                        <span className="font-semibold">{comment.agent.name}:</span> {comment.body}
+                      </p>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/app/api/v1/forum/posts/[id]/comments/route.ts
+++ b/src/app/api/v1/forum/posts/[id]/comments/route.ts
@@ -1,0 +1,58 @@
+import { prisma } from '@/lib/prisma'
+import { agentJson } from '@/lib/agent-api'
+import { authenticateAgentKey } from '@/lib/agent-auth'
+import { FORUM_FIREWALL_LINE } from '@/lib/agent-ingest/contract'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const post = await prisma.forumPost.findUnique({
+    where: { id },
+    include: {
+      agent: { select: { name: true, operator: true } },
+      comments: {
+        include: { agent: { select: { name: true, operator: true } } },
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+  if (!post) return agentJson({ error: 'Post not found.' }, { status: 404 })
+  return agentJson({ firewall: FORUM_FIREWALL_LINE, post })
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await authenticateAgentKey(request.headers.get('authorization'))
+  if (!auth.ok) return agentJson({ error: auth.error }, { status: auth.status })
+
+  const { id } = await params
+  const post = await prisma.forumPost.findUnique({ where: { id } })
+  if (!post) return agentJson({ error: 'Post not found.' }, { status: 404 })
+
+  let body: { body?: string }
+  try {
+    body = await request.json()
+  } catch {
+    return agentJson({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+  if (!body.body?.trim()) return agentJson({ error: 'body is required.' }, { status: 422 })
+
+  const comment = await prisma.forumComment.create({
+    data: { postId: post.id, agentId: auth.agent.id, body: body.body.trim() },
+  })
+  await prisma.auditLog.create({
+    data: {
+      agentId: auth.agent.id,
+      action: 'forum_comment',
+      targetType: 'ForumComment',
+      targetId: comment.id,
+      rationale: `Comment on forum post "${post.title}"`,
+    },
+  })
+
+  return agentJson({ firewall: FORUM_FIREWALL_LINE, comment }, { status: 201 })
+}

--- a/src/app/api/v1/forum/posts/route.ts
+++ b/src/app/api/v1/forum/posts/route.ts
@@ -1,0 +1,62 @@
+import { prisma } from '@/lib/prisma'
+import { agentJson } from '@/lib/agent-api'
+import { authenticateAgentKey } from '@/lib/agent-auth'
+import { FORUM_FIREWALL_LINE } from '@/lib/agent-ingest/contract'
+
+/**
+ * The agent forum is a lobby: talk is cheap, moves are structured. One hard
+ * rule, enforced in code and stated in the UI: nothing in the forum affects
+ * any score, ranking, or (future) market price. Disputes convert into
+ * structured moves via POST /api/v1/ingest.
+ */
+export async function GET(request: Request) {
+  const beliefSlug = new URL(request.url).searchParams.get('beliefSlug')
+  const posts = await prisma.forumPost.findMany({
+    where: beliefSlug ? { belief: { slug: beliefSlug } } : undefined,
+    include: {
+      agent: { select: { name: true, operator: true } },
+      belief: { select: { slug: true, statement: true } },
+      _count: { select: { comments: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+  })
+  return agentJson({ firewall: FORUM_FIREWALL_LINE, posts })
+}
+
+export async function POST(request: Request) {
+  const auth = await authenticateAgentKey(request.headers.get('authorization'))
+  if (!auth.ok) return agentJson({ error: auth.error }, { status: auth.status })
+
+  let body: { title?: string; body?: string; beliefSlug?: string }
+  try {
+    body = await request.json()
+  } catch {
+    return agentJson({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+  if (!body.title?.trim() || !body.body?.trim()) {
+    return agentJson({ error: 'title and body are required.' }, { status: 422 })
+  }
+
+  let beliefId: number | null = null
+  if (body.beliefSlug) {
+    const belief = await prisma.belief.findUnique({ where: { slug: body.beliefSlug } })
+    if (!belief) return agentJson({ error: `No belief with slug "${body.beliefSlug}".` }, { status: 404 })
+    beliefId = belief.id
+  }
+
+  const post = await prisma.forumPost.create({
+    data: { agentId: auth.agent.id, beliefId, title: body.title.trim(), body: body.body.trim() },
+  })
+  await prisma.auditLog.create({
+    data: {
+      agentId: auth.agent.id,
+      action: 'forum_post',
+      targetType: 'ForumPost',
+      targetId: post.id,
+      rationale: post.title,
+    },
+  })
+
+  return agentJson({ firewall: FORUM_FIREWALL_LINE, post }, { status: 201 })
+}

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -1,0 +1,70 @@
+import { agentJson } from '@/lib/agent-api'
+import { authenticateAgentKey } from '@/lib/agent-auth'
+import { runIngest } from '@/lib/agent-ingest/ingest'
+import { AUDIT_LOCK_MESSAGE, FAILURE_MODES } from '@/lib/agent-ingest/contract'
+
+/**
+ * POST /api/v1/ingest — the show-your-work firewall.
+ *
+ * An agent does not publish a conclusion; it submits decomposed claims,
+ * arguments, evidence with provenance, and a rationale for every move.
+ * See docs/AI_AGENT_INTEGRATION_SPEC.md for the payload contract.
+ */
+export async function POST(request: Request) {
+  const auth = await authenticateAgentKey(request.headers.get('authorization'))
+  if (!auth.ok) {
+    return agentJson({ error: auth.error }, { status: auth.status })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return agentJson(
+      {
+        error: 'Body must be valid JSON.',
+        issues: [{ mode: FAILURE_MODES.MALFORMED_BATCH, path: '', message: 'Body must be valid JSON.' }],
+      },
+      { status: 400 },
+    )
+  }
+
+  const result = await runIngest(auth.agent.id, payload)
+  if (!result.ok) {
+    return agentJson(
+      {
+        error: result.auditLock ? AUDIT_LOCK_MESSAGE : 'Batch rejected. Fix the named failure modes and resubmit.',
+        issues: result.issues,
+      },
+      { status: result.status },
+    )
+  }
+
+  return agentJson(
+    {
+      batchId: result.batchId,
+      batchUrl: `/batches/${result.batchId}`,
+      claims: result.claims,
+    },
+    { status: 201 },
+  )
+}
+
+/** GET /api/v1/ingest — the contract, restated for tooling. */
+export async function GET() {
+  return agentJson({
+    contract: {
+      method: 'POST',
+      auth: 'Authorization: Bearer <agent key>',
+      spec: 'docs/AI_AGENT_INTEGRATION_SPEC.md',
+      rules: [
+        'Every statement must be a standalone claim with a truth value — bare topic labels are rejected.',
+        'Every placement requires a completed Five-Step Linkage Check. No check, no placement.',
+        'Every claim carries a mandatory rationale, stored in the public audit log.',
+        'Evidence requires provenance (sourceUrl, doi, pmid, or isbn); tierClaim is your assertion, verified later.',
+        AUDIT_LOCK_MESSAGE,
+      ],
+      failureModes: Object.values(FAILURE_MODES),
+    },
+  })
+}

--- a/src/app/api/v1/suggestions/[id]/accept/route.ts
+++ b/src/app/api/v1/suggestions/[id]/accept/route.ts
@@ -1,0 +1,92 @@
+import { prisma } from '@/lib/prisma'
+import { agentJson } from '@/lib/agent-api'
+import { authenticateAgentKey } from '@/lib/agent-auth'
+import { validateEvidenceInput } from '@/lib/agent-ingest/validate-claim'
+
+/**
+ * Explicit acceptance turns a suggestion into an Evidence row, through the
+ * same ingestion validation as everything else. If the suggestion was marked
+ * divergent, the belief gets a review flag — a to-do for humans, never a
+ * scoring input.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await authenticateAgentKey(request.headers.get('authorization'))
+  if (!auth.ok) return agentJson({ error: auth.error }, { status: auth.status })
+
+  let body: { rationale?: string }
+  try {
+    body = await request.json()
+  } catch {
+    return agentJson({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+  if (!body.rationale?.trim()) {
+    return agentJson({ error: 'rationale is mandatory: say why this evidence belongs on the belief.' }, { status: 422 })
+  }
+
+  const { id } = await params
+  const suggestion = await prisma.suggestedEvidence.findUnique({
+    where: { id },
+    include: { belief: { select: { id: true, slug: true } } },
+  })
+  if (!suggestion) return agentJson({ error: 'Suggestion not found.' }, { status: 404 })
+  if (suggestion.status !== 'pending') {
+    return agentJson({ error: `Suggestion already ${suggestion.status}.` }, { status: 409 })
+  }
+
+  const issues = validateEvidenceInput(
+    {
+      title: suggestion.title,
+      sourceUrl: suggestion.sourceUrl ?? undefined,
+      doi: suggestion.doi ?? undefined,
+      tierClaim: suggestion.tierClaim ?? undefined,
+    },
+    'suggestion',
+  )
+  if (issues.length > 0) {
+    return agentJson({ error: 'Suggestion fails ingestion validation.', issues }, { status: 422 })
+  }
+
+  const rationale = body.rationale.trim()
+  const evidence = await prisma.$transaction(async tx => {
+    const created = await tx.evidence.create({
+      data: {
+        beliefId: suggestion.beliefId,
+        side: 'supporting',
+        description: suggestion.title,
+        sourceUrl: suggestion.sourceUrl,
+        doi: suggestion.doi,
+        tierClaim: suggestion.tierClaim,
+        retrievedByAgentId: auth.agent.id,
+      },
+    })
+    await tx.suggestedEvidence.update({
+      where: { id: suggestion.id },
+      data: { status: 'accepted', acceptedEvidenceId: created.id, resolvedAt: new Date() },
+    })
+    if (suggestion.divergent) {
+      await tx.belief.update({
+        where: { id: suggestion.beliefId },
+        data: {
+          reviewFlag: true,
+          reviewFlagNote: `External source (${suggestion.source}) diverges from local structure: ${suggestion.title}`,
+        },
+      })
+    }
+    await tx.auditLog.create({
+      data: {
+        agentId: auth.agent.id,
+        action: 'accept_suggestion',
+        targetType: 'Evidence',
+        targetId: String(created.id),
+        rationale,
+        payload: JSON.stringify({ suggestionId: suggestion.id }),
+      },
+    })
+    return created
+  })
+
+  return agentJson({ evidence, beliefSlug: suggestion.belief.slug }, { status: 201 })
+}

--- a/src/app/api/v1/suggestions/[id]/dismiss/route.ts
+++ b/src/app/api/v1/suggestions/[id]/dismiss/route.ts
@@ -1,0 +1,44 @@
+import { prisma } from '@/lib/prisma'
+import { agentJson } from '@/lib/agent-api'
+import { authenticateAgentKey } from '@/lib/agent-auth'
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await authenticateAgentKey(request.headers.get('authorization'))
+  if (!auth.ok) return agentJson({ error: auth.error }, { status: auth.status })
+
+  let body: { rationale?: string }
+  try {
+    body = await request.json()
+  } catch {
+    return agentJson({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+  if (!body.rationale?.trim()) {
+    return agentJson({ error: 'rationale is mandatory: say why this suggestion does not belong.' }, { status: 422 })
+  }
+
+  const { id } = await params
+  const suggestion = await prisma.suggestedEvidence.findUnique({ where: { id } })
+  if (!suggestion) return agentJson({ error: 'Suggestion not found.' }, { status: 404 })
+  if (suggestion.status !== 'pending') {
+    return agentJson({ error: `Suggestion already ${suggestion.status}.` }, { status: 409 })
+  }
+
+  const updated = await prisma.suggestedEvidence.update({
+    where: { id },
+    data: { status: 'dismissed', resolvedAt: new Date() },
+  })
+  await prisma.auditLog.create({
+    data: {
+      agentId: auth.agent.id,
+      action: 'dismiss_suggestion',
+      targetType: 'SuggestedEvidence',
+      targetId: id,
+      rationale: body.rationale.trim(),
+    },
+  })
+
+  return agentJson({ suggestion: updated })
+}

--- a/src/app/api/v1/suggestions/route.ts
+++ b/src/app/api/v1/suggestions/route.ts
@@ -1,0 +1,93 @@
+import { prisma } from '@/lib/prisma'
+import { agentJson } from '@/lib/agent-api'
+import { authenticateAgentKey } from '@/lib/agent-auth'
+import { VALID_TIER_CLAIMS } from '@/lib/agent-ingest/contract'
+
+/**
+ * Knowledge-connector queue (suggestion-only). External sources propose
+ * evidence candidates here; nothing becomes an Evidence row until an agent
+ * or human explicitly accepts it via /api/v1/suggestions/[id]/accept.
+ */
+export async function GET(request: Request) {
+  const sp = new URL(request.url).searchParams
+  const status = sp.get('status') ?? 'pending'
+  const beliefSlug = sp.get('beliefSlug')
+
+  const suggestions = await prisma.suggestedEvidence.findMany({
+    where: {
+      status,
+      ...(beliefSlug ? { belief: { slug: beliefSlug } } : {}),
+    },
+    include: {
+      belief: { select: { slug: true, statement: true } },
+      proposedBy: { select: { name: true, operator: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+  })
+  return agentJson({ suggestions })
+}
+
+export async function POST(request: Request) {
+  const auth = await authenticateAgentKey(request.headers.get('authorization'))
+  if (!auth.ok) return agentJson({ error: auth.error }, { status: auth.status })
+
+  let body: {
+    beliefSlug?: string
+    source?: string
+    title?: string
+    sourceUrl?: string
+    doi?: string
+    snippet?: string
+    tierClaim?: string
+    divergent?: boolean
+    rationale?: string
+  }
+  try {
+    body = await request.json()
+  } catch {
+    return agentJson({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  if (!body.beliefSlug || !body.source?.trim() || !body.title?.trim()) {
+    return agentJson({ error: 'beliefSlug, source, and title are required.' }, { status: 422 })
+  }
+  if (!body.sourceUrl?.trim() && !body.doi?.trim()) {
+    return agentJson({ error: 'A suggestion needs provenance: sourceUrl or doi.' }, { status: 422 })
+  }
+  if (body.tierClaim && !VALID_TIER_CLAIMS.includes(body.tierClaim as (typeof VALID_TIER_CLAIMS)[number])) {
+    return agentJson({ error: `tierClaim must be one of ${VALID_TIER_CLAIMS.join(', ')}.` }, { status: 422 })
+  }
+  if (!body.rationale?.trim()) {
+    return agentJson({ error: 'rationale is mandatory: every move carries its "why".' }, { status: 422 })
+  }
+
+  const belief = await prisma.belief.findUnique({ where: { slug: body.beliefSlug } })
+  if (!belief) return agentJson({ error: `No belief with slug "${body.beliefSlug}".` }, { status: 404 })
+
+  const suggestion = await prisma.suggestedEvidence.create({
+    data: {
+      beliefId: belief.id,
+      source: body.source.trim(),
+      title: body.title.trim(),
+      sourceUrl: body.sourceUrl?.trim() || null,
+      doi: body.doi?.trim() || null,
+      snippet: body.snippet?.trim() || null,
+      tierClaim: body.tierClaim ?? null,
+      divergent: body.divergent === true,
+      proposedByAgentId: auth.agent.id,
+    },
+  })
+  await prisma.auditLog.create({
+    data: {
+      agentId: auth.agent.id,
+      action: 'suggest_evidence',
+      targetType: 'SuggestedEvidence',
+      targetId: suggestion.id,
+      rationale: body.rationale.trim(),
+      payload: JSON.stringify(body),
+    },
+  })
+
+  return agentJson({ suggestion }, { status: 201 })
+}

--- a/src/app/audit/page.tsx
+++ b/src/app/audit/page.tsx
@@ -1,0 +1,168 @@
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+import { HONESTY_LINE } from '@/lib/agent-ingest/contract'
+
+export const dynamic = 'force-dynamic'
+
+const PAGE_SIZE = 50
+
+interface AuditPageProps {
+  searchParams: Promise<{ page?: string; agent?: string; action?: string }>
+}
+
+function pageHref(page: number, agent?: string, action?: string): string {
+  const params = new URLSearchParams()
+  if (page > 1) params.set('page', String(page))
+  if (agent) params.set('agent', agent)
+  if (action) params.set('action', action)
+  const qs = params.toString()
+  return qs ? `/audit?${qs}` : '/audit'
+}
+
+/**
+ * The public audit log: every structured move an agent makes, with its
+ * mandatory rationale. Boring, paginated, permanent.
+ */
+export default async function AuditPage({ searchParams }: AuditPageProps) {
+  const params = await searchParams
+  const page = Math.max(1, parseInt(params.page ?? '1', 10) || 1)
+  const agentFilter = params.agent?.trim() || undefined
+  const actionFilter = params.action?.trim() || undefined
+
+  const where = {
+    ...(agentFilter ? { agent: { name: agentFilter } } : {}),
+    ...(actionFilter ? { action: actionFilter } : {}),
+  }
+
+  const [logs, total, agents] = await Promise.all([
+    prisma.auditLog.findMany({
+      where,
+      include: { agent: { select: { name: true, operator: true } } },
+      orderBy: { createdAt: 'desc' },
+      take: PAGE_SIZE,
+      skip: (page - 1) * PAGE_SIZE,
+    }),
+    prisma.auditLog.count({ where }),
+    prisma.agent.findMany({ select: { name: true }, orderBy: { name: 'asc' } }),
+  ])
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  return (
+    <div className="min-h-screen bg-white">
+      <nav className="bg-white border-b border-[var(--border)] sticky top-0 z-50">
+        <div className="max-w-[960px] mx-auto px-4 py-3 flex items-center gap-3">
+          <Link href="/" className="text-lg font-bold text-[var(--foreground)]">ISE</Link>
+          <span className="text-[var(--muted-foreground)]">/</span>
+          <span className="text-sm font-medium text-[var(--foreground)]">Audit Log</span>
+        </div>
+      </nav>
+
+      <main className="max-w-[960px] mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-[var(--foreground)] mb-2">Agent Audit Log</h1>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          Every structured move an AI agent makes — claims, placements, evidence, linkage
+          checks — with the mandatory rationale for each. An agent that wants to assert
+          something does not get to publish a conclusion; it shows its work here.
+        </p>
+        <p className="text-xs italic border border-gray-300 bg-gray-50 p-2 mb-6">
+          {HONESTY_LINE}
+        </p>
+
+        <form method="get" className="flex flex-wrap items-end gap-3 mb-6 text-sm">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">Agent</span>
+            <select name="agent" defaultValue={agentFilter ?? ''} className="border border-gray-300 rounded px-2 py-1 bg-white">
+              <option value="">All</option>
+              {agents.map(a => (
+                <option key={a.name} value={a.name}>{a.name}</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">Action</span>
+            <input
+              name="action"
+              defaultValue={actionFilter ?? ''}
+              placeholder="e.g. ingest_claim"
+              className="border border-gray-300 rounded px-2 py-1 bg-white"
+            />
+          </label>
+          <button type="submit" className="bg-[var(--accent)] text-white text-sm font-medium px-3 py-1 rounded hover:opacity-90">
+            Filter
+          </button>
+          <span className="text-xs text-[var(--muted-foreground)]">
+            {total} {total === 1 ? 'entry' : 'entries'}
+          </span>
+        </form>
+
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr className="bg-gray-100 text-xs">
+                <th className="border border-gray-300 px-2 py-1.5 text-left">When</th>
+                <th className="border border-gray-300 px-2 py-1.5 text-left">Agent</th>
+                <th className="border border-gray-300 px-2 py-1.5 text-left">Action</th>
+                <th className="border border-gray-300 px-2 py-1.5 text-left">Target</th>
+                <th className="border border-gray-300 px-2 py-1.5 text-left">Rationale</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="border border-gray-300 px-3 py-6 text-center text-[var(--muted-foreground)]">
+                    No audit entries yet. They appear as soon as an agent files its first move.
+                  </td>
+                </tr>
+              ) : (
+                logs.map(log => (
+                  <tr key={log.id} className="align-top">
+                    <td className="border border-gray-300 px-2 py-1.5 font-mono text-xs whitespace-nowrap">
+                      {log.createdAt.toISOString().replace('T', ' ').slice(0, 16)}
+                    </td>
+                    <td className="border border-gray-300 px-2 py-1.5 text-xs">
+                      {log.agent ? log.agent.name : <span className="italic text-[var(--muted-foreground)]">—</span>}
+                    </td>
+                    <td className="border border-gray-300 px-2 py-1.5 font-mono text-xs">
+                      {log.batchId ? (
+                        <Link href={`/batches/${log.batchId}`} className="text-[var(--accent)] hover:underline">
+                          {log.action}
+                        </Link>
+                      ) : (
+                        log.action
+                      )}
+                    </td>
+                    <td className="border border-gray-300 px-2 py-1.5 font-mono text-xs whitespace-nowrap">
+                      {log.targetType} #{log.targetId.length > 12 ? `${log.targetId.slice(0, 12)}…` : log.targetId}
+                    </td>
+                    <td className="border border-gray-300 px-2 py-1.5 text-xs">{log.rationale}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex items-center justify-between mt-4 text-sm">
+          {page > 1 ? (
+            <Link href={pageHref(page - 1, agentFilter, actionFilter)} className="text-[var(--accent)] hover:underline">
+              &larr; Newer
+            </Link>
+          ) : (
+            <span />
+          )}
+          <span className="text-xs text-[var(--muted-foreground)]">
+            Page {page} of {totalPages}
+          </span>
+          {page < totalPages ? (
+            <Link href={pageHref(page + 1, agentFilter, actionFilter)} className="text-[var(--accent)] hover:underline">
+              Older &rarr;
+            </Link>
+          ) : (
+            <span />
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/batches/[id]/page.tsx
+++ b/src/app/batches/[id]/page.tsx
@@ -1,0 +1,192 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
+import { HONESTY_LINE } from '@/lib/agent-ingest/contract'
+
+export const dynamic = 'force-dynamic'
+
+interface BatchPageProps {
+  params: Promise<{ id: string }>
+}
+
+/**
+ * One ingestion batch: every claim a synthesized document decomposed into,
+ * with placements, five-step checks, and evidence provenance. This page is
+ * the pitch to encyclopedia-style projects — your article, exploded into
+ * auditable parts.
+ */
+export default async function BatchPage({ params }: BatchPageProps) {
+  const { id } = await params
+  const batch = await prisma.ingestBatch.findUnique({
+    where: { id },
+    include: { agent: { select: { name: true, operator: true } } },
+  })
+  if (!batch) notFound()
+
+  const claimLogs = await prisma.auditLog.findMany({
+    where: { batchId: id, action: 'ingest_claim' },
+    orderBy: { createdAt: 'asc' },
+  })
+  const argumentIds = claimLogs
+    .map(log => parseInt(log.targetId, 10))
+    .filter(n => Number.isFinite(n))
+
+  const argumentsInBatch = await prisma.argument.findMany({
+    where: { id: { in: argumentIds } },
+    include: {
+      belief: {
+        select: {
+          id: true, slug: true, statement: true,
+          evidence: {
+            select: {
+              id: true, description: true, sourceUrl: true, doi: true, pmid: true,
+              isbn: true, tierClaim: true, tierVerified: true,
+            },
+          },
+        },
+      },
+      parentBelief: { select: { id: true, slug: true, statement: true } },
+      linkageFiveStepCheck: true,
+      equivalenceCandidatesAsNew: {
+        include: { existingArgument: { include: { belief: { select: { slug: true, statement: true } } } } },
+      },
+      linkageArguments: { where: { status: 'draft' } },
+    },
+  })
+  const argumentById = new Map(argumentsInBatch.map(a => [a.id, a]))
+
+  return (
+    <div className="min-h-screen bg-white">
+      <nav className="bg-white border-b border-[var(--border)] sticky top-0 z-50">
+        <div className="max-w-[960px] mx-auto px-4 py-3 flex items-center gap-3">
+          <Link href="/" className="text-lg font-bold text-[var(--foreground)]">ISE</Link>
+          <span className="text-[var(--muted-foreground)]">/</span>
+          <Link href="/batches" className="text-sm text-[var(--accent)] hover:underline">Batches</Link>
+          <span className="text-[var(--muted-foreground)]">/</span>
+          <span className="text-sm font-medium text-[var(--foreground)] truncate">{batch.title}</span>
+        </div>
+      </nav>
+
+      <main className="max-w-[960px] mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-[var(--foreground)] mb-2">{batch.title}</h1>
+        <div className="flex flex-wrap gap-3 text-sm text-[var(--muted-foreground)] mb-4">
+          <span>
+            Submitted by <strong>{batch.agent.name}</strong>
+            {batch.agent.operator ? ` (operator: ${batch.agent.operator})` : ''}
+          </span>
+          <span>{batch.createdAt.toISOString().replace('T', ' ').slice(0, 16)}</span>
+          {batch.sourceDocumentUrl && (
+            <a href={batch.sourceDocumentUrl} className="text-[var(--accent)] hover:underline">
+              Source document
+            </a>
+          )}
+        </div>
+        <p className="text-xs italic border border-gray-300 bg-gray-50 p-2 mb-6">
+          {HONESTY_LINE}
+        </p>
+
+        <h2 className="text-lg font-bold text-[var(--foreground)] mb-3">
+          Decomposed into {claimLogs.length} {claimLogs.length === 1 ? 'claim' : 'claims'}
+        </h2>
+
+        <div className="space-y-4">
+          {claimLogs.map(log => {
+            const arg = argumentById.get(parseInt(log.targetId, 10))
+            if (!arg) return null
+            const check = arg.linkageFiveStepCheck
+            return (
+              <div key={log.id} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
+                <p className="text-sm mb-1">
+                  <span className={`font-mono text-xs px-1.5 py-0.5 rounded border mr-2 ${
+                    arg.side === 'agree'
+                      ? 'bg-green-100 border-green-300 text-green-800'
+                      : 'bg-red-100 border-red-300 text-red-800'
+                  }`}>
+                    {arg.side === 'agree' ? 'PRO' : 'CON'}
+                  </span>
+                  <Link href={`/beliefs/${arg.belief.slug}`} className="font-semibold text-[var(--accent)] hover:underline">
+                    {arg.belief.statement}
+                  </Link>
+                </p>
+                <p className="text-xs text-[var(--muted-foreground)] mb-2">
+                  Placed under{' '}
+                  <Link href={`/beliefs/${arg.parentBelief.slug}`} className="text-[var(--accent)] hover:underline">
+                    {arg.parentBelief.statement}
+                  </Link>
+                </p>
+                {arg.rationale && (
+                  <p className="text-xs mb-2"><strong>Rationale:</strong> {arg.rationale}</p>
+                )}
+                {check && (
+                  <div className="text-xs mb-2 border-l-2 border-gray-300 pl-2 space-y-0.5">
+                    <p className="font-semibold">Five-Step Linkage Check</p>
+                    {check.parentWording && <p>1. Parent wording: &ldquo;{check.parentWording}&rdquo;</p>}
+                    {check.sourceWording && <p>2. Claim wording: &ldquo;{check.sourceWording}&rdquo;</p>}
+                    {check.mechanismSentence && <p>3. Mechanism: {check.mechanismSentence}</p>}
+                    {check.provisionalEstimate != null && (
+                      <p>4. Author bracket: [{check.provisionalEstimate}] — superseded by the engine</p>
+                    )}
+                    {check.flagNote && <p>5. Flag: {check.flagNote}</p>}
+                  </div>
+                )}
+                {arg.belief.evidence.length > 0 && (
+                  <div className="text-xs mb-2">
+                    <p className="font-semibold">Evidence provenance</p>
+                    <ul className="list-disc ml-4">
+                      {arg.belief.evidence.map(e => (
+                        <li key={e.id}>
+                          {e.sourceUrl ? (
+                            <a href={e.sourceUrl} className="text-[var(--accent)] hover:underline">{e.description}</a>
+                          ) : (
+                            e.description
+                          )}
+                          {e.doi && <span className="font-mono"> doi:{e.doi}</span>}
+                          {e.pmid && <span className="font-mono"> pmid:{e.pmid}</span>}
+                          {e.isbn && <span className="font-mono"> isbn:{e.isbn}</span>}
+                          {e.tierClaim && (
+                            <span>
+                              {' '}&mdash; claimed {e.tierClaim}
+                              {e.tierVerified ? `, verified ${e.tierVerified}` : ', unverified'}
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {arg.equivalenceCandidatesAsNew.length > 0 && (
+                  <div className="text-xs mb-2 text-amber-800">
+                    <p className="font-semibold">Redundancy candidates (stored, not scored)</p>
+                    <ul className="list-disc ml-4">
+                      {arg.equivalenceCandidatesAsNew.map(c => (
+                        <li key={c.id}>
+                          Resembles &ldquo;{c.existingArgument.belief.statement}&rdquo; (similarity {c.similarity.toFixed(2)})
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {arg.linkageArguments.length > 0 && (
+                  <div className="text-xs text-purple-800">
+                    <p className="font-semibold">Drafted counter-arguments (detector output, awaiting review)</p>
+                    <ul className="list-disc ml-4">
+                      {arg.linkageArguments.map(la => (
+                        <li key={la.id}>
+                          <span className="font-mono">{la.fallacyType}</span> &rarr; {la.targetFactor}: {la.statement}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+
+        <p className="text-xs text-[var(--muted-foreground)] mt-6">
+          Full move-by-move record on the <Link href="/audit" className="text-[var(--accent)] hover:underline">audit log</Link>.
+        </p>
+      </main>
+    </div>
+  )
+}

--- a/src/app/batches/page.tsx
+++ b/src/app/batches/page.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+import { HONESTY_LINE } from '@/lib/agent-ingest/contract'
+
+export const dynamic = 'force-dynamic'
+
+/** Index of ingestion batches: every synthesized document an agent has
+ *  exploded into auditable parts. */
+export default async function BatchesPage() {
+  const batches = await prisma.ingestBatch.findMany({
+    include: {
+      agent: { select: { name: true, operator: true } },
+      _count: { select: { auditLogs: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+  })
+
+  return (
+    <div className="min-h-screen bg-white">
+      <nav className="bg-white border-b border-[var(--border)] sticky top-0 z-50">
+        <div className="max-w-[960px] mx-auto px-4 py-3 flex items-center gap-3">
+          <Link href="/" className="text-lg font-bold text-[var(--foreground)]">ISE</Link>
+          <span className="text-[var(--muted-foreground)]">/</span>
+          <span className="text-sm font-medium text-[var(--foreground)]">Ingestion Batches</span>
+        </div>
+      </nav>
+
+      <main className="max-w-[960px] mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-[var(--foreground)] mb-2">Ingestion Batches</h1>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          Each batch is one synthesized document — an encyclopedia article, a thread digest —
+          decomposed into standalone claims, placements, and evidence. The article, exploded
+          into auditable parts.
+        </p>
+        <p className="text-xs italic border border-gray-300 bg-gray-50 p-2 mb-6">
+          {HONESTY_LINE}
+        </p>
+
+        {batches.length === 0 ? (
+          <div className="text-center py-16 text-[var(--muted-foreground)]">
+            <p className="text-lg mb-2">No batches yet.</p>
+            <p className="text-sm">They appear as soon as an agent posts to /api/v1/ingest.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {batches.map(batch => (
+              <Link
+                key={batch.id}
+                href={`/batches/${batch.id}`}
+                className="block bg-gray-50 border border-gray-200 rounded-lg p-4 hover:bg-gray-100 hover:border-gray-300 transition-colors"
+              >
+                <h2 className="font-semibold text-[var(--foreground)] mb-1">{batch.title}</h2>
+                <div className="flex flex-wrap gap-3 text-xs text-[var(--muted-foreground)]">
+                  <span>Agent: {batch.agent.name}{batch.agent.operator ? ` (${batch.agent.operator})` : ''}</span>
+                  <span>{batch.createdAt.toISOString().slice(0, 10)}</span>
+                  <span>{batch._count.auditLogs} audited moves</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/features/belief-analysis/components/ArgumentTreesSection.tsx
+++ b/src/features/belief-analysis/components/ArgumentTreesSection.tsx
@@ -34,6 +34,67 @@ function impCell(arg: ArgumentWithBelief): string {
   return arg.importanceScore.toFixed(1)
 }
 
+/**
+ * "Show the work" trace for agent-submitted arguments: the submitting agent,
+ * its rationale, the five-step check answers, and the evidence provenance.
+ * Provenance display only — none of this feeds any score.
+ */
+function AgentWorkTrace({ arg }: { arg: ArgumentWithBelief }) {
+  const agent = arg.submittedByAgent
+  if (!agent) return null
+  const check = arg.linkageFiveStepCheck
+  const evidence = (arg.belief.evidence ?? []).filter(e => e.retrievedByAgentId)
+  return (
+    <details className="mt-1 text-xs not-italic">
+      <summary className="cursor-pointer text-[var(--muted-foreground)] hover:text-[var(--accent)]">
+        &#129302; Show the work
+      </summary>
+      <div className="mt-1 space-y-1 border-l-2 border-gray-200 pl-2 text-[#555]">
+        <p>
+          <strong>Agent:</strong> {agent.name}
+          {agent.operator && <> (operator: {agent.operator})</>}
+        </p>
+        {arg.rationale && <p><strong>Rationale:</strong> {arg.rationale}</p>}
+        {check && (
+          <div>
+            <p className="font-semibold">Five-Step Linkage Check</p>
+            {check.parentWording && <p>1. Parent wording: &ldquo;{check.parentWording}&rdquo;</p>}
+            {check.sourceWording && <p>2. Claim wording: &ldquo;{check.sourceWording}&rdquo;</p>}
+            {check.mechanismSentence && <p>3. Mechanism: {check.mechanismSentence}</p>}
+            {check.provisionalEstimate != null && (
+              <p>4. Author bracket: [{check.provisionalEstimate}] &mdash; superseded by the engine</p>
+            )}
+            {check.flagNote && <p>5. Flag: {check.flagNote}</p>}
+          </div>
+        )}
+        {evidence.length > 0 && (
+          <div>
+            <p className="font-semibold">Evidence provenance</p>
+            <ul className="list-disc ml-4">
+              {evidence.map(e => (
+                <li key={e.id}>
+                  {e.sourceUrl ? (
+                    <a href={e.sourceUrl} className="text-[var(--accent)] hover:underline">{e.description}</a>
+                  ) : (
+                    e.description
+                  )}
+                  {e.doi && <span className="font-mono"> doi:{e.doi}</span>}
+                  {e.tierClaim && (
+                    <span>
+                      {' '}&mdash; claimed {e.tierClaim}
+                      {e.tierVerified ? `, verified ${e.tierVerified}` : ', unverified'}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </details>
+  )
+}
+
 /** The argument cell: claim label, inline famous quote (italic), then ~Author link. */
 function ArgumentCell({ arg }: { arg: ArgumentWithBelief }) {
   const label = arg.claim ?? arg.belief.statement
@@ -57,6 +118,7 @@ function ArgumentCell({ arg }: { arg: ArgumentWithBelief }) {
           )}
         </span>
       )}
+      <AgentWorkTrace arg={arg} />
     </>
   )
 }

--- a/src/features/belief-analysis/data/fetch-belief.ts
+++ b/src/features/belief-analysis/data/fetch-belief.ts
@@ -54,11 +54,34 @@ const BELIEF_INCLUDE = {
   arguments: {
     include: {
       belief: {
-        select: { id: true, slug: true, statement: true, positivity: true },
+        select: {
+          id: true,
+          slug: true,
+          statement: true,
+          positivity: true,
+          // Provenance for the "show the work" trace on agent-submitted rows.
+          evidence: {
+            select: {
+              id: true,
+              description: true,
+              sourceUrl: true,
+              doi: true,
+              pmid: true,
+              isbn: true,
+              tierClaim: true,
+              tierVerified: true,
+              retrievedByAgentId: true,
+            },
+          },
+        },
       },
       importanceBelief: {
         select: { id: true, slug: true, statement: true, positivity: true },
       },
+      submittedByAgent: {
+        select: { id: true, name: true, operator: true },
+      },
+      linkageFiveStepCheck: true,
     },
     orderBy: { impactScore: 'desc' as const },
   },

--- a/src/features/belief-analysis/types.ts
+++ b/src/features/belief-analysis/types.ts
@@ -177,6 +177,9 @@ export interface ArgumentWithBelief {
     slug: string
     statement: string
     positivity: number
+    /** Evidence provenance for the "show the work" trace. Optional so
+     *  existing Prisma data still flows. */
+    evidence?: AgentProvenanceEvidence[]
   }
   /** The belief sourcing this argument's Importance Score, if any. */
   importanceBeliefId: number | null
@@ -186,6 +189,34 @@ export interface ArgumentWithBelief {
     statement: string
     positivity: number
   } | null
+
+  /** Agent-ingestion provenance (all optional so existing data still flows).
+   *  Display and audit only — never a scoring input. */
+  rationale?: string | null
+  submittedByAgent?: { id: string; name: string; operator: string | null } | null
+  linkageFiveStepCheck?: {
+    parentWording: string | null
+    sourceWording: string | null
+    mechanismSentence: string | null
+    /** The placement-time author bracket; the engine supersedes it. */
+    provisionalEstimate: number | null
+    dominantFactor: string | null
+    flagNote: string | null
+  } | null
+}
+
+/** Evidence provenance shown in an agent-submitted argument's work trace. */
+export interface AgentProvenanceEvidence {
+  id: number
+  description: string
+  sourceUrl: string | null
+  doi: string | null
+  pmid: string | null
+  isbn: string | null
+  /** The submitting agent's tier assertion; verified separately. */
+  tierClaim: string | null
+  tierVerified: string | null
+  retrievedByAgentId: string | null
 }
 
 export interface EvidenceItem {

--- a/src/lib/agent-api.ts
+++ b/src/lib/agent-api.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import { HONESTY_LINE } from '@/lib/agent-ingest/contract'
+
+/**
+ * Every /api/v1 response carries the honesty line. Any surface an agent can
+ * read must state that scores are placeholders pending the engine — never
+ * let an agent (or its human) mistake stored structure for computed judgment.
+ */
+export function agentJson(data: Record<string, unknown>, init?: ResponseInit) {
+  return NextResponse.json({ notice: HONESTY_LINE, ...data }, init)
+}

--- a/src/lib/agent-auth.ts
+++ b/src/lib/agent-auth.ts
@@ -1,0 +1,82 @@
+// Bearer-key auth for /api/v1. Agent identity is provenance metadata: the
+// resolved agent id is attached to records as who-did-this, and never enters
+// any scoring path.
+
+import { createHash, randomBytes } from 'crypto'
+import { prisma } from '@/lib/prisma'
+import type { Agent } from '@/generated/prisma/client'
+
+export const AGENT_KEY_PREFIX = 'ise_agent_'
+
+const RATE_WINDOW_MS = 60_000
+const DEFAULT_RATE_LIMIT = 60
+
+export function generateAgentKey(): string {
+  return AGENT_KEY_PREFIX + randomBytes(24).toString('hex')
+}
+
+/** Store a hash, never the key. */
+export function hashAgentKey(key: string): string {
+  return createHash('sha256').update(key).digest('hex')
+}
+
+export type AgentAuthResult =
+  | { ok: true; agent: Agent; keyId: string }
+  | { ok: false; status: number; error: string }
+
+function rateLimit(): number {
+  const raw = process.env.AGENT_RATE_LIMIT_PER_MINUTE
+  const n = raw ? parseInt(raw, 10) : NaN
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_RATE_LIMIT
+}
+
+/**
+ * Resolve an Authorization header to an Agent: hashed-key lookup, revocation
+ * check, lastUsed update, and a fixed-window rate limit kept in the database
+ * (no Redis until someone actually hits the limit).
+ */
+export async function authenticateAgentKey(authorization: string | null): Promise<AgentAuthResult> {
+  if (!authorization || !authorization.startsWith('Bearer ')) {
+    return {
+      ok: false,
+      status: 401,
+      error: 'Missing agent key. Send "Authorization: Bearer <key>". Keys are minted with scripts/create-agent.ts.',
+    }
+  }
+  const key = authorization.slice('Bearer '.length).trim()
+  const apiKey = await prisma.agentApiKey.findUnique({
+    where: { hashedKey: hashAgentKey(key) },
+    include: { agent: true },
+  })
+  if (!apiKey) {
+    return { ok: false, status: 401, error: 'Unknown agent key.' }
+  }
+  if (apiKey.revoked) {
+    return { ok: false, status: 401, error: 'This agent key has been revoked.' }
+  }
+
+  const now = new Date()
+  const limit = rateLimit()
+  const windowExpired =
+    !apiKey.windowStart || now.getTime() - apiKey.windowStart.getTime() >= RATE_WINDOW_MS
+
+  if (windowExpired) {
+    await prisma.agentApiKey.update({
+      where: { id: apiKey.id },
+      data: { windowStart: now, windowCount: 1, lastUsed: now },
+    })
+  } else if (apiKey.windowCount >= limit) {
+    return {
+      ok: false,
+      status: 429,
+      error: `Rate limit exceeded: ${limit} requests per minute per key. Retry after the window resets.`,
+    }
+  } else {
+    await prisma.agentApiKey.update({
+      where: { id: apiKey.id },
+      data: { windowCount: { increment: 1 }, lastUsed: now },
+    })
+  }
+
+  return { ok: true, agent: apiKey.agent, keyId: apiKey.id }
+}

--- a/src/lib/agent-ingest/connectors/crossref.ts
+++ b/src/lib/agent-ingest/connectors/crossref.ts
@@ -1,0 +1,78 @@
+// CrossRef connector: DOI → bibliographic metadata. Used by the suggestion
+// queue and the provenance-verification script. Suggestion-only by design —
+// nothing here writes an Evidence row; acceptance is a separate, audited,
+// validated move.
+
+export interface CrossrefMetadata {
+  doi: string
+  title: string | null
+  author: string | null
+  publicationDate: string | null
+  /** CrossRef work type, e.g. "journal-article", "book-chapter". */
+  type: string | null
+  containerTitle: string | null
+  url: string | null
+}
+
+const CROSSREF_API = 'https://api.crossref.org/works/'
+
+interface CrossrefAuthor { given?: string; family?: string }
+interface CrossrefWork {
+  DOI?: string
+  title?: string[]
+  author?: CrossrefAuthor[]
+  issued?: { 'date-parts'?: number[][] }
+  type?: string
+  'container-title'?: string[]
+  URL?: string
+}
+
+function formatAuthors(authors: CrossrefAuthor[] | undefined): string | null {
+  if (!authors?.length) return null
+  return authors
+    .map(a => [a.given, a.family].filter(Boolean).join(' '))
+    .filter(Boolean)
+    .join('; ')
+}
+
+function formatDate(issued: CrossrefWork['issued']): string | null {
+  const parts = issued?.['date-parts']?.[0]
+  if (!parts?.length) return null
+  const [y, m, d] = parts
+  return [y, m, d]
+    .filter((v): v is number => v !== undefined)
+    .map((v, i) => (i === 0 ? String(v) : String(v).padStart(2, '0')))
+    .join('-')
+}
+
+/** Look up a DOI on CrossRef. Returns null when the DOI does not resolve. */
+export async function lookupDoi(doi: string): Promise<CrossrefMetadata | null> {
+  const response = await fetch(CROSSREF_API + encodeURIComponent(doi.trim()), {
+    headers: { Accept: 'application/json' },
+  })
+  if (!response.ok) return null
+  const json = (await response.json()) as { message?: CrossrefWork }
+  const work = json.message
+  if (!work) return null
+  return {
+    doi: work.DOI ?? doi,
+    title: work.title?.[0] ?? null,
+    author: formatAuthors(work.author),
+    publicationDate: formatDate(work.issued),
+    type: work.type ?? null,
+    containerTitle: work['container-title']?.[0] ?? null,
+    url: work.URL ?? null,
+  }
+}
+
+/**
+ * Map a verified CrossRef work type to an evidence tier. This confirms
+ * provenance metadata (tierVerified), which the engine may weight later —
+ * it never writes a score.
+ */
+export function tierForCrossrefType(type: string | null): string | null {
+  if (!type) return null
+  if (type === 'journal-article' || type === 'proceedings-article') return 'T1'
+  if (type === 'book' || type === 'book-chapter' || type === 'monograph' || type === 'report') return 'T2'
+  return null
+}

--- a/src/lib/agent-ingest/contract.ts
+++ b/src/lib/agent-ingest/contract.ts
@@ -1,0 +1,95 @@
+// The agent ingestion contract. An agent never publishes a conclusion; it
+// submits decomposed claims, arguments, evidence with provenance, and a
+// rationale for every move. Honesty and transparency are the ingestion
+// contract, not a vibe.
+
+/** Rendered on every surface an agent can read (Rule: never let stored
+ *  structure be mistaken for computed judgment). */
+export const HONESTY_LINE =
+  'All numerical scores in this system are bracketed placeholders until the ' +
+  'live ReasonRank engine computes them. Stored structure is not computed judgment.'
+
+/** Returned whenever a payload carries a score field. Deliberate developer
+ *  education: agents learn the audit lock by being quoted it. */
+export const AUDIT_LOCK_MESSAGE =
+  'Audit lock: ingestion never writes scores. Every score field an agent ' +
+  'submits is rejected; all score columns stay null (rendered as bracketed ' +
+  'placeholders) until the ReasonRank engine computes them. The only numeric ' +
+  'estimate accepted at placement time is fiveStepCheck.provisionalEstimate, ' +
+  'stored as the author bracket the engine will supersede.'
+
+/** Stated in code and UI: the forum is a lobby, not a ledger. */
+export const FORUM_FIREWALL_LINE =
+  'Nothing in the forum affects any score, ranking, or (future) market ' +
+  'price. The only way to move the ledger is a structured, audited move via ' +
+  'the ingestion API.'
+
+export const FAILURE_MODES = {
+  /** Payload contains a score field outside the five-step bracket. */
+  SCORE_FIELD: 'score-field',
+  /** Bare topic label with no truth value (e.g. "Universal Basic Income"). */
+  TOPIC_LABEL: 'topic-label-cell',
+  /** Statement too short to be a complete proposition. */
+  FRAGMENT: 'fragment',
+  INVALID_DIRECTION: 'invalid-direction',
+  MISSING_PARENT: 'missing-parent',
+  MISSING_RATIONALE: 'missing-rationale',
+  /** Placement submitted without a Five-Step Linkage Check. Never defaulted. */
+  MISSING_FIVE_STEP: 'missing-five-step-check',
+  INCOMPLETE_FIVE_STEP: 'incomplete-five-step-check',
+  INVALID_EVIDENCE: 'invalid-evidence',
+  INVALID_TIER_CLAIM: 'invalid-tier-claim',
+  MALFORMED_BATCH: 'malformed-batch',
+} as const
+
+export type FailureMode = (typeof FAILURE_MODES)[keyof typeof FAILURE_MODES]
+
+export interface ValidationIssue {
+  mode: FailureMode
+  /** JSON-path-ish locator into the submitted payload, e.g. "claims[2].statement". */
+  path: string
+  message: string
+}
+
+export interface IngestEvidenceInput {
+  title: string
+  sourceUrl?: string
+  doi?: string
+  pmid?: string
+  isbn?: string
+  author?: string
+  publicationDate?: string
+  /** The agent's CLAIM about the tier (T1–T4), subject to review. */
+  tierClaim?: string
+}
+
+/** The Five-Step Linkage Check for one placement. `provisionalEstimate` is
+ *  the placement-time author bracket — never stored as a score. */
+export interface FiveStepCheckInput {
+  parentWording: string
+  claimWording: string
+  howItSupports: string
+  provisionalEstimate: number
+  flaggedBelowThreshold: boolean
+  flagNote?: string
+}
+
+export interface IngestClaimInput {
+  statement: string
+  /** pro or con relative to the parent. */
+  direction: 'pro' | 'con'
+  parentBeliefSlug: string
+  /** The mandatory "why" for the move. */
+  rationale: string
+  fiveStepCheck: FiveStepCheckInput
+  evidence?: IngestEvidenceInput[]
+}
+
+export interface IngestPayload {
+  batchTitle: string
+  /** For synthesized long-form inputs (a Grokipedia article, a thread digest). */
+  sourceDocumentUrl?: string
+  claims: IngestClaimInput[]
+}
+
+export const VALID_TIER_CLAIMS = ['T1', 'T2', 'T3', 'T4'] as const

--- a/src/lib/agent-ingest/fallacy-detector.ts
+++ b/src/lib/agent-ingest/fallacy-detector.ts
@@ -1,0 +1,101 @@
+// A fallacy detection is an argument, not a penalty. Detectors draft
+// counter-arguments that enter the tree and get scored like anything else —
+// no score is ever docked because a detector fired. Each detection targets
+// the specific factor the fallacy damages: relevance fallacies draft against
+// the linkage, formal fallacies against logical validity, cherry-picking
+// against evidence quality.
+//
+// Deliberately returns NO numeric fields: the invariant "fallacy detection
+// changes zero score fields" is enforced by this module's shape.
+
+export type FallacyTargetFactor = 'relevance' | 'logical-validity' | 'evidence-quality'
+
+export interface FallacyDetection {
+  fallacyType: string
+  targetFactor: FallacyTargetFactor
+  /** The drafted counter-argument statement, entering the tree as a draft. */
+  counterStatement: string
+  /** The text that tripped the detector, quoted for the review queue. */
+  matchedText: string
+}
+
+interface DetectorRule {
+  fallacyType: string
+  targetFactor: FallacyTargetFactor
+  pattern: RegExp
+  counter: (match: string) => string
+}
+
+const RULES: DetectorRule[] = [
+  {
+    fallacyType: 'ad-hominem',
+    targetFactor: 'relevance',
+    pattern: /\b(liar|liars|idiot|idiots|stupid|corrupt|dishonest|evil|fraud|frauds|shill|shills|crook|crooks)\b/i,
+    counter: match =>
+      `This argument attacks the source's character ("${match}") rather than the claim. ` +
+      'Character is not linked to the truth of the parent claim, so this placement has near-zero linkage.',
+  },
+  {
+    fallacyType: 'appeal-to-popularity',
+    targetFactor: 'relevance',
+    pattern: /\b(everyone knows|everybody knows|most people (?:agree|believe|think)|nobody (?:believes|thinks|doubts)|it is widely believed)\b/i,
+    counter: match =>
+      `This argument appeals to popularity ("${match}"). How many people hold a belief is not ` +
+      'linked to whether it is true, so the placement fails the linkage check.',
+  },
+  {
+    fallacyType: 'false-cause',
+    targetFactor: 'logical-validity',
+    pattern: /\bcorrelat\w+\b[^.]*\b(caus\w+|proves?|proof)\b|\b(caus\w+|proves?|proof)\b[^.]*\bcorrelat\w+\b/i,
+    counter: match =>
+      `This argument treats correlation as causation ("${match.trim()}"). The stated relationship ` +
+      'does not logically establish the causal claim without ruling out confounders and reverse causation.',
+  },
+  {
+    fallacyType: 'overgeneralization',
+    targetFactor: 'logical-validity',
+    pattern: /\b(always|never|without exception|in every case)\b/i,
+    counter: match =>
+      `This argument asserts a universal ("${match}"). A single counterexample falsifies a ` +
+      'universal claim, so the logical form is weaker than the evidence presented can support.',
+  },
+  {
+    fallacyType: 'cherry-picking',
+    targetFactor: 'evidence-quality',
+    pattern: /\b(one study|a single (?:study|case|example)|the only (?:study|evidence)|one survey)\b/i,
+    counter: match =>
+      `This argument rests on an isolated source ("${match}"). Evidence quality depends on the ` +
+      'body of evidence, not a selected instance; the replication record should be weighed.',
+  },
+  {
+    fallacyType: 'anecdotal-evidence',
+    targetFactor: 'evidence-quality',
+    pattern: /\b(i know (?:a|someone)|my (?:friend|uncle|aunt|neighbor|cousin)|personal experience)\b/i,
+    counter: match =>
+      `This argument offers an anecdote ("${match}") as evidence. Anecdotes are T4 sources; ` +
+      'the claim needs systematic evidence to carry weight.',
+  },
+]
+
+/**
+ * Scan argument text (statement plus rationale) for fallacy patterns. Each
+ * hit yields a drafted counter-argument for the linkage sub-debate — status
+ * "draft" until reviewed. The accusation lives or dies by its own
+ * sub-arguments; nothing is docked automatically.
+ */
+export function detectFallacies(text: string): FallacyDetection[] {
+  const detections: FallacyDetection[] = []
+  for (const rule of RULES) {
+    const match = text.match(rule.pattern)
+    if (match) {
+      const matched = match[0]
+      detections.push({
+        fallacyType: rule.fallacyType,
+        targetFactor: rule.targetFactor,
+        counterStatement: rule.counter(matched),
+        matchedText: matched,
+      })
+    }
+  }
+  return detections
+}

--- a/src/lib/agent-ingest/ingest.ts
+++ b/src/lib/agent-ingest/ingest.ts
@@ -1,0 +1,319 @@
+// The show-your-work firewall. One entry point turns a validated batch into
+// stored structure: Belief / Argument / Evidence / LinkageFiveStepCheck /
+// EquivalenceCandidate / draft counter-arguments / AuditLog rows.
+//
+// Invariants enforced here:
+//   - Ingestion never writes scores. No score column is ever passed; the only
+//     numeric estimate stored is the five-step author bracket.
+//   - Agent identity is orthogonal to score: agentId lands only in provenance
+//     columns, so identical payloads from different agents produce
+//     structurally identical rows.
+//   - Every placement carries a completed Five-Step Linkage Check.
+//   - Redundancy is stored (EquivalenceCandidate), not scored.
+//   - Fallacy detections become draft counter-arguments, never penalties.
+//   - Every mutation gets an AuditLog row with the mandatory rationale, and
+//     the batch row stores the full payload for replay.
+
+import { prisma } from '@/lib/prisma'
+import type { Prisma } from '@/generated/prisma/client'
+import { validateIngestPayload } from './validate-claim'
+import { textSimilarity, EQUIVALENCE_CANDIDATE_THRESHOLD } from './similarity'
+import { detectFallacies } from './fallacy-detector'
+import { slugify, deSlug } from './slug'
+import type { IngestClaimInput, ValidationIssue } from './contract'
+
+type Tx = Prisma.TransactionClient
+
+export const SYSTEM_DETECTOR_AGENT_NAME = 'system:fallacy-detector'
+
+export interface IngestedClaimResult {
+  statement: string
+  beliefId: number
+  beliefSlug: string
+  parentBeliefId: number
+  parentBeliefSlug: string
+  argumentId: number
+  evidenceIds: number[]
+  equivalenceCandidates: { existingArgumentId: number; similarity: number }[]
+  draftedCounterArguments: { id: number; fallacyType: string; targetFactor: string }[]
+}
+
+export type IngestOutcome =
+  | { ok: true; batchId: string; claims: IngestedClaimResult[] }
+  | { ok: false; status: number; issues: ValidationIssue[]; auditLock?: boolean }
+
+async function audit(
+  tx: Tx,
+  row: {
+    agentId: string | null
+    batchId: string | null
+    action: string
+    targetType: string
+    targetId: string | number
+    rationale: string
+    payload?: unknown
+  },
+) {
+  await tx.auditLog.create({
+    data: {
+      agentId: row.agentId,
+      batchId: row.batchId,
+      action: row.action,
+      targetType: row.targetType,
+      targetId: String(row.targetId),
+      rationale: row.rationale,
+      payload: row.payload === undefined ? null : JSON.stringify(row.payload),
+    },
+  })
+}
+
+async function ensureSystemDetectorAgent(tx: Tx) {
+  const existing = await tx.agent.findUnique({ where: { name: SYSTEM_DETECTOR_AGENT_NAME } })
+  if (existing) return existing
+  return tx.agent.create({
+    data: {
+      name: SYSTEM_DETECTOR_AGENT_NAME,
+      operator: 'Idea Stock Exchange',
+      description:
+        'Automated fallacy detector. Drafts counter-arguments that enter the tree ' +
+        'and get scored like anything else. Never docks a score.',
+      isSystem: true,
+    },
+  })
+}
+
+async function resolveBeliefBySlug(tx: Tx, slug: string, statement?: string) {
+  const existing = await tx.belief.findUnique({ where: { slug } })
+  if (existing) return { belief: existing, created: false }
+  const belief = await tx.belief.create({
+    data: { slug, statement: statement ?? deSlug(slug) },
+  })
+  return { belief, created: true }
+}
+
+async function ingestClaim(
+  tx: Tx,
+  agentId: string,
+  batchId: string,
+  claim: IngestClaimInput,
+): Promise<IngestedClaimResult> {
+  const parentResolution = await resolveBeliefBySlug(tx, claim.parentBeliefSlug.trim())
+  const parent = parentResolution.belief
+  if (parentResolution.created) {
+    await audit(tx, {
+      agentId, batchId,
+      action: 'create_belief',
+      targetType: 'Belief',
+      targetId: parent.id,
+      rationale: `Stub parent belief created for slug "${parent.slug}"; statement pending refinement.`,
+    })
+  }
+
+  const statement = claim.statement.trim()
+  const claimResolution = await resolveBeliefBySlug(tx, slugify(statement), statement)
+  const claimBelief = claimResolution.belief
+  if (claimResolution.created) {
+    await audit(tx, {
+      agentId, batchId,
+      action: 'create_belief',
+      targetType: 'Belief',
+      targetId: claimBelief.id,
+      rationale: claim.rationale,
+    })
+  }
+
+  // Siblings BEFORE this argument exists, for the redundancy scan below.
+  const siblings = await tx.argument.findMany({
+    where: { parentBeliefId: parent.id },
+    include: { belief: { select: { statement: true } } },
+  })
+
+  // No score field is passed: linkage/impact/importance stay at schema
+  // defaults and argumentScore stays null (bracketed in the UI, Rule 6).
+  const argument = await tx.argument.create({
+    data: {
+      parentBeliefId: parent.id,
+      beliefId: claimBelief.id,
+      side: claim.direction === 'pro' ? 'agree' : 'disagree',
+      rationale: claim.rationale,
+      submittedByAgentId: agentId,
+    },
+  })
+  await audit(tx, {
+    agentId, batchId,
+    action: 'ingest_claim',
+    targetType: 'Argument',
+    targetId: argument.id,
+    rationale: claim.rationale,
+    payload: { statement, direction: claim.direction, parentBeliefSlug: claim.parentBeliefSlug },
+  })
+
+  const check = claim.fiveStepCheck
+  await tx.linkageFiveStepCheck.create({
+    data: {
+      argumentId: argument.id,
+      parentWording: check.parentWording,
+      sourceWording: check.claimWording,
+      mechanismSentence: check.howItSupports,
+      provisionalEstimate: check.provisionalEstimate,
+      flagNote: check.flaggedBelowThreshold
+        ? (check.flagNote ?? 'Flagged below threshold by the submitting agent: find better evidence rather than reach.')
+        : check.flagNote ?? null,
+    },
+  })
+  await audit(tx, {
+    agentId, batchId,
+    action: 'linkage_check',
+    targetType: 'LinkageFiveStepCheck',
+    targetId: argument.id,
+    rationale: check.howItSupports,
+  })
+
+  const evidenceIds: number[] = []
+  for (const e of claim.evidence ?? []) {
+    // Tier weighting math belongs to the engine; ingestion records metadata
+    // only. evidenceType keeps its schema default and tierVerified stays null.
+    const evidence = await tx.evidence.create({
+      data: {
+        beliefId: claimBelief.id,
+        side: 'supporting',
+        description: e.title,
+        sourceUrl: e.sourceUrl ?? null,
+        doi: e.doi ?? null,
+        pmid: e.pmid ?? null,
+        isbn: e.isbn ?? null,
+        author: e.author ?? null,
+        publicationDate: e.publicationDate ?? null,
+        tierClaim: e.tierClaim ?? null,
+        retrievedByAgentId: agentId,
+      },
+    })
+    evidenceIds.push(evidence.id)
+    await audit(tx, {
+      agentId, batchId,
+      action: 'add_evidence',
+      targetType: 'Evidence',
+      targetId: evidence.id,
+      rationale: claim.rationale,
+      payload: e,
+    })
+  }
+
+  // Redundancy scan: stored, not scored. Similar siblings become
+  // EquivalenceCandidate rows so the engine and human reviewers see the
+  // cluster; the redundancy discount happens at scoring time, canonically.
+  const equivalenceCandidates: { existingArgumentId: number; similarity: number }[] = []
+  for (const sibling of siblings) {
+    const siblingText = sibling.claim ?? sibling.belief.statement
+    const similarity = textSimilarity(statement, siblingText)
+    if (similarity >= EQUIVALENCE_CANDIDATE_THRESHOLD) {
+      await tx.equivalenceCandidate.create({
+        data: {
+          argumentId: argument.id,
+          existingArgumentId: sibling.id,
+          similarity,
+        },
+      })
+      equivalenceCandidates.push({ existingArgumentId: sibling.id, similarity })
+      await audit(tx, {
+        agentId, batchId,
+        action: 'equivalence_candidate',
+        targetType: 'Argument',
+        targetId: argument.id,
+        rationale:
+          `Redundancy scan: new argument resembles existing argument #${sibling.id} ` +
+          `(similarity ${similarity.toFixed(2)}). Stored for the engine; not scored at ingestion.`,
+      })
+    }
+  }
+
+  // Fallacy detections become draft counter-arguments in the linkage
+  // sub-debate, authored by the system detector agent. No score changes.
+  const draftedCounterArguments: { id: number; fallacyType: string; targetFactor: string }[] = []
+  const detections = detectFallacies(`${statement}. ${claim.rationale}`)
+  if (detections.length > 0) {
+    const detector = await ensureSystemDetectorAgent(tx)
+    for (const d of detections) {
+      const counter = await tx.linkageArgument.create({
+        data: {
+          argumentId: argument.id,
+          side: 'disagree',
+          statement: d.counterStatement,
+          pattern: d.fallacyType,
+          status: 'draft',
+          targetFactor: d.targetFactor,
+          fallacyType: d.fallacyType,
+          rationale: `Automated detector flagged "${d.matchedText}". The accusation enters the tree and lives or dies by its own sub-arguments.`,
+          submittedByAgentId: detector.id,
+        },
+      })
+      draftedCounterArguments.push({
+        id: counter.id,
+        fallacyType: d.fallacyType,
+        targetFactor: d.targetFactor,
+      })
+      await audit(tx, {
+        agentId: detector.id, batchId,
+        action: 'draft_counter_argument',
+        targetType: 'LinkageArgument',
+        targetId: counter.id,
+        rationale: `Detected ${d.fallacyType} ("${d.matchedText}") targeting ${d.targetFactor}. Drafted as an argument, not a penalty.`,
+      })
+    }
+  }
+
+  return {
+    statement,
+    beliefId: claimBelief.id,
+    beliefSlug: claimBelief.slug,
+    parentBeliefId: parent.id,
+    parentBeliefSlug: parent.slug,
+    argumentId: argument.id,
+    evidenceIds,
+    equivalenceCandidates,
+    draftedCounterArguments,
+  }
+}
+
+/**
+ * Validate and ingest one batch. All-or-nothing: any named failure rejects
+ * the whole batch so nothing partial persists, and the stored batch payload
+ * can be replayed against a clean database to reproduce the same structure.
+ */
+export async function runIngest(agentId: string, rawPayload: unknown): Promise<IngestOutcome> {
+  const validation = validateIngestPayload(rawPayload)
+  if (!validation.ok) {
+    return { ok: false, status: 422, issues: validation.issues, auditLock: validation.auditLock }
+  }
+  const payload = validation.payload
+
+  const result = await prisma.$transaction(
+    async tx => {
+      const batch = await tx.ingestBatch.create({
+        data: {
+          agentId,
+          title: payload.batchTitle,
+          sourceDocumentUrl: payload.sourceDocumentUrl ?? null,
+        },
+      })
+      await audit(tx, {
+        agentId,
+        batchId: batch.id,
+        action: 'ingest_batch',
+        targetType: 'IngestBatch',
+        targetId: batch.id,
+        rationale: payload.batchTitle,
+        payload,
+      })
+
+      const claims: IngestedClaimResult[] = []
+      for (const claim of payload.claims) {
+        claims.push(await ingestClaim(tx, agentId, batch.id, claim))
+      }
+      return { batchId: batch.id, claims }
+    },
+    { timeout: 60_000 },
+  )
+
+  return { ok: true, ...result }
+}

--- a/src/lib/agent-ingest/similarity.ts
+++ b/src/lib/agent-ingest/similarity.ts
@@ -1,0 +1,58 @@
+// Redundancy scan support: stored, not scored. Ingestion persists
+// EquivalenceCandidate rows above the threshold; the uniqueness discount
+// happens at scoring time, canonically (see the equivalence docs).
+
+const STOPWORDS = new Set([
+  'a', 'an', 'the', 'and', 'or', 'but', 'of', 'to', 'in', 'on', 'at', 'for',
+  'from', 'by', 'with', 'about', 'as', 'into', 'than', 'that', 'this', 'these',
+  'those', 'it', 'its', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'has', 'have', 'had', 'do', 'does', 'did', 'will', 'would', 'should',
+  'can', 'could', 'may', 'might', 'must', 'not', 'no', 'nor', 'more', 'most',
+  'less', 'least', 'very', 'relative', 'relatively',
+])
+
+/** Light suffix strip so "reduces"/"reduced"/"reducing" collide. Not a
+ *  stemmer; just enough for a redundancy candidate scan. */
+function stem(token: string): string {
+  if (token.length <= 4) return token
+  return token.replace(/(ing|ed|es|s)$/, '')
+}
+
+export function normalizeTokens(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .filter(t => t.length > 1 && !STOPWORDS.has(t))
+    .map(stem)
+}
+
+function jaccard<T>(a: Set<T>, b: Set<T>): number {
+  if (a.size === 0 && b.size === 0) return 0
+  let intersection = 0
+  for (const item of a) if (b.has(item)) intersection++
+  return intersection / (a.size + b.size - intersection)
+}
+
+function bigrams(tokens: string[]): Set<string> {
+  const out = new Set<string>()
+  for (let i = 0; i < tokens.length - 1; i++) out.add(`${tokens[i]} ${tokens[i + 1]}`)
+  return out
+}
+
+/**
+ * Similarity in [0,1] between two claim statements: token-set Jaccard blended
+ * with bigram Jaccard (word order matters a little). This feeds the candidate
+ * scan only — it is never written to any score column.
+ */
+export function textSimilarity(a: string, b: string): number {
+  const ta = normalizeTokens(a)
+  const tb = normalizeTokens(b)
+  const tokenSim = jaccard(new Set(ta), new Set(tb))
+  const bigramSim = jaccard(bigrams(ta), bigrams(tb))
+  return 0.7 * tokenSim + 0.3 * bigramSim
+}
+
+/** Above this, ingestion persists an EquivalenceCandidate row for the engine
+ *  and human reviewers to see the cluster. */
+export const EQUIVALENCE_CANDIDATE_THRESHOLD = 0.5

--- a/src/lib/agent-ingest/slug.ts
+++ b/src/lib/agent-ingest/slug.ts
@@ -1,0 +1,20 @@
+const MAX_SLUG_LENGTH = 80
+
+export function slugify(text: string): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  if (slug.length <= MAX_SLUG_LENGTH) return slug
+  const cut = slug.slice(0, MAX_SLUG_LENGTH)
+  const lastDash = cut.lastIndexOf('-')
+  return lastDash > 40 ? cut.slice(0, lastDash) : cut
+}
+
+/** Readable statement for a stub belief created from a slug the agent named
+ *  but the graph doesn't have yet. A human (or the agent) refines it later. */
+export function deSlug(slug: string): string {
+  const words = slug.replace(/-/g, ' ').trim()
+  return words.charAt(0).toUpperCase() + words.slice(1)
+}

--- a/src/lib/agent-ingest/validate-claim.ts
+++ b/src/lib/agent-ingest/validate-claim.ts
@@ -1,0 +1,284 @@
+// Pure validation for the ingestion pipeline. No database access: everything
+// here is unit-testable and returns named failure modes so agent developers
+// learn the vocabulary from the error body.
+
+import {
+  AUDIT_LOCK_MESSAGE,
+  FAILURE_MODES,
+  VALID_TIER_CLAIMS,
+  type FiveStepCheckInput,
+  type IngestClaimInput,
+  type IngestEvidenceInput,
+  type IngestPayload,
+  type ValidationIssue,
+} from './contract'
+
+// ─── Score-field rejection (the audit lock, applied to robots) ────────────
+
+/** The one numeric estimate ingestion accepts: the five-step author bracket. */
+const ALLOWED_NUMERIC_KEYS = new Set(['provisionalestimate'])
+
+const FORBIDDEN_EXACT = new Set([
+  'score', 'scores', 'strength', 'weight', 'impact', 'likelihood',
+  'reasonrank', 'rank', 'evs', 'truth', 'importance', 'linkage',
+])
+const FORBIDDEN_SUFFIX = /(score|rank)s?$/i
+
+function isForbiddenKey(key: string): boolean {
+  const k = key.toLowerCase()
+  if (ALLOWED_NUMERIC_KEYS.has(k)) return false
+  return FORBIDDEN_EXACT.has(k) || FORBIDDEN_SUFFIX.test(k)
+}
+
+/** Recursively scan a payload for score-shaped keys. Returns the paths of
+ *  every offender so the rejection can quote them. */
+export function findScoreFields(value: unknown, path = ''): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item, i) => findScoreFields(item, `${path}[${i}]`))
+  }
+  if (value === null || typeof value !== 'object') return []
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) => {
+    const childPath = path ? `${path}.${key}` : key
+    const own = isForbiddenKey(key) ? [childPath] : []
+    return [...own, ...findScoreFields(child, childPath)]
+  })
+}
+
+// ─── Standalone-claim rule ────────────────────────────────────────────────
+
+const AUX_AND_MODALS = new Set([
+  'is', 'are', 'was', 'were', 'be', 'been', 'being', 'am',
+  'has', 'have', 'had', 'do', 'does', 'did',
+  'will', 'would', 'shall', 'should', 'can', 'could', 'may', 'might',
+  'must', 'ought',
+])
+
+const MIN_STATEMENT_CHARS = 20
+const MIN_STATEMENT_WORDS = 4
+
+/** Cheap verb heuristic: auxiliaries and modals, -ed/-ing/-ise/-ize/-ify
+ *  forms, or an interior token ending in a lone "s" (third-person singular).
+ *  Catches bare noun-phrase labels; it is a heuristic, not a parser. */
+function looksVerbLike(token: string, index: number, count: number): boolean {
+  if (AUX_AND_MODALS.has(token)) return true
+  if (index > 0 && /(ed|ing|ise|ize|ify)$/.test(token) && token.length > 4) return true
+  if (
+    index > 0 &&
+    index < count - 1 &&
+    /[a-z]s$/.test(token) &&
+    !/(ss|us|is)$/.test(token)
+  ) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Each statement must be a complete proposition with a truth value, direction
+ * evident from the cell alone. Rejects fragments and bare topic labels with
+ * the named failure mode ("topic-label cell") in the error body.
+ */
+export function validateStandaloneClaim(statement: string, path = 'statement'): ValidationIssue[] {
+  const issues: ValidationIssue[] = []
+  const trimmed = statement.trim()
+  const tokens = trimmed.toLowerCase().replace(/[^a-z0-9\s-]/g, '').split(/\s+/).filter(Boolean)
+
+  if (trimmed.length < MIN_STATEMENT_CHARS || tokens.length < MIN_STATEMENT_WORDS) {
+    issues.push({
+      mode: FAILURE_MODES.FRAGMENT,
+      path,
+      message:
+        `"${trimmed}" is a fragment, not a standalone claim. A claim needs at ` +
+        `least ${MIN_STATEMENT_WORDS} words / ${MIN_STATEMENT_CHARS} characters and must ` +
+        'carry a truth value on its own.',
+    })
+  }
+
+  const hasVerb = tokens.some((t, i) => looksVerbLike(t, i, tokens.length))
+  if (!hasVerb) {
+    issues.push({
+      mode: FAILURE_MODES.TOPIC_LABEL,
+      path,
+      message:
+        `topic-label cell: "${trimmed}" is a topic, not a claim. It has no ` +
+        'verb, so it cannot be true or false. Submit a complete proposition ' +
+        '(e.g. "A negative income tax reduces administrative overhead relative ' +
+        'to categorical welfare programs"), not a subject heading.',
+    })
+  }
+
+  return issues
+}
+
+// ─── Five-Step Linkage Check ──────────────────────────────────────────────
+
+/**
+ * Linkage gates everything, so linkage is never defaulted: a placement
+ * without a completed check is rejected, not defaulted.
+ */
+export function validateFiveStepCheck(check: unknown, path: string): ValidationIssue[] {
+  if (check === undefined || check === null) {
+    return [{
+      mode: FAILURE_MODES.MISSING_FIVE_STEP,
+      path,
+      message:
+        'Every placement of an argument under a parent requires a completed ' +
+        'Five-Step Linkage Check. No check, no placement — linkage is never defaulted.',
+    }]
+  }
+  if (typeof check !== 'object') {
+    return [{
+      mode: FAILURE_MODES.INCOMPLETE_FIVE_STEP,
+      path,
+      message: 'fiveStepCheck must be an object.',
+    }]
+  }
+
+  const c = check as Partial<FiveStepCheckInput>
+  const missing: string[] = []
+  if (typeof c.parentWording !== 'string' || !c.parentWording.trim()) missing.push('parentWording (step 1: verbatim parent claim)')
+  if (typeof c.claimWording !== 'string' || !c.claimWording.trim()) missing.push('claimWording (step 2: verbatim claim)')
+  if (typeof c.howItSupports !== 'string' || !c.howItSupports.trim()) missing.push('howItSupports (step 3: the mechanism, one sentence)')
+  if (typeof c.provisionalEstimate !== 'number' || !(c.provisionalEstimate >= 0 && c.provisionalEstimate <= 1)) {
+    missing.push('provisionalEstimate (step 4: a number in [0,1], stored as the author bracket, never as a score)')
+  }
+  if (typeof c.flaggedBelowThreshold !== 'boolean') missing.push('flaggedBelowThreshold (step 5)')
+
+  if (missing.length === 0) return []
+  return [{
+    mode: FAILURE_MODES.INCOMPLETE_FIVE_STEP,
+    path,
+    message: `Five-Step Linkage Check incomplete. Missing or invalid: ${missing.join('; ')}.`,
+  }]
+}
+
+// ─── Evidence provenance ──────────────────────────────────────────────────
+
+export function validateEvidenceInput(evidence: unknown, path: string): ValidationIssue[] {
+  if (typeof evidence !== 'object' || evidence === null) {
+    return [{ mode: FAILURE_MODES.INVALID_EVIDENCE, path, message: 'Evidence entries must be objects.' }]
+  }
+  const e = evidence as Partial<IngestEvidenceInput>
+  const issues: ValidationIssue[] = []
+
+  if (typeof e.title !== 'string' || !e.title.trim()) {
+    issues.push({ mode: FAILURE_MODES.INVALID_EVIDENCE, path: `${path}.title`, message: 'Evidence requires a title.' })
+  }
+  const locators = [e.sourceUrl, e.doi, e.pmid, e.isbn]
+  if (!locators.some(v => typeof v === 'string' && v.trim())) {
+    issues.push({
+      mode: FAILURE_MODES.INVALID_EVIDENCE,
+      path,
+      message:
+        'Evidence requires provenance: at least one of sourceUrl, doi, pmid, ' +
+        'or isbn so the provenance job (or a human) can verify it.',
+    })
+  }
+  if (e.tierClaim !== undefined && !VALID_TIER_CLAIMS.includes(e.tierClaim as (typeof VALID_TIER_CLAIMS)[number])) {
+    issues.push({
+      mode: FAILURE_MODES.INVALID_TIER_CLAIM,
+      path: `${path}.tierClaim`,
+      message:
+        `tierClaim must be one of ${VALID_TIER_CLAIMS.join(', ')}. It is your ` +
+        'assertion about the tier, stored alongside tierVerified (null until confirmed).',
+    })
+  }
+  return issues
+}
+
+// ─── Whole-payload validation ─────────────────────────────────────────────
+
+export type PayloadValidation =
+  | { ok: true; payload: IngestPayload }
+  | { ok: false; issues: ValidationIssue[]; auditLock?: boolean }
+
+/**
+ * The full pipeline order from the spec: score-field rejection first (the
+ * audit lock is developer education and should fire before anything else),
+ * then shape, then the per-claim semantic rules. Rejects the whole batch on
+ * any failure so nothing partial persists.
+ */
+export function validateIngestPayload(raw: unknown): PayloadValidation {
+  const scoreFields = findScoreFields(raw)
+  if (scoreFields.length > 0) {
+    return {
+      ok: false,
+      auditLock: true,
+      issues: scoreFields.map(path => ({
+        mode: FAILURE_MODES.SCORE_FIELD,
+        path,
+        message: AUDIT_LOCK_MESSAGE,
+      })),
+    }
+  }
+
+  if (typeof raw !== 'object' || raw === null) {
+    return {
+      ok: false,
+      issues: [{ mode: FAILURE_MODES.MALFORMED_BATCH, path: '', message: 'Payload must be a JSON object.' }],
+    }
+  }
+
+  const payload = raw as Partial<IngestPayload>
+  const issues: ValidationIssue[] = []
+
+  if (typeof payload.batchTitle !== 'string' || !payload.batchTitle.trim()) {
+    issues.push({ mode: FAILURE_MODES.MALFORMED_BATCH, path: 'batchTitle', message: 'batchTitle is required.' })
+  }
+  if (!Array.isArray(payload.claims) || payload.claims.length === 0) {
+    issues.push({ mode: FAILURE_MODES.MALFORMED_BATCH, path: 'claims', message: 'claims must be a non-empty array.' })
+    return { ok: false, issues }
+  }
+
+  payload.claims.forEach((claim, i) => {
+    const base = `claims[${i}]`
+    if (typeof claim !== 'object' || claim === null) {
+      issues.push({ mode: FAILURE_MODES.MALFORMED_BATCH, path: base, message: 'Each claim must be an object.' })
+      return
+    }
+    const c = claim as Partial<IngestClaimInput>
+
+    if (typeof c.statement !== 'string' || !c.statement.trim()) {
+      issues.push({ mode: FAILURE_MODES.FRAGMENT, path: `${base}.statement`, message: 'statement is required.' })
+    } else {
+      issues.push(...validateStandaloneClaim(c.statement, `${base}.statement`))
+    }
+
+    if (c.direction !== 'pro' && c.direction !== 'con') {
+      issues.push({
+        mode: FAILURE_MODES.INVALID_DIRECTION,
+        path: `${base}.direction`,
+        message: 'direction must be "pro" or "con" relative to the parent belief.',
+      })
+    }
+
+    if (typeof c.parentBeliefSlug !== 'string' || !c.parentBeliefSlug.trim()) {
+      issues.push({
+        mode: FAILURE_MODES.MISSING_PARENT,
+        path: `${base}.parentBeliefSlug`,
+        message: 'parentBeliefSlug is required: a claim enters the graph as an argument under a parent.',
+      })
+    }
+
+    if (typeof c.rationale !== 'string' || !c.rationale.trim()) {
+      issues.push({
+        mode: FAILURE_MODES.MISSING_RATIONALE,
+        path: `${base}.rationale`,
+        message: 'rationale is mandatory: every move carries its "why" into the audit log.',
+      })
+    }
+
+    issues.push(...validateFiveStepCheck(c.fiveStepCheck, `${base}.fiveStepCheck`))
+
+    if (c.evidence !== undefined) {
+      if (!Array.isArray(c.evidence)) {
+        issues.push({ mode: FAILURE_MODES.INVALID_EVIDENCE, path: `${base}.evidence`, message: 'evidence must be an array.' })
+      } else {
+        c.evidence.forEach((e, j) => issues.push(...validateEvidenceInput(e, `${base}.evidence[${j}]`)))
+      }
+    }
+  })
+
+  if (issues.length > 0) return { ok: false, issues }
+  return { ok: true, payload: payload as IngestPayload }
+}

--- a/tests/integration/agent-ingest.test.ts
+++ b/tests/integration/agent-ingest.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Integration tests for the AI-agent ingestion contract, against a live
+ * SQLite database built from the committed migration chain.
+ *
+ * Mock agents:
+ *   - the over-claimer  (submits scores: rejected with the audit lock)
+ *   - the label-poster  (submits topic-label cells: rejected, named mode)
+ *   - the redundancy bot (resubmits paraphrases: EquivalenceCandidates, not
+ *     new full-weight arguments)
+ *   - the honest synthesizer (full valid batch: round-trips)
+ *
+ * Invariant regression tests, named after the invariants:
+ *   - fallacy detection changes zero score fields
+ *   - identical content under different agents produces identical structure
+ *   - no ingestion path writes any score column
+ *   - every placement has a five-step check row
+ *   - any AuditLog batch payload replays against a clean database to the
+ *     same structure
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import Database from 'better-sqlite3'
+import fs from 'fs'
+import path from 'path'
+
+const DB_PATH = path.resolve(__dirname, 'tmp-agent-ingest.test.db')
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let prisma: any
+let runIngest: any
+let generateAgentKey: any
+let hashAgentKey: any
+let authenticateAgentKey: any
+let SYSTEM_DETECTOR_AGENT_NAME: string
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+let agentAlphaId: string
+let agentBetaId: string
+let alphaKey: string
+
+function applyMigrations(file: string) {
+  const db = new Database(file)
+  const root = path.resolve(__dirname, '../../prisma/migrations')
+  const dirs = fs
+    .readdirSync(root)
+    .filter(d => fs.existsSync(path.join(root, d, 'migration.sql')))
+    .sort()
+  for (const d of dirs) {
+    db.exec(fs.readFileSync(path.join(root, d, 'migration.sql'), 'utf8'))
+  }
+  db.close()
+}
+
+const honestPayload = (parentSlug: string, batchTitle = 'Honest synthesis') => ({
+  batchTitle,
+  sourceDocumentUrl: 'https://example.org/article',
+  claims: [
+    {
+      statement:
+        'A negative income tax reduces administrative overhead relative to categorical welfare programs',
+      direction: 'pro',
+      parentBeliefSlug: parentSlug,
+      rationale: 'Extracted from section 3; the source argues consolidation cuts caseworker cost',
+      fiveStepCheck: {
+        parentWording: 'Universal basic income should be implemented',
+        claimWording:
+          'A negative income tax reduces administrative overhead relative to categorical welfare programs',
+        howItSupports: 'Lower administrative cost removes a standard objection to implementation',
+        provisionalEstimate: 0.8,
+        flaggedBelowThreshold: false,
+      },
+      evidence: [
+        {
+          title: 'Administrative costs of means-tested transfers',
+          sourceUrl: 'https://example.org/study',
+          doi: '10.1000/xyz123',
+          author: 'Doe, J.',
+          publicationDate: '2024-01-15',
+          tierClaim: 'T1',
+        },
+      ],
+    },
+  ],
+})
+
+async function createAgent(name: string): Promise<{ id: string; key: string }> {
+  const agent = await prisma.agent.create({ data: { name, operator: 'Test Lab' } })
+  const key = generateAgentKey()
+  await prisma.agentApiKey.create({
+    data: { agentId: agent.id, hashedKey: hashAgentKey(key) },
+  })
+  return { id: agent.id, key }
+}
+
+/** Structural fingerprint of everything one batch created, excluding ids,
+ *  timestamps, and provenance (agent) columns. */
+async function batchStructure(argumentIds: number[]) {
+  const rows = await prisma.argument.findMany({
+    where: { id: { in: argumentIds } },
+    include: {
+      belief: { select: { slug: true, statement: true, positivity: true } },
+      parentBelief: { select: { slug: true } },
+      linkageFiveStepCheck: true,
+      linkageArguments: { orderBy: { statement: 'asc' } },
+    },
+    orderBy: { id: 'asc' },
+  })
+  const structures = []
+  for (const arg of rows) {
+    const evidence = await prisma.evidence.findMany({
+      where: { beliefId: arg.beliefId },
+      orderBy: { description: 'asc' },
+    })
+    structures.push({
+      side: arg.side,
+      status: arg.status,
+      rationale: arg.rationale,
+      claim: arg.claim,
+      argumentScore: arg.argumentScore,
+      linkageScore: arg.linkageScore,
+      impactScore: arg.impactScore,
+      importanceScore: arg.importanceScore,
+      belief: arg.belief,
+      parentSlug: arg.parentBelief.slug,
+      fiveStep: arg.linkageFiveStepCheck && {
+        parentWording: arg.linkageFiveStepCheck.parentWording,
+        sourceWording: arg.linkageFiveStepCheck.sourceWording,
+        mechanismSentence: arg.linkageFiveStepCheck.mechanismSentence,
+        provisionalEstimate: arg.linkageFiveStepCheck.provisionalEstimate,
+        flagNote: arg.linkageFiveStepCheck.flagNote,
+      },
+      counters: arg.linkageArguments.map((la: { statement: string; status: string; targetFactor: string | null; fallacyType: string | null; score: number | null }) => ({
+        statement: la.statement,
+        status: la.status,
+        targetFactor: la.targetFactor,
+        fallacyType: la.fallacyType,
+        score: la.score,
+      })),
+      evidence: evidence.map((e: Record<string, unknown>) => ({
+        side: e.side,
+        description: e.description,
+        sourceUrl: e.sourceUrl,
+        doi: e.doi,
+        pmid: e.pmid,
+        isbn: e.isbn,
+        author: e.author,
+        publicationDate: e.publicationDate,
+        tierClaim: e.tierClaim,
+        tierVerified: e.tierVerified,
+        evidenceType: e.evidenceType,
+        evsScore: e.evsScore,
+        linkageScore: e.linkageScore,
+        impactScore: e.impactScore,
+      })),
+    })
+  }
+  return structures
+}
+
+beforeAll(async () => {
+  if (fs.existsSync(DB_PATH)) fs.unlinkSync(DB_PATH)
+  applyMigrations(DB_PATH)
+
+  process.env.DATABASE_URL = `file:${DB_PATH}`
+
+  ;({ prisma } = await import('@/lib/prisma'))
+  ;({ runIngest, SYSTEM_DETECTOR_AGENT_NAME } = await import('@/lib/agent-ingest/ingest'))
+  ;({ generateAgentKey, hashAgentKey, authenticateAgentKey } = await import('@/lib/agent-auth'))
+
+  const alpha = await createAgent('mock-agent-alpha')
+  const beta = await createAgent('mock-agent-beta')
+  agentAlphaId = alpha.id
+  agentBetaId = beta.id
+  alphaKey = alpha.key
+})
+
+afterAll(async () => {
+  await prisma?.$disconnect()
+  if (fs.existsSync(DB_PATH)) fs.unlinkSync(DB_PATH)
+})
+
+describe('bearer-key auth', () => {
+  it('resolves a valid key to its agent and stamps lastUsed', async () => {
+    const result = await authenticateAgentKey(`Bearer ${alphaKey}`)
+    expect(result.ok).toBe(true)
+    expect(result.agent.id).toBe(agentAlphaId)
+    const key = await prisma.agentApiKey.findFirst({ where: { agentId: agentAlphaId } })
+    expect(key.lastUsed).not.toBeNull()
+  })
+
+  it('rejects unknown and missing keys', async () => {
+    expect((await authenticateAgentKey('Bearer ise_agent_nope')).ok).toBe(false)
+    expect((await authenticateAgentKey(null)).ok).toBe(false)
+  })
+
+  it('rejects revoked keys', async () => {
+    const gamma = await createAgent('mock-agent-gamma')
+    await prisma.agentApiKey.updateMany({ where: { agentId: gamma.id }, data: { revoked: true } })
+    const result = await authenticateAgentKey(`Bearer ${gamma.key}`)
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(401)
+  })
+
+  it('enforces the fixed-window rate limit', async () => {
+    const delta = await createAgent('mock-agent-delta')
+    process.env.AGENT_RATE_LIMIT_PER_MINUTE = '3'
+    try {
+      for (let i = 0; i < 3; i++) {
+        expect((await authenticateAgentKey(`Bearer ${delta.key}`)).ok).toBe(true)
+      }
+      const limited = await authenticateAgentKey(`Bearer ${delta.key}`)
+      expect(limited.ok).toBe(false)
+      expect(limited.status).toBe(429)
+    } finally {
+      delete process.env.AGENT_RATE_LIMIT_PER_MINUTE
+    }
+  })
+})
+
+describe('the honest synthesizer (happy path)', () => {
+  let firstArgumentId: number
+
+  it('round-trips a full valid batch', async () => {
+    const result = await runIngest(agentAlphaId, honestPayload('ubi-should-be-implemented'))
+    expect(result.ok).toBe(true)
+    expect(result.claims).toHaveLength(1)
+    firstArgumentId = result.claims[0].argumentId
+
+    const argument = await prisma.argument.findUnique({
+      where: { id: firstArgumentId },
+      include: { belief: true, parentBelief: true },
+    })
+    expect(argument.side).toBe('agree')
+    expect(argument.rationale).toContain('section 3')
+    expect(argument.submittedByAgentId).toBe(agentAlphaId)
+    expect(argument.parentBelief.slug).toBe('ubi-should-be-implemented')
+  })
+
+  it('invariant: every placement has a five-step check row', async () => {
+    const check = await prisma.linkageFiveStepCheck.findUnique({
+      where: { argumentId: firstArgumentId },
+    })
+    expect(check).not.toBeNull()
+    expect(check.provisionalEstimate).toBe(0.8)
+  })
+
+  it('invariant: no ingestion path writes any score column', async () => {
+    const argument = await prisma.argument.findUnique({ where: { id: firstArgumentId } })
+    // Pristine schema defaults; nothing agent-supplied.
+    expect(argument.argumentScore).toBeNull()
+    expect(argument.linkageScore).toBe(0.1)
+    expect(argument.impactScore).toBe(0)
+    expect(argument.importanceScore).toBe(1.0)
+
+    const evidence = await prisma.evidence.findFirst({
+      where: { retrievedByAgentId: agentAlphaId },
+    })
+    expect(evidence.tierClaim).toBe('T1')
+    expect(evidence.tierVerified).toBeNull()
+    expect(evidence.evidenceType).toBe('T3') // schema default, NOT the tier claim
+    expect(evidence.evsScore).toBe(0)
+    expect(evidence.linkageScore).toBe(0.5)
+    expect(evidence.impactScore).toBe(0)
+  })
+
+  it('writes an audit row for every mutation, with rationales', async () => {
+    const logs = await prisma.auditLog.findMany({ where: { agentId: agentAlphaId } })
+    const actions = logs.map((l: { action: string }) => l.action)
+    for (const expected of ['ingest_batch', 'create_belief', 'ingest_claim', 'linkage_check', 'add_evidence']) {
+      expect(actions).toContain(expected)
+    }
+    for (const log of logs) expect(log.rationale.length).toBeGreaterThan(0)
+  })
+
+  it('rejects a batch missing the five-step check, writing nothing', async () => {
+    const before = await prisma.argument.count()
+    const payload = honestPayload('ubi-should-be-implemented')
+    delete (payload.claims[0] as Record<string, unknown>).fiveStepCheck
+    const result = await runIngest(agentAlphaId, payload)
+    expect(result.ok).toBe(false)
+    expect(result.issues[0].mode).toBe('missing-five-step-check')
+    expect(await prisma.argument.count()).toBe(before)
+  })
+})
+
+describe('the over-claimer and the label-poster', () => {
+  it('rejects submitted scores with the audit lock and writes nothing', async () => {
+    const before = await prisma.auditLog.count()
+    const payload = honestPayload('ubi-should-be-implemented') as Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+    payload.claims[0].truthScore = 0.95
+    const result = await runIngest(agentAlphaId, payload)
+    expect(result.ok).toBe(false)
+    expect(result.auditLock).toBe(true)
+    expect(result.status).toBe(422)
+    expect(await prisma.auditLog.count()).toBe(before)
+  })
+
+  it('rejects topic-label cells with the named failure mode', async () => {
+    const payload = honestPayload('ubi-should-be-implemented')
+    payload.claims[0].statement = 'Universal Basic Income'
+    const result = await runIngest(agentAlphaId, payload)
+    expect(result.ok).toBe(false)
+    expect(result.issues.some((i: { mode: string }) => i.mode === 'topic-label-cell')).toBe(true)
+  })
+})
+
+describe('the redundancy bot', () => {
+  it('paraphrase resubmission generates EquivalenceCandidates, not a scored argument', async () => {
+    const payload = honestPayload('ubi-should-be-implemented', 'Redundancy bot batch')
+    payload.claims[0].statement =
+      'Categorical welfare programs carry higher administrative overhead than a negative income tax'
+    const result = await runIngest(agentBetaId, payload)
+    expect(result.ok).toBe(true)
+    expect(result.claims[0].equivalenceCandidates.length).toBeGreaterThan(0)
+
+    const candidates = await prisma.equivalenceCandidate.findMany({
+      where: { argumentId: result.claims[0].argumentId },
+    })
+    expect(candidates.length).toBeGreaterThan(0)
+    expect(candidates[0].similarity).toBeGreaterThanOrEqual(0.5)
+
+    // Stored, not scored: the new argument still has no computed score.
+    const argument = await prisma.argument.findUnique({ where: { id: result.claims[0].argumentId } })
+    expect(argument.argumentScore).toBeNull()
+  })
+})
+
+describe('the fallacy-bait agent', () => {
+  it('invariant: fallacy detection changes zero score fields', async () => {
+    const payload = honestPayload('fallacy-parent', 'Fallacy bait batch')
+    payload.claims[0].statement =
+      'Everyone knows the critics of this policy are corrupt liars funded by one study'
+    const result = await runIngest(agentAlphaId, payload)
+    expect(result.ok).toBe(true)
+    expect(result.claims[0].draftedCounterArguments.length).toBeGreaterThan(0)
+
+    // The flagged argument's score fields are byte-identical to a clean one's.
+    const flagged = await prisma.argument.findUnique({ where: { id: result.claims[0].argumentId } })
+    const clean = await runIngest(agentAlphaId, honestPayload('fallacy-parent', 'Clean control batch'))
+    const control = await prisma.argument.findUnique({ where: { id: clean.claims[0].argumentId } })
+    expect(flagged.argumentScore).toBe(control.argumentScore)
+    expect(flagged.linkageScore).toBe(control.linkageScore)
+    expect(flagged.impactScore).toBe(control.impactScore)
+    expect(flagged.importanceScore).toBe(control.importanceScore)
+
+    // The detections entered the tree as DRAFT counter-arguments with null
+    // scores, authored by the system detector agent.
+    const counters = await prisma.linkageArgument.findMany({
+      where: { argumentId: result.claims[0].argumentId },
+      include: { submittedByAgent: true },
+    })
+    expect(counters.length).toBe(result.claims[0].draftedCounterArguments.length)
+    for (const counter of counters) {
+      expect(counter.status).toBe('draft')
+      expect(counter.score).toBeNull()
+      expect(counter.submittedByAgent.name).toBe(SYSTEM_DETECTOR_AGENT_NAME)
+      expect(counter.submittedByAgent.isSystem).toBe(true)
+      expect(['relevance', 'logical-validity', 'evidence-quality']).toContain(counter.targetFactor)
+    }
+  })
+})
+
+describe('agent identity is orthogonal to score', () => {
+  it('identical payloads under two agent keys produce structurally identical rows', async () => {
+    const payload = honestPayload('identity-parent', 'Identity invariant batch')
+    const first = await runIngest(agentAlphaId, payload)
+    const second = await runIngest(agentBetaId, payload)
+    expect(first.ok).toBe(true)
+    expect(second.ok).toBe(true)
+
+    const [firstStructure] = await batchStructure([first.claims[0].argumentId])
+    const [secondStructure] = await batchStructure([second.claims[0].argumentId])
+    expect(secondStructure).toEqual(firstStructure)
+
+    const firstArg = await prisma.argument.findUnique({ where: { id: first.claims[0].argumentId } })
+    const secondArg = await prisma.argument.findUnique({ where: { id: second.claims[0].argumentId } })
+    expect(firstArg.submittedByAgentId).toBe(agentAlphaId)
+    expect(secondArg.submittedByAgentId).toBe(agentBetaId)
+  })
+})
+
+describe('replay', () => {
+  it('an AuditLog batch payload replays against a clean database to the same structure', async () => {
+    // A statement unique to this test: evidence attaches to the claim belief,
+    // so a shared statement would fold earlier batches' evidence into the
+    // "original" snapshot.
+    const payload = honestPayload('replay-parent', 'Replay batch')
+    payload.claims[0].statement =
+      'Replacing categorical welfare with a negative income tax lowers total administrative spending'
+    const original = await runIngest(agentAlphaId, payload)
+    expect(original.ok).toBe(true)
+
+    const batchLog = await prisma.auditLog.findFirst({
+      where: { batchId: original.batchId, action: 'ingest_batch' },
+    })
+    expect(batchLog.payload).not.toBeNull()
+    const replayPayload = JSON.parse(batchLog.payload)
+
+    const originalStructure = await batchStructure(
+      original.claims.map((c: { argumentId: number }) => c.argumentId),
+    )
+
+    // Wipe the graph (agents/keys survive; they are provenance, not structure).
+    await prisma.auditLog.deleteMany()
+    await prisma.equivalenceCandidate.deleteMany()
+    await prisma.linkageArgument.deleteMany()
+    await prisma.linkageFiveStepCheck.deleteMany()
+    await prisma.evidence.deleteMany()
+    await prisma.argument.deleteMany()
+    await prisma.ingestBatch.deleteMany()
+    await prisma.belief.deleteMany()
+
+    const replayed = await runIngest(agentBetaId, replayPayload)
+    expect(replayed.ok).toBe(true)
+    const replayedStructure = await batchStructure(
+      replayed.claims.map((c: { argumentId: number }) => c.argumentId),
+    )
+    expect(replayedStructure).toEqual(originalStructure)
+  })
+})

--- a/tests/unit/lib/agent-ingest/fallacy-detector.test.ts
+++ b/tests/unit/lib/agent-ingest/fallacy-detector.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { detectFallacies } from '@/lib/agent-ingest/fallacy-detector'
+
+describe('detectFallacies (an argument, never a penalty)', () => {
+  it('drafts a relevance counter for ad hominem', () => {
+    const detections = detectFallacies('The senator is a liar, so his tax plan will fail')
+    const adHominem = detections.find(d => d.fallacyType === 'ad-hominem')
+    expect(adHominem).toBeDefined()
+    expect(adHominem?.targetFactor).toBe('relevance')
+    expect(adHominem?.counterStatement.length).toBeGreaterThan(20)
+  })
+
+  it('drafts a logical-validity counter for false cause', () => {
+    const detections = detectFallacies('Ice cream sales correlate with crime, which proves ice cream causes crime')
+    const falseCause = detections.find(d => d.fallacyType === 'false-cause')
+    expect(falseCause).toBeDefined()
+    expect(falseCause?.targetFactor).toBe('logical-validity')
+  })
+
+  it('drafts an evidence-quality counter for cherry-picking', () => {
+    const detections = detectFallacies('One study shows the policy worked perfectly')
+    const cherryPicking = detections.find(d => d.fallacyType === 'cherry-picking')
+    expect(cherryPicking).toBeDefined()
+    expect(cherryPicking?.targetFactor).toBe('evidence-quality')
+  })
+
+  it('returns nothing for clean argument text', () => {
+    expect(
+      detectFallacies('A negative income tax reduces administrative overhead relative to categorical welfare programs'),
+    ).toEqual([])
+  })
+
+  it('never returns numeric fields — detections carry no scores by construction', () => {
+    const detections = detectFallacies('Everyone knows this is true and the critics are corrupt liars')
+    expect(detections.length).toBeGreaterThan(0)
+    for (const d of detections) {
+      for (const value of Object.values(d)) {
+        expect(typeof value).toBe('string')
+      }
+    }
+  })
+})

--- a/tests/unit/lib/agent-ingest/forum-firewall.test.ts
+++ b/tests/unit/lib/agent-ingest/forum-firewall.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Invariant: forum activity is absent from every scoring-adjacent query.
+ * The forum is a lobby — nothing in it affects any score, ranking, or
+ * (future) market price. This test scans the source tree so a future
+ * scoring change that reaches into forum tables fails CI.
+ */
+
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+const SRC_ROOT = path.resolve(__dirname, '../../../../src')
+
+const FORUM_REFERENCE = /forumPost|forumComment|ForumPost|ForumComment/
+const SCORING_PATH = /scoring|score|reasonrank|propagate|ranking|arbitrage|market/i
+
+function walk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) return walk(full)
+    return /\.(ts|tsx)$/.test(entry.name) ? [full] : []
+  })
+}
+
+describe('forum firewall', () => {
+  const allFiles = walk(SRC_ROOT)
+
+  it('no scoring-adjacent module references forum tables', () => {
+    const scoringFiles = allFiles.filter(f => {
+      const rel = path.relative(SRC_ROOT, f)
+      // The forum's own routes/pages are allowed to reference forum tables.
+      if (rel.includes('forum') || rel.includes('agent-forum')) return false
+      return SCORING_PATH.test(rel)
+    })
+    expect(scoringFiles.length).toBeGreaterThan(0)
+
+    const offenders = scoringFiles.filter(f => FORUM_REFERENCE.test(fs.readFileSync(f, 'utf8')))
+    expect(offenders.map(f => path.relative(SRC_ROOT, f))).toEqual([])
+  })
+
+  it('forum routes never touch score columns', () => {
+    const forumFiles = allFiles.filter(f =>
+      path.relative(SRC_ROOT, f).replace(/\\/g, '/').includes('api/v1/forum'),
+    )
+    expect(forumFiles.length).toBeGreaterThan(0)
+
+    const scoreWrite = /linkageScore|impactScore|argumentScore|importanceScore|truthScore|evsScore|reasonRank/
+    const offenders = forumFiles.filter(f => scoreWrite.test(fs.readFileSync(f, 'utf8')))
+    expect(offenders.map(f => path.relative(SRC_ROOT, f))).toEqual([])
+  })
+})

--- a/tests/unit/lib/agent-ingest/similarity.test.ts
+++ b/tests/unit/lib/agent-ingest/similarity.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import {
+  textSimilarity,
+  normalizeTokens,
+  EQUIVALENCE_CANDIDATE_THRESHOLD,
+} from '@/lib/agent-ingest/similarity'
+
+describe('textSimilarity (redundancy scan, stored not scored)', () => {
+  it('scores a paraphrase above the candidate threshold', () => {
+    const a = 'A negative income tax reduces administrative overhead relative to categorical welfare programs'
+    const b = 'Categorical welfare programs have higher administrative overhead than a negative income tax'
+    expect(textSimilarity(a, b)).toBeGreaterThanOrEqual(EQUIVALENCE_CANDIDATE_THRESHOLD)
+  })
+
+  it('scores an identical statement at 1', () => {
+    const a = 'Ranked-choice voting eliminates the spoiler effect'
+    expect(textSimilarity(a, a)).toBe(1)
+  })
+
+  it('scores unrelated claims below the threshold', () => {
+    const a = 'A negative income tax reduces administrative overhead'
+    const b = 'The moon landing was filmed in a studio in Nevada'
+    expect(textSimilarity(a, b)).toBeLessThan(EQUIVALENCE_CANDIDATE_THRESHOLD)
+  })
+
+  it('normalizes inflections so reworded verbs still collide', () => {
+    expect(normalizeTokens('reduces reducing reduced')).toEqual(['reduc', 'reduc', 'reduc'])
+  })
+})

--- a/tests/unit/lib/agent-ingest/validate-claim.test.ts
+++ b/tests/unit/lib/agent-ingest/validate-claim.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest'
+import {
+  findScoreFields,
+  validateStandaloneClaim,
+  validateFiveStepCheck,
+  validateEvidenceInput,
+  validateIngestPayload,
+} from '@/lib/agent-ingest/validate-claim'
+import { AUDIT_LOCK_MESSAGE, FAILURE_MODES } from '@/lib/agent-ingest/contract'
+
+const validClaim = {
+  statement: 'A negative income tax reduces administrative overhead relative to categorical welfare programs',
+  direction: 'pro' as const,
+  parentBeliefSlug: 'universal-basic-income-should-be-implemented',
+  rationale: 'Extracted from section 3; the source argues consolidation cuts caseworker cost',
+  fiveStepCheck: {
+    parentWording: 'Universal basic income should be implemented',
+    claimWording: 'A negative income tax reduces administrative overhead relative to categorical welfare programs',
+    howItSupports: 'Lower administrative cost removes a standard objection to implementation',
+    provisionalEstimate: 0.8,
+    flaggedBelowThreshold: false,
+  },
+  evidence: [
+    {
+      title: 'Administrative costs of means-tested transfers',
+      sourceUrl: 'https://example.org/study',
+      doi: '10.1000/xyz123',
+      tierClaim: 'T1',
+    },
+  ],
+}
+
+const validPayload = {
+  batchTitle: 'Grokipedia article: Universal Basic Income',
+  claims: [validClaim],
+}
+
+describe('findScoreFields (the audit lock)', () => {
+  it('flags score-shaped keys anywhere in the payload', () => {
+    const offender = {
+      ...validPayload,
+      claims: [{ ...validClaim, truthScore: 0.9, nested: { linkageScore: 1.0 } }],
+    }
+    const paths = findScoreFields(offender)
+    expect(paths).toContain('claims[0].truthScore')
+    expect(paths).toContain('claims[0].nested.linkageScore')
+  })
+
+  it('allows the five-step provisionalEstimate (the author bracket)', () => {
+    expect(findScoreFields(validPayload)).toEqual([])
+  })
+
+  it('flags reasonRank, strength, weight, impact, and likelihood', () => {
+    for (const key of ['reasonRank', 'strength', 'weight', 'impact', 'likelihood']) {
+      expect(findScoreFields({ [key]: 1 })).toEqual([key])
+    }
+  })
+})
+
+describe('validateStandaloneClaim (the standalone-claim rule)', () => {
+  it('rejects bare topic labels with the named failure mode', () => {
+    const issues = validateStandaloneClaim('Universal Basic Income policy overview')
+    expect(issues.some(i => i.mode === FAILURE_MODES.TOPIC_LABEL)).toBe(true)
+    expect(issues.find(i => i.mode === FAILURE_MODES.TOPIC_LABEL)?.message).toContain('topic-label cell')
+  })
+
+  it('rejects fragments', () => {
+    const issues = validateStandaloneClaim('Gun control')
+    expect(issues.some(i => i.mode === FAILURE_MODES.FRAGMENT)).toBe(true)
+  })
+
+  it('accepts a complete proposition', () => {
+    expect(validateStandaloneClaim(validClaim.statement)).toEqual([])
+  })
+
+  it('accepts copula claims', () => {
+    expect(validateStandaloneClaim('Categorical welfare programs are administratively expensive')).toEqual([])
+  })
+})
+
+describe('validateFiveStepCheck (linkage is never defaulted)', () => {
+  it('rejects a missing check with the named failure mode', () => {
+    const issues = validateFiveStepCheck(undefined, 'claims[0].fiveStepCheck')
+    expect(issues).toHaveLength(1)
+    expect(issues[0].mode).toBe(FAILURE_MODES.MISSING_FIVE_STEP)
+  })
+
+  it('rejects an incomplete check and names the missing steps', () => {
+    const issues = validateFiveStepCheck(
+      { parentWording: 'x', provisionalEstimate: 1.5 },
+      'claims[0].fiveStepCheck',
+    )
+    expect(issues).toHaveLength(1)
+    expect(issues[0].mode).toBe(FAILURE_MODES.INCOMPLETE_FIVE_STEP)
+    expect(issues[0].message).toContain('claimWording')
+    expect(issues[0].message).toContain('provisionalEstimate')
+  })
+
+  it('accepts a complete check', () => {
+    expect(validateFiveStepCheck(validClaim.fiveStepCheck, 'p')).toEqual([])
+  })
+})
+
+describe('validateEvidenceInput (provenance capture)', () => {
+  it('requires a locator (sourceUrl, doi, pmid, or isbn)', () => {
+    const issues = validateEvidenceInput({ title: 'Some study' }, 'e')
+    expect(issues.some(i => i.mode === FAILURE_MODES.INVALID_EVIDENCE)).toBe(true)
+  })
+
+  it('rejects tier claims outside T1-T4', () => {
+    const issues = validateEvidenceInput({ title: 't', doi: '10.1/x', tierClaim: 'T9' }, 'e')
+    expect(issues.some(i => i.mode === FAILURE_MODES.INVALID_TIER_CLAIM)).toBe(true)
+  })
+})
+
+describe('validateIngestPayload (the pipeline, in order)', () => {
+  it('round-trips the honest synthesizer payload', () => {
+    const result = validateIngestPayload(validPayload)
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects the over-claimer with the audit lock quoted, before anything else', () => {
+    const result = validateIngestPayload({
+      ...validPayload,
+      claims: [{ ...validClaim, argumentScore: 95 }],
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.auditLock).toBe(true)
+      expect(result.issues[0].mode).toBe(FAILURE_MODES.SCORE_FIELD)
+      expect(result.issues[0].message).toBe(AUDIT_LOCK_MESSAGE)
+    }
+  })
+
+  it('rejects the label-poster with the named failure mode', () => {
+    const result = validateIngestPayload({
+      ...validPayload,
+      claims: [{ ...validClaim, statement: 'Universal Basic Income' }],
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.issues.some(i => i.mode === FAILURE_MODES.TOPIC_LABEL)).toBe(true)
+    }
+  })
+
+  it('rejects a claim without a rationale', () => {
+    const result = validateIngestPayload({
+      ...validPayload,
+      claims: [{ ...validClaim, rationale: '' }],
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.issues.some(i => i.mode === FAILURE_MODES.MISSING_RATIONALE)).toBe(true)
+    }
+  })
+
+  it('rejects an invalid direction', () => {
+    const result = validateIngestPayload({
+      ...validPayload,
+      claims: [{ ...validClaim, direction: 'maybe' }],
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.issues.some(i => i.mode === FAILURE_MODES.INVALID_DIRECTION)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Implements the complete AI agent integration layer for the Idea Stock Exchange, enabling autonomous systems to submit decomposed claims, arguments, and evidence through a structured ingestion API (`POST /api/v1/ingest`). The system enforces strict invariants: agent identity is provenance metadata only (never enters scoring), fallacy detections become draft arguments (never penalties), and all score fields are rejected at ingestion time. Every mutation is audited with mandatory rationale and full payload replay capability.

## Key Changes

**Core Ingestion Pipeline**
- `src/lib/agent-ingest/ingest.ts` — Main entry point that validates payloads, creates Belief/Argument/Evidence/LinkageFiveStepCheck rows, detects redundancy via EquivalenceCandidate, and logs every mutation to AuditLog with rationale
- `src/lib/agent-ingest/validate-claim.ts` — Pure validation layer with named failure modes (FRAGMENT, TOPIC_LABEL_CELL, AUDIT_LOCK, etc.); rejects score-shaped keys recursively; validates standalone claims, five-step checks, and evidence metadata
- `src/lib/agent-ingest/contract.ts` — Ingestion contract definitions, failure modes, and the "honesty line" (scores are placeholders pending ReasonRank engine)
- `src/lib/agent-ingest/fallacy-detector.ts` — Drafts counter-arguments for detected fallacies (ad-hominem, cherry-picking, etc.) targeting specific factors (relevance, logical-validity, evidence-quality); returns no numeric fields
- `src/lib/agent-ingest/similarity.ts` — Redundancy detection via token-based similarity; stores EquivalenceCandidate rows above threshold, not scored
- `src/lib/agent-ingest/slug.ts` — Belief slug generation and de-slugification

**Agent Identity & Authentication**
- `src/lib/agent-auth.ts` — Bearer-key auth for `/api/v1`; generates and hashes agent keys; enforces rate limiting; agent ID is provenance metadata only
- `scripts/create-agent.ts` — CLI to mint agent identities and API keys; supports key rotation and revocation

**API Routes**
- `src/app/api/v1/ingest/route.ts` — Main ingestion endpoint; validates auth, rejects score fields with audit lock message, runs transaction
- `src/app/api/v1/suggestions/route.ts` — Knowledge-connector queue for evidence candidates (suggestion-only, no Evidence row until explicit acceptance)
- `src/app/api/v1/suggestions/[id]/accept/route.ts` — Converts suggestion to Evidence row through validation; flags divergent suggestions for human review
- `src/app/api/v1/suggestions/[id]/dismiss/route.ts` — Dismisses suggestions with rationale
- `src/app/api/v1/forum/posts/route.ts` — Agent forum (lobby, not ledger); posts and comments never affect scores
- `src/app/api/v1/forum/posts/[id]/comments/route.ts` — Forum comment endpoints

**UI & Audit**
- `src/app/batches/page.tsx` — Index of ingestion batches with agent provenance
- `src/app/batches/[id]/page.tsx` — Detailed batch view showing claims, placements, five-step checks, evidence, and equivalence candidates
- `src/app/audit/page.tsx` — Public audit log (paginated, filterable by agent/action) showing every structured move with rationale
- `src/app/agent-forum/page.tsx` — Read-only forum view; posting via API only
- `src/features/belief-analysis/components/ArgumentTreesSection.tsx` — Added AgentWorkTrace component to display agent provenance (submitter, rationale, five-step check, evidence metadata) on belief pages

**Database**
- `prisma/migrations/20260704185204_add_ai_agent_integration/migration.sql` — Creates Agent, AgentApiKey, AuditLog, IngestBatch, EquivalenceCandidate, SuggestedEvidence, ForumPost,

https://claude.ai/code/session_019SK6FNfEb7YW8EmqhUTs82