### PR TITLE
Add scoring engine documentation and algorithm pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ npx eslint <files>    # lint files you edited (`npm run lint` runs the whole rep
 npm test              # vitest, only when changing scoring / core logic
 ```
 
-The repo has ~50 pre-existing implicit-any errors in routes I didn't touch (notably `src/app/algorithms/belief-equivalency/*`, `src/app/equivalence/*`, several API routes, `src/lib/prisma.ts`'s missing generated client). They are not your fault — verify *only* that your edited files are clean, not that the global typecheck count is zero.
+The global typecheck is currently clean (0 errors) — keep it that way. If `@/generated/prisma/client` import errors appear, run `npm run db:generate` first; that is a missing-artifact problem, not a code problem.
 
 ## The Belief Page Is the Crown Jewel
 
@@ -84,4 +84,7 @@ Or set `CLAUDE_DEBUG_FILE` before launching. File logging cannot be enabled mid-
 - `/beliefs/[slug]` — the canonical belief page (this is the one that matters).
 - `/beliefs/set-aside-distractions-for-real-solutions` — bespoke route, predates the canonical structure. Don't use as a template.
 - `/product-reviews/[slug]` — separate concept that reuses some belief components. Edits to belief sections may affect it; check before refactoring.
-- `/algorithms/strong-to-weak`, `/Linkage Scores`, `/Argument scores from sub-argument scores` — explainer pages linked from the belief page header. If you add a link to a belief page, verify the target exists or use plain text (Rule 5).
+- `/algorithms` — index of every score explainer; subpages include `reason-rank`, `linkage-scores`, `importance-score`, `truth-scores`, `evidence-scores`, `unique-scores`, `assumptions`, `topic-overlap`, `objective-criteria`, `strong-to-weak`, `belief-equivalency`, `combine-similar-beliefs`. Belief-page components link these — if you add a link, verify the target exists or use plain text (Rule 5). Wiki-style space-URL routes (`/Linkage Scores` etc.) do NOT exist; never link them.
+- `/how-it-works` — the Engine of Reason explainer, with a live engine readout.
+- `/arguments/[id]/linkage` — an edge's linkage sub-debate; `/arguments/[id]/score` — the edge's impact-provenance page (factor-by-factor derivation).
+- `/contact` — contact/contribution pointers (target for all former Contact Me links).

--- a/docs/BELIEF_PAGE_RULES.md
+++ b/docs/BELIEF_PAGE_RULES.md
@@ -149,6 +149,16 @@ Score / Related) → "Beliefs this supports" line. No summary or background (Rul
    Disagree), each side with `Argument / Score / Link / Impact`. Each argument cell is
    the claim, the single most famous supporting quote inline (italic, small), then the
    submitter as `~Name`. Pro Total / Con Total row, then the **Net Belief Score** line.
+   The Net Belief Score is reported as a **share and margin** — the net divided by the
+   belief's own `Pro + Con` total — not as a bare numerator. A bare "+9.2" floats free;
+   "58% of the argument weight, a +15-point margin" is actionable. This is the *internal*
+   denominator (the belief vs. its own rebuttals). See `docs/THE_DENOMINATOR.md`.
+1b. **Contrast Class** *(only when the topic has a rival option set)* — the *external*
+   denominator made visible: the mutually exclusive rivals this belief is priced against,
+   each with its own argument-tree score `S` and an **opportunity-cost value**
+   `OCV = S(this) − max S(rivals)`. Exactly one option (the field winner) has `OCV > 0`.
+   Every option's score must trace to its own belief's tree — never a fabricated constant
+   (Rule 6). Comparative arguments ("rival Y beats X") belong here, not in the con column.
 2. **Evidence Ledger** — one two-sided table (Supporting / Weakening), each side with
    `Evidence / Type / Link / Impact`.
 3. **Conflict Resolution Framework**

--- a/docs/BELIEF_PAGE_RULES.md
+++ b/docs/BELIEF_PAGE_RULES.md
@@ -185,13 +185,19 @@ Score / Related) → "Beliefs this supports" line. No summary or background (Rul
 0. **Scorecard** — a readout of the scored content below, not a prose summary:
    `Net Belief Score (Pro vs. Con)` / `Bottom line` (one-sentence verdict scoped to
    what the tree supports) / `Strongest pro / con` (the top-ranked argument from each
-   side) / `What would move this score most` (the top falsifiability score-mover).
+   side) / `What would move this score most` (the top falsifiability score-mover),
+   plus a collapsed **twelve-dimension engine readout** (each dimension links to its
+   `/algorithms/*` explainer; null dimensions render blank per Rule 6).
    Followed by the "How to read this page" box explaining score-ranked tables.
 1. **Argument Trees** — one two-sided scored table (Reasons to Agree / Reasons to
    Disagree), each side with `Argument / Score / Link / Imp / Impact`. Each argument
    cell is the claim, the single most famous supporting quote inline (italic, small),
-   then the submitter as `~Name`. Pro Total / Con Total row, then the **Net Belief
-   Score** line.
+   then the submitter as `~Name`. **Every score cell is a doorway** (a blank cell is
+   never a link, per Rule 6): Score opens the child belief's own page, Link opens the
+   edge's linkage debate, Imp opens the importance sub-belief when one sources it,
+   and Impact opens the score-provenance page (`/arguments/[id]/score`) showing the
+   full sign × truth × |linkage| × importance × uniqueness derivation with a live
+   uniqueness trace. Pro Total / Con Total row, then the **Net Belief Score** line.
    The Net Belief Score is reported as a **share and margin** — the net divided by the
    belief's own `Pro + Con` total — not as a bare numerator. A bare "+9.2" floats free;
    "58% of the argument weight, a +15-point margin" is actionable. This is the *internal*
@@ -220,7 +226,13 @@ Score / Related) → "Beliefs this supports" line. No summary or background (Rul
    `Claim (links to its own page) / Category (Units) / Magnitude / Likelihood % /
    Expected Value`, ranked by Expected Value with subtotals only within a category;
    then **Short vs. Long-Term Impacts** (`Short-Term / Score / Long-Term / Score`)
-7. **Conflict Resolution Framework**
+7. **Conflict Resolution Framework** — opens with the **Pipeline readout**, computed
+   from the scored rows below (never hand-authored): interests both sides actually
+   share (cross-side similarity, both clearing the Resolution Floor), the primary
+   conflict pair (highest validity-weighted linkage-accuracy unshared interest per
+   side), genuine value conflicts (shared values ranked far apart), and compromise
+   candidates (cost/benefit items where a likelihood shift ≤ 15 points flips their
+   category's net — the winnable disagreements).
    - 7a. Shared Values, Different Rankings (`Value / Supporter Rank / Opponent Rank /
      Why Rankings Differ / Score`, then a "What would shift these rankings?" row)
    - 7b. Likely Interests of Supporters (`Interest / Prevalence / Linkage Confidence /
@@ -245,7 +257,13 @@ Score / Related) → "Beliefs this supports" line. No summary or background (Rul
 11. **Similar Beliefs** (`More Extreme / Score / More Moderate / Score`, scored by
     belief equivalency)
 12. **Definitions** (`Term / Definition / Score`) — LAST before footer
-13. **Contribute / footer**
+13. **Contribute / footer** — the two moves, stated and usable: an add-a-reason form
+    (the new reason becomes a belief page of its own; no score field is ever
+    submitted — the audit lock rejects them and the engine computes scores on
+    propagation), and the reminder that every score above is a clickable doorway.
+    On high-stakes beliefs the form and API walk the speed bumps: acknowledge the
+    strongest current opposing argument (verified server-side) and affirm the moral
+    principle the post rests on.
 
 ---
 

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -1,381 +1,101 @@
-# How the Idea Stock Exchange Organizes Beliefs
+# How the Idea Stock Exchange Works
 
-> **Transforming scattered arguments into structured knowledge**
+> The reader-facing version of this document is the live route **`/how-it-works`**
+> (`src/app/how-it-works/page.tsx`). This file is the developer map of the same
+> claims, each tied to the code that implements it.
 
-## The Problem
+## The one-sentence version
 
-Right now, human knowledge is disorganized chaos:
+One permanent, structured, evidence-ranked page per idea. Every argument is a
+belief page of its own, every edge between them carries scores, the engine
+computes every number recursively, and every score on a page is a doorway into
+the sub-debate that produced it.
 
-- The same debate happens on Twitter, Reddit, blogs, academic papers, and comment sections
-- Nobody knows which arguments have already been made
-- Evidence is scattered and never connected
-- Every generation rebuilds the same discussions from scratch
+## The engine
 
-**We don't need more information. We need better organization.**
-
-## The Solution: Seven Core Principles
-
-The ISE solves this through seven organizational principles that work together:
-
-### 1. 📚 Multi-Taxonomy Topic Classification
-
-**What it does:** Every belief gets classified into multiple topic systems simultaneously.
-
-**How it works:** When you create a belief like "Electric cars are good for the environment," the system automatically generates a **Topic Signature** (like DNA for ideas):
+The live conclusion-score core, per argument edge:
 
 ```
-Technology → Transportation → Electric Vehicles  (90% confidence)
-Environment → Climate → Emissions                (85% confidence)
-Economics → Energy Markets                       (70% confidence)
-Ethics → Intergenerational → Harm Reduction      (60% confidence)
+impact = sign x truth x |linkage| x importance x uniqueness x 100
 ```
 
-**Why it matters:** A single belief can live in multiple domains. This mirrors how humans actually think about complex topics.
-
-**Tech stack:**
-- 10 internal taxonomies (technology, environment, economics, politics, ethics, science, health, social, education, culture)
-- Integration with Dewey Decimal, Library of Congress, Wikipedia Categories, OpenAlex, MeSH, UNESCO, Google Knowledge Graph
-- Keyword-based classification with confidence scoring
-
-### 2. 🎯 Topic Pages as Control Panels
-
-**What it does:** Every topic gets a dedicated page that acts as the command center for all beliefs in that area.
-
-**Example: "Electric Cars" Topic Page**
-
-```
-📊 Statistics:
-- 47 total beliefs
-- 28 positive beliefs
-- 5 neutral beliefs
-- 14 negative beliefs
-- Average conclusion score: 62
-
-✅ Positive Beliefs (sorted by strength):
-   1. "Electric cars dramatically reduce lifetime emissions" (+85)
-   2. "Electric cars reduce air pollution in cities" (+68)
-   3. "Electric cars lower long-term operating costs" (+55)
-
-⚪ Neutral Beliefs:
-   1. "Electric cars require lithium-ion batteries" (0)
-   2. "Electric cars have higher upfront costs" (0)
-
-❌ Negative Beliefs (sorted by strength):
-   1. "Electric cars cause harmful mining impacts" (-55)
-   2. "Electric cars increase rare-earth mineral demand" (-38)
-   3. "Electric car batteries degrade over time" (-25)
-```
-
-**Why it matters:** Instead of hunting through endless threads, you see the entire landscape of a debate in one organized view.
-
-### 3. 📄 One Page Per Belief (Deduplication)
-
-**What it does:** Merges synonymous statements into a single belief page.
-
-**Example:**
-These five statements all express the same underlying belief:
-
-- "Trump is an idiot"
-- "Trump is stupid"
-- "Trump isn't very smart"
-- "Trump has low cognitive ability"
-- "Trump is the dumbest president ever"
-
-**How it detects duplicates:**
-
-The system calculates a **Same-Topic Score (0-100%)** using:
-
-| Factor | Weight | Description |
-|--------|--------|-------------|
-| Entity Match | 30% | Same person/thing? (Trump vs. Biden) |
-| Attribute Match | 25% | Same quality? (intelligence vs. ethics) |
-| Sentiment Match | 20% | Same direction? (positive vs. negative) |
-| Strength Match | 15% | Similar intensity? |
-| Synonym Match | 10% | Linguistic equivalence |
-
-**Result:** All arguments, evidence, and discussion happen on ONE page instead of being scattered across thousands of duplicate threads.
-
-### 4. 💪 Strength Scoring (Claim Intensity)
-
-**What it does:** Measures how bold a claim is (0-100), independent of whether it's true.
-
-**Examples:**
-
-| Statement | Strength | Why |
-|-----------|----------|-----|
-| "Trump is not very smart" | 20 | Hedged with "not very" |
-| "Trump is dumb" | 40 | Direct claim, no modifiers |
-| "Trump is extremely stupid" | 75 | Intensifier "extremely" |
-| "Trump is the dumbest president ever" | 100 | Superlative + absolute |
-
-**How it's calculated:**
-
-- **Intensifiers:** +10 each (very, extremely, incredibly)
-- **Hedges:** -10 each (somewhat, maybe, possibly)
-- **Superlatives:** +20 each (best, worst, greatest)
-- **Absolutes:** +15 each (always, never, all, none)
-
-**Why it matters:** Distinguishes careful, qualified claims from bold, categorical assertions. Helps readers understand how confident a claim is, not just what it claims.
-
-### 5. 😊😐😠 Positivity/Negativity Scoring
-
-**What it does:** Measures sentiment toward the subject (-100 to +100).
-
-**Examples:**
-
-```
-+85: "Lincoln was a visionary leader who saved the union"
-  0: "Lincoln was the 16th president of the United States"
--85: "Lincoln violated constitutional rights during the war"
-
-+70: "Nuclear energy is clean and reliable"
-  0: "Nuclear energy uses uranium as fuel"
--70: "Nuclear energy creates dangerous radioactive waste"
-```
-
-**Why it matters:** Topic pages can organize beliefs from positive → neutral → negative, giving you a balanced view of all perspectives.
-
-### 6. 🔗 Comprehensive Linkage
-
-**What it does:** Connects every belief to everything related.
-
-**What gets linked:**
-
-| Link Type | Status | Description |
-|-----------|--------|-------------|
-| Arguments | ✅ Implemented | Pro/con reasoning with sub-arguments |
-| Evidence | ✅ Implemented | Studies, data, citations (tiered by quality) |
-| Similar Beliefs | ✅ Implemented | Semantically related beliefs |
-| Laws | ✅ Implemented | Relevant legislation |
-| Assumptions | ✅ Implemented | Required premises |
-| People | 🔄 Planned | Stakeholders and their positions |
-| Books & Media | 🔄 Planned | Supporting/opposing media |
-| Values | 🔄 Planned | Values of supporters vs. opponents |
-| Interests | 🔄 Planned | Who benefits and who loses |
-| Cost-Benefit | 🔄 Planned | Quantified impacts |
-| Solutions | ✅ Implemented | Compromise proposals |
-| Biases | 🔄 Planned | Cognitive biases affecting reasoning |
-
-**Evidence Quality Tiers:**
-
-- ⭐⭐⭐⭐⭐ Tier 1: Peer-reviewed meta-analyses, RCTs, official data
-- ⭐⭐⭐⭐ Tier 2: Expert analysis, institutional reports
-- ⭐⭐⭐ Tier 3: Investigative journalism, surveys
-- ⭐⭐ Tier 4: Opinion pieces, anecdotal evidence
-
-**Why it matters:** Everything connects to everything. No more hunting through Google to find that perfect study you remember reading.
-
-### 7. 🔄 Automatic Updates
-
-**What it does:** Conclusion scores update automatically as new evidence and arguments are added.
-
-**How it works:**
-
-```
-Initial state:
-"Electric cars are good for the environment"
-- 3 supporting arguments (avg score: 60)
-- 1 opposing argument (score: 40)
-→ Conclusion Score: 55
-
-New evidence added:
-- Meta-analysis: "EVs reduce lifetime emissions by 68%"
-- Supporting argument strength increases to 75
-→ Conclusion Score: 62 (auto-updated)
-
-Counter-evidence added:
-- Study: "Lithium mining causes significant habitat destruction"
-- New opposing argument (score: 65)
-→ Conclusion Score: 58 (auto-updated)
-```
-
-**Algorithm:** Uses ReasonRank (PageRank for arguments) to weight arguments by their quality, evidence, and resistance to counterarguments.
-
-**Why it matters:** Beliefs evolve with evidence. Truth is dynamic, not static.
-
-## How It All Works Together
-
-### User Journey Example
-
-**1. User creates a belief:**
-```
-Input: "Nuclear energy is the best solution to climate change"
-```
-
-**2. System processes automatically:**
-
-✅ **Duplicate check:** No similar beliefs found (creates new page)
-
-✅ **Dimensional scoring:**
-- Specificity: 65 (mentions specific solution)
-- Sentiment: +70 (positive - "best solution")
-- Strength: 85 (superlative - "best")
-
-✅ **Topic classification:**
-- Environment → Climate → Solutions (confidence: 0.9)
-- Technology → Energy → Nuclear (confidence: 0.85)
-- Economics → Energy Markets (confidence: 0.7)
-
-✅ **Topic assignment:** Assigned to "Climate Solutions" topic
-
-**3. Topic page updates:**
-
-The "Climate Solutions" topic page now shows:
-- Statistics: 49 beliefs (was 48)
-- Positive beliefs: 29 (was 28)
-- This belief appears sorted by strength score
-
-**4. User adds arguments:**
-
-Supporting: "Nuclear has zero carbon emissions during operation"
-Opposing: "Nuclear creates radioactive waste lasting thousands of years"
-
-**5. Conclusion score updates:**
-
-Based on argument quality, evidence, and ReasonRank algorithm.
-
-**6. Users discover through multiple paths:**
-
-- Browse "Climate Solutions" topic page
-- Search "nuclear energy"
-- Navigate from "Renewable Energy" → "Energy Alternatives" → "Nuclear"
-- Follow topic signature links
-
-## The Result
-
-**Before ISE:**
-- "Nuclear energy climate change" → 10 million scattered results
-- Duplicate debates on Reddit, Twitter, blogs, forums
-- Arguments never connected to evidence
-- Same points made over and over
-- No way to know current state of debate
-
-**After ISE:**
-- ONE page: "Nuclear energy is the best solution to climate change"
-- All arguments organized and ranked
-- All evidence linked and tiered
-- All perspectives visible (positive, neutral, negative)
-- Clear conclusion score based on evidence
-- Automatic updates as new information emerges
-
-## Why This Matters
-
-### For Individuals
-- Stop wasting time re-reading the same arguments
-- See the full picture before forming opinions
-- Build on existing knowledge instead of starting from scratch
-- Track how debates evolve over time
-
-### For Society
-- End circular debates that go nowhere
-- Proportion beliefs to evidence strength
-- Identify areas of genuine disagreement vs. semantic confusion
-- Make collective reasoning cumulative, not repetitive
-
-### For Truth
-- Evidence-based consensus becomes visible
-- Bad arguments can't hide in obscurity
-- Good arguments rise to the top
-- Knowledge evolves as evidence changes
-
-## Technical Implementation
-
-### Current Status
-
-✅ **Fully Implemented:**
-- Belief model with dimensional scoring
-- Topic model with statistics
-- Semantic clustering for duplicate detection
-- Conclusion score calculation (ReasonRank)
-- Fallacy detection (10 types)
-- Evidence verification system
-- Strength scoring service
-- Taxonomy classification service
-- Topic page organization
-
-🔄 **In Progress:**
-- Enhanced frontend visualizations
-- API endpoints for organized topic pages
-- Batch classification tools
-
-📋 **Planned:**
-- AI-powered classification improvements
-- Real-time WebSocket updates
-- Advanced visualization (3D belief space)
-- Media integration
-- CBO (Chief Belief Officer) system
-
-### Tech Stack
-
-**Backend:**
-- Node.js + Express
-- MongoDB + Mongoose
-- Custom algorithms (ReasonRank, Semantic Clustering)
-- Services: TaxonomyService, StrengthScoringService
-
-**Frontend:**
-- React 18 + Vite
-- Tailwind CSS
-- React Router
-
-**Algorithms:**
-- ReasonRank (PageRank for arguments)
-- Semantic similarity (Jaccard, Cosine, Levenshtein)
-- Strength scoring (linguistic pattern detection)
-- Multi-taxonomy classification (keyword-based)
-
-## Get Involved
-
-**For Users:**
-- Create beliefs and add arguments
-- Submit evidence with citations
-- Help organize topics
-- Verify evidence quality
-
-**For Developers:**
-- Contribute to open-source codebase
-- Improve scoring algorithms
-- Build taxonomy integrations
-- Develop visualizations
-
-**For Researchers:**
-- Use the API for analysis
-- Study belief evolution
-- Test argumentation theories
-- Improve classification systems
-
-## Conclusion
-
-The ISE doesn't invent new information. It organizes what already exists.
-
-By implementing these seven principles, we transform scattered arguments into a structured, navigable knowledge base where:
-
-1. **Every belief has one home** (no duplicates)
-2. **Every topic has one control panel** (organized display)
-3. **Every claim has clear intensity** (strength scoring)
-4. **Every perspective is visible** (positive/neutral/negative)
-5. **Every argument is connected** (comprehensive linkage)
-6. **Every conclusion updates automatically** (living knowledge)
-7. **Every classification is multi-dimensional** (topic signatures)
-
-**This is how we stop repeating the same debates forever.**
-
-**This is how thinking becomes cumulative instead of exhausting.**
-
-**This is how we build collective intelligence.**
-
----
-
-**Start exploring:** [ideastockexchange.org](https://ideastockexchange.org) *(coming soon)*
-
-**Read the docs:**
-- [BELIEF_ORGANIZATION_SYSTEM.md](./BELIEF_ORGANIZATION_SYSTEM.md) - Full specification
-- [INTEGRATION_GUIDE.md](./INTEGRATION_GUIDE.md) - Developer guide
-- [ARCHITECTURE.md](./ARCHITECTURE.md) - System architecture
-- [ONE_PAGE_PER_BELIEF.md](./ONE_PAGE_PER_BELIEF.md) - Deduplication framework
-
-**Contribute:** [github.com/myklob/ideastockexchange](https://github.com/myklob/ideastockexchange)
-
----
-
-*Last updated: 2025-01-28*
+- **Implementation:** `computeArgumentImpactScore` in
+  `src/core/scoring/scoring-engine.ts`; recursive propagation in
+  `src/lib/propagate-belief-scores.ts` (`propagateBeliefScores`,
+  `propagateAllBeliefScores`, `propagateFromLinkageChange`).
+- **truth** — the child belief's own tree score, computed from *its* arguments
+  and evidence (`computeBeliefScores` in
+  `src/features/belief-analysis/data/fetch-belief.ts`). Recursion with no
+  hardcoded floor: `Argument` joins two `Belief` rows (`prisma/schema.prisma`).
+- **linkage** — computed from the edge's own linkage sub-debate
+  (`calculateLinkageFromArguments`); every linkage value links to
+  `/arguments/[id]/linkage`.
+- **importance** — optionally sourced from a dedicated importance sub-belief
+  (`Argument.importanceBeliefId` → `deriveImportanceFromBeliefScore`), so
+  "does this matter?" is itself debatable.
+- **uniqueness** — computed at scoring time from each argument's similarity to
+  earlier same-side siblings (`siblingUniquenessFor` +
+  `src/core/scoring/duplication-scoring.ts`); restatements never double-count.
+- **Propagation triggers:** linkage posts, agent ingestion
+  (`/api/v1/ingest`), evidence acceptance, human argument posts
+  (`/api/beliefs/[id]/arguments`), manual `/api/beliefs/[id]/propagate` and
+  `/api/scoring/propagate-all`, plus the seed chain's final engine pass
+  (`prisma/seed-propagate.ts`).
+
+## Click-into-the-score
+
+Every score cell on the belief page is a doorway (Rule 6 keeps blank cells
+unlinked):
+
+| Cell | Opens |
+|---|---|
+| Score | the child belief's own page (the sub-debate that produced it) |
+| Link | `/arguments/[id]/linkage` — the edge's linkage debate |
+| Imp | the importance sub-belief, when one sources it |
+| Impact | `/arguments/[id]/score` — the factor-by-factor provenance page with a live uniqueness trace |
+
+The Scorecard carries the twelve-dimension engine readout
+(`BeliefScores` in `src/features/belief-analysis/types.ts`), each dimension
+linking to its `/algorithms/*` explainer.
+
+## The denominator
+
+A bare net is a numerator. `src/core/scoring/contrast-class.ts` supplies the
+two denominators: the justification share/margin (internal) and the
+opportunity-cost value against the best rival in the contrast class
+(external), rendered as the Contrast Class section. Spec:
+`docs/THE_DENOMINATOR.md`.
+
+## Conflict resolution pipeline
+
+`src/core/scoring/conflict-resolution.ts` reads the scored trees sideways and
+computes four outputs (rendered as the Pipeline readout in the Conflict
+Resolution section; adapter in
+`src/features/belief-analysis/lib/conflict-pipeline.ts`):
+
+1. **Shared interests** — cross-side similarity over interest statements, both
+   sides clearing the Resolution Floor (70).
+2. **Primary conflict pair** — the highest validity-weighted linkage-accuracy
+   unshared interest per side.
+3. **Genuine value conflicts** — shared values the two sides rank far apart.
+4. **Compromise candidates** — cost/benefit items where a likelihood shift
+   ≤ 0.15 flips their category's net: the winnable disagreements.
+
+CBA row likelihoods derive from each claim's own belief tree when linked
+(`deriveCbaItems`) — never assigned by gut.
+
+## Posting and speed bumps
+
+`POST /api/beliefs/[id]/arguments` is the human add-a-row move: the reason
+becomes a belief page, the edge is created unscored (the audit lock rejects
+submitted score fields), and the engine propagates. On beliefs flagged
+`highStakes`, the API enforces the speed bumps: acknowledge the strongest
+current opposing argument (verified server-side) and affirm the moral
+principle the post rests on. The form lives in the belief page's Contribute
+section (`AddArgumentForm.tsx`).
+
+## The canonical trio
+
+`docs/BELIEF_PAGE_RULES.md` (rules) ↔ `templates/belief-analysis-template.html`
+(template) ↔ `src/app/beliefs/[slug]/page.tsx` + section components (code).
+Change one, update the other two.

--- a/docs/THE_DENOMINATOR.md
+++ b/docs/THE_DENOMINATOR.md
@@ -1,0 +1,103 @@
+# The Denominator: Scoring a Belief Against Its Counterclaims
+
+*Framework spec for the ISE scoring engine. A pro-minus-con score floats free
+until you divide it by something, and the right something is the rival claim.*
+
+This document is the canonical reference for the contrast-class / opportunity-cost
+layer. It is referenced by:
+
+- `src/core/scoring/contrast-class.ts` — the engine (pure math, two layers)
+- `src/features/belief-analysis/components/ContrastClassSection.tsx` — the page block
+- `src/features/belief-analysis/components/ArgumentTreesSection.tsx` — the share/margin readout
+- `src/features/belief-analysis/data/contrast-classes.ts` — the static option-set overlay
+- `templates/belief-analysis-template.html` and `docs/BELIEF_PAGE_RULES.md`
+
+Keep this doc, the rules doc, the template, and the page in sync.
+
+---
+
+## 1. The bug
+
+A bare **Net Belief Score** of `Pro Total − Con Total` is a numerator with nothing
+under the line. "+9.2 relative to what?" A pro-minus-con silently picks "do nothing"
+as the denominator and never tells you. The real rival is often already sitting in
+the con column disguised as a single argument. The fix is to stop hiding the
+denominator and make it a structural part of the page.
+
+## 2. Core principle
+
+Value is never absolute. It is always *against the next thing you could have chosen* —
+the economist's **opportunity cost**. The unit of scoring is the belief plus its
+**contrast class**: the set of mutually exclusive claims that answer the same question
+and compete for the same budget. On ISE this is the spectrum of positions on the Topic
+page. One constraint makes it rigorous: **you can only divide commensurable things.**
+Only rival answers to one question share a denominator.
+
+## 3. Two layers (they stack, they do not compete)
+
+- **Layer 1 — Justification (internal denominator).** `J(X) = (Pro − Con) / (Pro + Con)`,
+  range −1..+1. How lopsided the belief is versus its own rebuttals. Doubles as the
+  Rule 9 inversion trigger (negative ⇒ net-refuted). Identity: `J = 2p − 1` where
+  `p = Pro / (Pro + Con)` is the implied-probability / market-share view.
+  - *Cautions:* it washes out evidence volume (`[9,1]` and `[90,10]` both score +0.8 —
+    report mass alongside, never folded in) and it is paddable (discount duplicates).
+- **Layer 2 — Comparative / opportunity cost (external denominator).**
+  `OCV(oi) = S(oi) − max_{j≠i} S(oj)`. Does the belief beat its best rival? Exactly one
+  option has `OCV > 0`. Magnitude is what you give up by not choosing the best rival.
+
+Layer 1 produces the quantity Layer 2 compares: Layer 1 runs inside each node, Layer 2
+across the siblings.
+
+### Criteria-normalized denominator
+Score every option on the same objective criteria, min-max normalize each criterion
+across the rivals (`n(oi,k) = (r − min)/(max − min)`), then weight by per-criterion
+**importance** (which lives on the *topic*, the right home for the otherwise-blank
+Importance column): `W(oi) = Σ_k importance_k · n(oi,k)`. Use `W` to *decompose* a
+margin, not as a second headline.
+
+### Argument sorting (the dedup that cleans Layer 1)
+Sort every argument before scoring: **intrinsic** ("X is true on its own terms") feeds
+Layer 1; **comparative** ("rival Y beats X") is pulled out of the pro/con tally and
+moved to Layer 2. Left in the con column a comparative argument double-counts the rival.
+
+## 4. Signed-score edge case
+
+ReasonRank scores can go negative. A share `S / ΣS` is only meaningful for non-negative
+inputs. **Preferred:** drop the share for signed quantities and report `OCV` (well-defined
+for any reals). **If a 0–1 field view is wanted:** rank-shift `S'(o) = S(o) − min + ε`
+first and state the shift so nobody mistakes it for a probability. Rule 9 (invert
+negative beliefs to positive form) reinforces this — a class of positive claims mostly
+avoids the signed-score problem at the top level.
+
+## 5. Engine spec
+
+For a topic with mutually exclusive options `O = {o1 … on}`:
+
+1. Each `oi` carries an argument-tree score `S(oi)` from existing ReasonRank machinery.
+   No new scoring primitive — the denominator is built from scores the engine produces.
+2. Pairwise margin `M(oi, oj) = S(oi) − S(oj)`.
+3. Opportunity-cost value `OCV(oi) = S(oi) − max_{j≠i} S(oj)` — the headline comparative score.
+4. Criteria matrix `n(oi,k)` (min-max) and `W(oi) = Σ importance_k · n(oi,k)` for decomposition.
+5. Field share (optional) `Price(oi) = S(oi) / Σ S(oj)` **only** when all `S ≥ 0`; otherwise
+   report `OCV`, never a faked probability.
+
+## 6. Invariant contract
+
+All seven engine invariants hold: the 0–1 ranges are affine rescalings of real rival
+scores (no tanh/clamp by fiat); `OCV`/`Price` are **outputs** that must never feed back
+into any argument's `S` (one-way valve); every term under the line is itself a fully
+scored, audited node, so traceability holds end to end.
+
+## 7. What changes on a belief page
+
+1. Add a **Contrast Class** block: the mutually exclusive option set, each rival's `S`, and OCV.
+2. Promote comparative "rival is better" arguments out of the con table into the Contrast Class.
+3. Relabel the headline: bare net → share + margin (Layer 1) and `OCV` vs. the named best rival (Layer 2).
+4. Fill the **Importance** column from the topic's per-criterion weights.
+5. Print the denominator beside every verdict: "harm > good" never stands alone; it carries its "compared to ___".
+
+---
+
+*Bottom line: pro-minus-con answered "do the reasons to agree win on this island,"
+when the real question is "does this island beat the next island over." Put the rival
+under the line.*

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
-    "db:seed": "npx tsx prisma/seed-beliefs.ts && npx tsx prisma/seed-belief-distractions.ts && npx tsx prisma/seed-debate-topics.ts && npx tsx prisma/seed-product-reviews.ts && npx tsx prisma/seed-linkage-example.ts && npx tsx prisma/seed-interests-example.ts && npx tsx prisma/seed-product-review-extras.ts && npx tsx prisma/seed-markets.ts",
+    "db:seed": "npx tsx prisma/seed-beliefs.ts && npx tsx prisma/seed-belief-distractions.ts && npx tsx prisma/seed-debate-topics.ts && npx tsx prisma/seed-product-reviews.ts && npx tsx prisma/seed-linkage-example.ts && npx tsx prisma/seed-interests-example.ts && npx tsx prisma/seed-product-review-extras.ts && npx tsx prisma/seed-markets.ts && npx tsx prisma/seed-propagate.ts",
     "db:seed-reviews": "npx tsx prisma/seed-product-reviews.ts",
     "db:seed-markets": "npx tsx prisma/seed-markets.ts",
     "epoch:run": "npx tsx scripts/run-epoch.ts",

--- a/prisma/migrations/20260706000000_add_uniqueness_and_high_stakes/migration.sql
+++ b/prisma/migrations/20260706000000_add_uniqueness_and_high_stakes/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: the uniqueness discount, applied at scoring time (Rule 6: null until computed).
+ALTER TABLE "Argument" ADD COLUMN "uniquenessScore" REAL;
+
+-- AlterTable: high-stakes beliefs route posting through the speed-bump flow.
+ALTER TABLE "Belief" ADD COLUMN "highStakes" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -299,6 +299,11 @@ model Belief {
   reviewFlag     Boolean @default(false)
   reviewFlagNote String?
 
+  /// High-stakes flag: posting to this belief goes through the speed-bump flow
+  /// (acknowledge the strongest opposing point + moral-principle consistency
+  /// check) before the API accepts the submission. Editorial, set per topic.
+  highStakes Boolean @default(false)
+
   suggestedEvidence SuggestedEvidence[]
   forumPosts        ForumPost[]
 
@@ -356,7 +361,15 @@ model Argument {
   quoteAuthorUrl String?
   /// The argument's own displayed score (the "Score" column), distinct from the
   /// computed Impact. Null renders blank until real sub-argument scoring exists (Rule 6).
+  /// Populated by score propagation as the child belief's own tree score (0-100).
   argumentScore  Float?
+
+  /// Uniqueness factor (0-1): how much new signal this argument adds versus its
+  /// earlier same-side siblings (1 − max mechanical similarity, oldest keeps
+  /// credit). Null until the engine computes it at scoring time (Rule 6) — the
+  /// uniqueness discount promised by the redundancy scan. Multiplies into
+  /// impactScore so restatements never double-count.
+  uniquenessScore Float?
 
   /// Importance Score (0-1): how much this argument moves the probability needle.
   /// 1.0 = decisive, 0.5 = moderate, 0.1 = minor. Weights the argument's contribution

--- a/prisma/seed-beliefs.ts
+++ b/prisma/seed-beliefs.ts
@@ -6,7 +6,7 @@ async function main() {
   // Create main belief
   const mainBelief = await prisma.belief.upsert({
     where: { slug: 'universal-basic-income-should-be-implemented' },
-    update: {},
+    update: { highStakes: true },
     create: {
       slug: 'universal-basic-income-should-be-implemented',
       statement: 'Universal Basic Income should be implemented in developed nations',
@@ -16,6 +16,8 @@ async function main() {
       positivity: 25,
       specificity: 0.55,
       claimStrength: 0.6,
+      // Posting here goes through the speed-bump flow (steelman + principle).
+      highStakes: true,
     },
   })
 

--- a/prisma/seed-beliefs.ts
+++ b/prisma/seed-beliefs.ts
@@ -221,11 +221,16 @@ async function main() {
   })
 
   // Create arguments (reasons linking beliefs to the main belief).
-  // Wipe this seed's edges first so re-running never double-counts a side
+  // Skip when edges already exist so re-running never double-counts a side
   // (duplicated rows would silently inflate every net and OCV verdict).
-  await prisma.argument.deleteMany({
+  // A delete-first guard would trip the FK constraints of linkage sub-debate
+  // rows seeded later in the chain.
+  const existingEdges = await prisma.argument.count({
     where: { parentBeliefId: { in: [mainBelief.id, moderateBelief.id, extremeBelief.id] } },
   })
+  if (existingEdges > 0) {
+    console.log('Argument edges already seeded; skipping edge creation.')
+  } else {
   await prisma.argument.createMany({
     data: [
       {
@@ -300,6 +305,7 @@ async function main() {
       { parentBeliefId: extremeBelief.id, beliefId: workIncentiveBelief.id, side: 'disagree', linkageScore: 0.65, impactScore: 18.0, linkageType: 'STRONG_CAUSAL' },
     ],
   })
+  }
 
   // Create evidence
   await prisma.evidence.createMany({
@@ -448,6 +454,23 @@ async function main() {
       costs: '1. Problems created: Massive fiscal cost ($2-4T annually in US), potential inflation\n2. Who loses: High earners via taxation, existing welfare administrators\n3. Negative externalities: Possible reduction in labor supply, dependency concerns',
       costLikelihood: 0.7,
     },
+  })
+
+  // Row-based cost/benefit items feeding the conflict-resolution pipeline.
+  // Categories keep unlike units apart; the dollars category is deliberately
+  // close (net +$20B) so the compromise-candidate detector has a real, small,
+  // achievable likelihood shift to surface, while hours is deliberately far
+  // apart (a symbolic disagreement no small shift can flip).
+  await prisma.costBenefitItem.deleteMany({ where: { beliefId: mainBelief.id } })
+  await prisma.costBenefitItem.createMany({
+    data: [
+      { beliefId: mainBelief.id, side: 'benefit', claim: 'Cuts welfare administration overhead', category: 'dollars ($B/yr)', magnitude: 150, likelihood: 0.8, expectedValue: 120 },
+      { beliefId: mainBelief.id, side: 'benefit', claim: 'Consumption boost to local economies', category: 'dollars ($B/yr)', magnitude: 300, likelihood: 0.6, expectedValue: 180 },
+      { beliefId: mainBelief.id, side: 'cost', claim: 'Net fiscal outlay after replaced programs', category: 'dollars ($B/yr)', magnitude: 400, likelihood: 0.7, expectedValue: 280 },
+      { beliefId: mainBelief.id, side: 'benefit', claim: 'Time returned to caregivers and students', category: 'hours (B/yr)', magnitude: 120, likelihood: 0.75, expectedValue: 90 },
+      { beliefId: mainBelief.id, side: 'cost', claim: 'Reduced labor-force participation hours', category: 'hours (B/yr)', magnitude: 500, likelihood: 0.4, expectedValue: 200 },
+      { beliefId: mainBelief.id, side: 'benefit', claim: 'Ends means-test surveillance and paperwork', category: 'freedom (index)', magnitude: 80, likelihood: 0.7, expectedValue: 56, claimBeliefId: bureaucracyBelief.id },
+    ],
   })
 
   // Create impact analysis
@@ -629,6 +652,11 @@ async function main() {
     ],
   })
 
+  // Clear dependent satisfaction rows first (seeded later in the chain by
+  // seed-interests-example.ts) so re-running the chain never FK-fails here.
+  await prisma.interestSatisfaction.deleteMany({
+    where: { interest: { beliefId: mainBelief.id } },
+  })
   await prisma.interestEntry.deleteMany({ where: { beliefId: mainBelief.id } })
   await prisma.interestEntry.createMany({
     data: [

--- a/prisma/seed-beliefs.ts
+++ b/prisma/seed-beliefs.ts
@@ -274,6 +274,28 @@ async function main() {
     ],
   })
 
+  // Argument trees for the RIVAL options in the income-floor contrast class.
+  // The denominator framework (docs/THE_DENOMINATOR.md) prices UBI against its
+  // rivals, so each rival needs its own scored tree for OCV to be real and
+  // traceable rather than a fabricated constant. Negative income tax reuses the
+  // shared pro-beliefs (poverty reduction, lower bureaucracy) and is weakened by
+  // the same fiscal worry; automated luxury communism shares the automation
+  // premise but is dragged down by the fiscal-sustainability and work-incentive cons.
+  await prisma.argument.createMany({
+    data: [
+      // Negative income tax (moderateBelief) — a strong, well-supported rival.
+      { parentBeliefId: moderateBelief.id, beliefId: povertyBelief.id, side: 'agree', linkageScore: 0.8, impactScore: 21.0, linkageType: 'STRONG_CAUSAL' },
+      { parentBeliefId: moderateBelief.id, beliefId: bureaucracyBelief.id, side: 'agree', linkageScore: 0.6, impactScore: 14.0, linkageType: 'CONTEXTUAL' },
+      { parentBeliefId: moderateBelief.id, beliefId: marketFreedomBelief.id, side: 'agree', linkageScore: 0.55, impactScore: 11.0, linkageType: 'CONTEXTUAL' },
+      { parentBeliefId: moderateBelief.id, beliefId: fiscalBelief.id, side: 'disagree', linkageScore: 0.5, impactScore: 9.0, linkageType: 'STRONG_CAUSAL' },
+      // Fully automated luxury communism (extremeBelief) — a weak rival: shares
+      // the automation premise but loses badly on fiscal and work-incentive cons.
+      { parentBeliefId: extremeBelief.id, beliefId: automationBelief.id, side: 'agree', linkageScore: 0.7, impactScore: 16.0, linkageType: 'STRONG_CAUSAL' },
+      { parentBeliefId: extremeBelief.id, beliefId: fiscalBelief.id, side: 'disagree', linkageScore: 0.8, impactScore: 24.0, linkageType: 'STRONG_CAUSAL' },
+      { parentBeliefId: extremeBelief.id, beliefId: workIncentiveBelief.id, side: 'disagree', linkageScore: 0.65, impactScore: 18.0, linkageType: 'STRONG_CAUSAL' },
+    ],
+  })
+
   // Create evidence
   await prisma.evidence.createMany({
     data: [

--- a/prisma/seed-interests-example.ts
+++ b/prisma/seed-interests-example.ts
@@ -53,6 +53,16 @@ async function main() {
       'Stated often, but the same voters back universal programs like Social Security — words and votes diverge.'),
   ])
 
+  // A genuinely shared interest, stated by each side in its own words. The
+  // conflict-resolution pipeline pairs these by cross-side similarity — both
+  // clear the Resolution Floor, so compromise gets built on them.
+  await Promise.all([
+    mk('supporter', 'Ending extreme poverty and homelessness', 35, 56, 90,
+      'Supporters fund anti-poverty pilots even in designs with no universal payment.'),
+    mk('opponent', 'Ending extreme poverty and homelessness', 30, 50, 82,
+      'Opponents back targeted anti-poverty spending at similar rates; the fight is the mechanism, not the goal.'),
+  ])
+
   await prisma.unstatedInterestCandidate.createMany({
     data: [
       {

--- a/prisma/seed-propagate.ts
+++ b/prisma/seed-propagate.ts
@@ -1,0 +1,29 @@
+/**
+ * Final step of the seed chain: run the scoring engine over the whole graph.
+ *
+ * The seed files hand-set linkage/impact placeholders so the pages render
+ * something before the engine runs. This pass replaces every placeholder with
+ * engine-computed output — impact = sign × truth × |linkage| × importance ×
+ * uniqueness × 100, argumentScore = the child's own tree score — so a fresh
+ * dev database starts with live scores, not bracketed illustrations.
+ */
+import { propagateAllBeliefScores } from '../src/lib/propagate-belief-scores'
+import { prisma } from '../src/lib/prisma'
+
+async function main() {
+  const result = await propagateAllBeliefScores()
+  console.log(
+    `Engine pass complete: ${result.updatedArguments} argument edges and ` +
+      `${result.updatedBeliefs} beliefs recomputed from ${result.startedFrom} leaves ` +
+      `(max depth ${result.maxDepth}).`,
+  )
+}
+
+main()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/src/app/algorithms/assumptions/page.tsx
+++ b/src/app/algorithms/assumptions/page.tsx
@@ -1,0 +1,81 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Hidden Assumptions — Idea Stock Exchange',
+  description:
+    'Every argument-to-conclusion linkage smuggles unstated premises. ISE surfaces them, scores them, and lets you challenge them.',
+}
+
+const container = 'max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]'
+
+function Breadcrumb() {
+  return (
+    <p className="text-right text-sm italic text-gray-600 mb-6">
+      <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+      {' > '}
+      <Link href="/algorithms" className="text-blue-700 hover:underline">Algorithms</Link>
+      {' > '}
+      <strong>Hidden Assumptions</strong>
+    </p>
+  )
+}
+
+export default function AssumptionsPage() {
+  return (
+    <div className={container}>
+      <Breadcrumb />
+      <h1 className="text-3xl font-bold mb-3">Hidden Assumptions</h1>
+      <p className="text-lg text-gray-600 mb-6">
+        &ldquo;X, therefore Y&rdquo; is never just X and Y. The step between them rests on
+        premises nobody typed — and those premises are where arguments actually fail.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Where assumptions hide</h2>
+      <p className="mb-4">
+        Every{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">
+          linkage
+        </Link>{' '}
+        between an argument and its conclusion has a mechanism — the sentence explaining
+        <em> how</em> X being true supports Y. Write the mechanism down and its unstated premises
+        become visible: &ldquo;automation displaces workers, therefore we need UBI&rdquo;
+        assumes displacement outpaces re-employment, that no cheaper remedy exists, and that
+        cash is the binding constraint. Each of those can be false while X stays true.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">How ISE surfaces them</h2>
+      <ul className="list-disc ml-6 mb-4 space-y-1">
+        <li>
+          <strong>Assumptions by side</strong> on every belief page: what you must accept for the
+          belief to hold, and what you must accept to reject it — symmetrically, with scores.
+        </li>
+        <li>
+          <strong>Per-linkage hidden-assumption lists</strong> on each argument&apos;s linkage
+          page: the premises that specific X-supports-Y step depends on.
+        </li>
+        <li>
+          <strong>Component claims</strong> in the Logical Anatomy section: the belief&apos;s
+          AND/OR structure, with each component marked stated or unstated and
+          survives-if-false or not.
+        </li>
+      </ul>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Assumptions are claims — the recursion applies</h2>
+      <p className="mb-4">
+        A surfaced assumption is a standalone claim with a truth value, which means it can get
+        its own belief page, its own pro/con tree, and its own score. Challenge one by arguing
+        it where it lives: when the assumption&apos;s score falls, the linkage that depended on
+        it weakens, and propagation moves every conclusion downstream. When the assumption chain
+        breaks entirely, the linkage is a non-sequitur and scores near zero no matter how true
+        the argument is.
+      </p>
+
+      <p className="mt-8 text-sm text-gray-600">
+        Related: <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">Linkage Scores</Link> ·{' '}
+        <Link href="/algorithms/truth-scores" className="text-blue-700 hover:underline">Truth Scores</Link> ·{' '}
+        <Link href="/algorithms/reason-rank" className="text-blue-700 hover:underline">ReasonRank</Link>
+      </p>
+    </div>
+  )
+}

--- a/src/app/algorithms/evidence-scores/page.tsx
+++ b/src/app/algorithms/evidence-scores/page.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Evidence Scores — Idea Stock Exchange',
+  description:
+    'How the Evidence Verification Score (EVS) weighs source tier, replication, and relevance — and why evidence is not an argument.',
+}
+
+const container = 'max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]'
+
+function Breadcrumb() {
+  return (
+    <p className="text-right text-sm italic text-gray-600 mb-6">
+      <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+      {' > '}
+      <Link href="/algorithms" className="text-blue-700 hover:underline">Algorithms</Link>
+      {' > '}
+      <strong>Evidence Scores</strong>
+    </p>
+  )
+}
+
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+
+export default function EvidenceScoresPage() {
+  return (
+    <div className={container}>
+      <Breadcrumb />
+      <h1 className="text-3xl font-bold mb-3">Evidence Scores (EVS)</h1>
+      <p className="text-lg text-gray-600 mb-6">
+        Evidence is data that can fail empirically. A reason that can only fail logically is an
+        argument and belongs in the tree — evidence anchors the tree to the world.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">The inputs</h2>
+      <div className="overflow-x-auto mb-4">
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr>
+              <th className={TH}>Input</th>
+              <th className={TH}>What it measures</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className={TD}>Source tier weight</td>
+              <td className={TD}>
+                T1 peer-reviewed/official &gt; T2 expert/institutional &gt; T3 journalism/surveys
+                &gt; T4 opinion/anecdote. A submitter&apos;s tier is a <em>claim</em>, recorded as
+                such until verified — the two are displayed separately.
+              </td>
+            </tr>
+            <tr>
+              <td className={TD}>Replication quantity &amp; percentage</td>
+              <td className={TD}>
+                How many independent attempts exist and what share of them reproduced the finding.
+                One dramatic study is weaker than three boring confirmations.
+              </td>
+            </tr>
+            <tr>
+              <td className={TD}>Conclusion relevance</td>
+              <td className={TD}>
+                Whether the data actually bears on this belief — the evidence-side twin of the{' '}
+                <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">
+                  linkage score
+                </Link>
+                . A rock-solid finding about the wrong question scores near zero here.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p className="mb-4">
+        These combine into a per-item EVS in [0, 1]. On the belief page, the evidence dimension
+        is the supporting share of total EVS weight: supporting &divide; (supporting +
+        weakening).
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Falsified evidence collapses what rests on it</h2>
+      <p className="mb-4">
+        The reasoning graph is a dependency graph, not a citation graph. In a citation graph,
+        removing a source leaves the citing page standing; here, evidence that fails —
+        retracted, falsified, misread — should pull the score of every argument anchored to it
+        down with it, and propagation carries that collapse upward through every conclusion
+        that depended on the branch.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Provenance is mandatory</h2>
+      <p className="mb-4">
+        Evidence enters with a source URL, DOI, PMID, or ISBN — no orphan claims. Agent-submitted
+        evidence carries a full audit trail (who retrieved it, when, with what rationale),
+        displayed in the argument&apos;s &ldquo;show the work&rdquo; trace. Provenance is display
+        and audit only; it never feeds a score directly.
+      </p>
+
+      <p className="mt-8 text-sm text-gray-600">
+        Related: <Link href="/algorithms/truth-scores" className="text-blue-700 hover:underline">Truth Scores</Link> ·{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">Linkage Scores</Link> ·{' '}
+        <Link href="/algorithms/reason-rank" className="text-blue-700 hover:underline">ReasonRank</Link>
+      </p>
+    </div>
+  )
+}

--- a/src/app/algorithms/importance-score/page.tsx
+++ b/src/app/algorithms/importance-score/page.tsx
@@ -1,0 +1,427 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Importance Score — Idea Stock Exchange',
+  description:
+    'How the Idea Stock Exchange weights arguments by how much they matter — including sourcing importance from a dedicated, debatable sub-belief.',
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function Breadcrumb() {
+  return (
+    <p className="text-right text-sm italic text-gray-600 mb-6">
+      <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+      {' > '}
+      <Link href="/algorithms" className="text-blue-700 hover:underline">Algorithms</Link>
+      {' > '}
+      <strong>Importance Score</strong>
+    </p>
+  )
+}
+
+function CalloutBox({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-[#eef5ff] border-l-4 border-[#3366cc] px-4 py-3 mb-5 rounded-r">
+      {children}
+    </div>
+  )
+}
+
+function FormulaBox({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-gray-100 border border-gray-300 px-4 py-3 font-mono text-lg my-4 rounded">
+      {children}
+    </div>
+  )
+}
+
+// ─── Mapping table data ──────────────────────────────────────────────────────
+
+const mappingRows = [
+  {
+    net: '+100',
+    importance: '1.00',
+    label: 'Decisive',
+    meaning: 'The claim that this argument matters is fully supported. Full weight.',
+  },
+  {
+    net: '+50',
+    importance: '0.75',
+    label: 'Major',
+    meaning: 'The importance debate leans strongly toward mattering.',
+  },
+  {
+    net: '0',
+    importance: '0.50',
+    label: 'Moderate',
+    meaning: 'Unargued or evenly contested. The argument carries half weight.',
+  },
+  {
+    net: '−50',
+    importance: '0.25',
+    label: 'Minor',
+    meaning: 'The community has largely refuted the claim that this matters.',
+  },
+  {
+    net: '−100',
+    importance: '0.00',
+    label: 'Negligible',
+    meaning: 'Fully refuted. A true, relevant, unimportant argument contributes nothing.',
+  },
+]
+
+// ─── Worked example data ─────────────────────────────────────────────────────
+
+const naziRows = [
+  {
+    argument: '"The regime systematically murdered millions of people."',
+    truth: '0.99',
+    linkage: '0.98',
+    importance: '1.00',
+    impact: '+97.0',
+    impactClass: 'text-green-700',
+  },
+  {
+    argument: '"Nazi leaders were often rude in personal correspondence."',
+    truth: '0.90',
+    linkage: '0.30',
+    importance: '0.05',
+    impact: '+1.4',
+    impactClass: 'text-orange-600',
+  },
+]
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function ImportanceScorePage() {
+  return (
+    <main className="max-w-[900px] mx-auto px-4 py-8 text-[#222]">
+      <Breadcrumb />
+
+      {/* ── Title ───────────────────────────────────────────────────────── */}
+      <h1 className="text-3xl font-bold mb-4 leading-tight">
+        Importance Score: Measuring Whether an Argument Actually Matters
+      </h1>
+
+      <CalloutBox>
+        <p className="text-[1.05rem]">
+          <strong>The Core Diagnostic Question:</strong>{' '}
+          <em>
+            &ldquo;If this argument is true and connected, how far should it move the
+            probability needle on the conclusion?&rdquo;
+          </em>
+        </p>
+      </CalloutBox>
+
+      {/* ── The problem ─────────────────────────────────────────────────── */}
+      <h2 className="text-2xl font-bold mt-8 mb-3">True and Relevant Is Still Not Enough</h2>
+
+      <p className="mb-3">
+        The{' '}
+        <Link href="/algorithms/truth-scores" className="text-blue-700 hover:underline">
+          Truth Score
+        </Link>{' '}
+        asks whether an argument is accurate. The{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">
+          Linkage Score
+        </Link>{' '}
+        asks whether it connects to the conclusion. Both can be high while the argument remains
+        trivial. A verified fact, genuinely on-topic, can still be a rounding error next to the
+        considerations that actually decide the question.
+      </p>
+      <p className="mb-3">
+        The Importance Score is the third dimension: a weight from <strong>0 to 1</strong>{' '}
+        measuring how much a proven, connected argument should move the parent belief.
+        A score of 1.0 means decisive, 0.5 means moderate, 0.1 means minor. On belief pages it
+        appears as the <strong>Imp</strong> column in the argument tables.
+      </p>
+      <p className="mb-4">
+        Without it, debates reward whoever can stack the most small true things. With it, one
+        decisive argument outweighs a hundred trivia points &mdash; because the math says so,
+        not because a moderator does.
+      </p>
+
+      <hr className="my-6 border-gray-300" />
+
+      {/* ── The killer feature ──────────────────────────────────────────── */}
+      <h2 className="text-2xl font-bold mb-3">
+        The Key Move: &ldquo;Does This Matter?&rdquo; Is Itself a Debatable Claim
+      </h2>
+
+      <p className="mb-3">
+        Most scoring systems treat importance as a knob someone turns. The Idea Stock Exchange
+        treats it as a <strong>claim someone must defend</strong>. An argument can carry an
+        optional third edge: a dedicated <em>importance sub-belief</em> whose whole job is to
+        assert that the argument matters.
+      </p>
+      <p className="mb-3">
+        Example: under the conclusion <em>&ldquo;The US should adopt approval voting,&rdquo;</em>{' '}
+        the argument <em>&ldquo;Plurality voting causes spoiler effects&rdquo;</em> can source its
+        importance from the sub-belief{' '}
+        <em>&ldquo;The spoiler effect is a major, solvable problem.&rdquo;</em> That sub-belief is
+        a full belief page: it collects its own reasons to agree and disagree, and earns its own
+        net score on the &minus;100 to +100 scale. The argument&apos;s importance is then derived
+        from that net score by a linear map:
+      </p>
+
+      <FormulaBox>Importance = (Net Score + 100) / 200, clamped to [0, 1]</FormulaBox>
+
+      <div className="overflow-x-auto mb-4">
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="border border-gray-300 px-3 py-2 text-center">Importance Belief Net Score</th>
+              <th className="border border-gray-300 px-3 py-2 text-center">Derived Importance</th>
+              <th className="border border-gray-300 px-3 py-2 text-left">Label</th>
+              <th className="border border-gray-300 px-3 py-2 text-left">Meaning</th>
+            </tr>
+          </thead>
+          <tbody>
+            {mappingRows.map(row => (
+              <tr key={row.net} className="border-b border-gray-200 hover:bg-gray-50">
+                <td className="border border-gray-300 px-3 py-2 text-center font-mono">{row.net}</td>
+                <td className="border border-gray-300 px-3 py-2 text-center font-mono font-bold">
+                  {row.importance}
+                </td>
+                <td className="border border-gray-300 px-3 py-2 font-semibold">{row.label}</td>
+                <td className="border border-gray-300 px-3 py-2">{row.meaning}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mb-3">
+        This closes a loophole every debate platform leaves open. If you think an opponent&apos;s
+        argument is overweighted, you do not downvote it or complain &mdash; you add reasons to
+        disagree with its importance belief. If those reasons survive scrutiny, the net score
+        falls, the derived importance falls with it, and the argument&apos;s contribution to the
+        parent shrinks automatically. The weight tracks the live debate about its own
+        significance, the same way{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">
+          linkage
+        </Link>{' '}
+        tracks the live debate about the connection.
+      </p>
+      <p className="mb-4">
+        Worked mapping: suppose the spoiler-effect importance belief settles at a net score of{' '}
+        <strong>+62</strong>. Then Importance = (62 + 100) / 200 = <strong>0.81</strong>. If the
+        argument itself has a truth score of 0.90 and a linkage of 0.85, its impact on the
+        approval-voting conclusion is 0.90 &times; 0.85 &times; 0.81 &times; 100 ={' '}
+        <strong>+62.0</strong>. Every number in that chain has a page where you can argue it down.
+      </p>
+
+      <h3 className="text-xl font-bold mt-5 mb-2">The Fallback: Manual Weights</h3>
+      <p className="mb-3">
+        Not every argument has an importance sub-belief yet. When the edge is absent, the
+        importance score is a manual value set when the argument is placed, defaulting to 1.0
+        (full weight). This is the honest current state: derived importance is computed and
+        auto-propagates wherever an importance belief exists; everywhere else, a placement-time
+        number stands in until someone creates the sub-belief and starts the debate.
+      </p>
+      <p className="mb-4">
+        For setting those manual weights &mdash; and eventually for structuring importance
+        debates themselves &mdash; the design rubric weighs four factors: <strong>scope</strong>{' '}
+        (how many people are affected, 30%), <strong>magnitude</strong> (effect size per person,
+        30%), <strong>reversibility</strong> (irreversible harms matter more, 20%), and{' '}
+        <strong>urgency</strong> (time-sensitive issues matter more, 20%). Today that rubric is
+        guidance for humans, not an automated calculation. The computed paths are the linear map
+        above and the manual default.
+      </p>
+
+      <hr className="my-6 border-gray-300" />
+
+      {/* ── Where it lands in the math ──────────────────────────────────── */}
+      <h2 className="text-2xl font-bold mb-3">Where Importance Enters the Math</h2>
+      <p className="mb-3">
+        When the scoring engine propagates a child belief&apos;s score up to its parent, each
+        argument edge contributes:
+      </p>
+
+      <FormulaBox>
+        Impact = sign &times; Truth &times; |Linkage| &times; Importance &times; Uniqueness &times; 100
+      </FormulaBox>
+
+      <ul className="list-disc list-inside mb-4 space-y-1">
+        <li>
+          <strong>sign</strong> &mdash; +1 for reasons to agree, &minus;1 for reasons to disagree.
+        </li>
+        <li>
+          <strong>Truth</strong> (0&ndash;1) &mdash; how well-supported the argument is by its own
+          sub-arguments (
+          <Link href="/algorithms/truth-scores" className="text-blue-700 hover:underline">
+            Truth Scores
+          </Link>
+          ).
+        </li>
+        <li>
+          <strong>|Linkage|</strong> (0&ndash;1) &mdash; how strongly it connects to this
+          conclusion (
+          <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">
+            Linkage Scores
+          </Link>
+          ); the absolute value is used so the side alone controls direction.
+        </li>
+        <li>
+          <strong>Importance</strong> (0&ndash;1) &mdash; this page.
+        </li>
+        <li>
+          <strong>Uniqueness</strong> (0&ndash;1) &mdash; discount for restating an earlier
+          same-side argument (
+          <Link href="/algorithms/unique-scores" className="text-blue-700 hover:underline">
+            Uniqueness Scores
+          </Link>
+          ).
+        </li>
+      </ul>
+      <p className="mb-4">
+        Because the factors multiply, a zero anywhere zeroes the whole contribution. True but
+        irrelevant dies on linkage. Relevant but false dies on truth. True, relevant, but trivial
+        dies here, on importance. Pro and con impacts then sum into the parent&apos;s net score,
+        as described in the{' '}
+        <Link href="/algorithms/reason-rank" className="text-blue-700 hover:underline">
+          ReasonRank Algorithm
+        </Link>
+        .
+      </p>
+
+      <hr className="my-6 border-gray-300" />
+
+      {/* ── Worked example ──────────────────────────────────────────────── */}
+      <h2 className="text-2xl font-bold mb-3">Worked Example: True but Unimportant</h2>
+      <p className="mb-4">
+        Conclusion: <em>&ldquo;The Nazi regime was morally catastrophic.&rdquo;</em> Consider two
+        supporting arguments, both factually accurate:
+      </p>
+
+      <div className="overflow-x-auto mb-2">
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="border border-gray-300 px-3 py-2 text-left">Argument</th>
+              <th className="border border-gray-300 px-3 py-2 text-center">Truth</th>
+              <th className="border border-gray-300 px-3 py-2 text-center">Linkage</th>
+              <th className="border border-gray-300 px-3 py-2 text-center">Importance</th>
+              <th className="border border-gray-300 px-3 py-2 text-center">Impact</th>
+            </tr>
+          </thead>
+          <tbody>
+            {naziRows.map(row => (
+              <tr key={row.argument} className="border-b border-gray-200 hover:bg-gray-50">
+                <td className="border border-gray-300 px-3 py-2">{row.argument}</td>
+                <td className="border border-gray-300 px-3 py-2 text-center font-mono">{row.truth}</td>
+                <td className="border border-gray-300 px-3 py-2 text-center font-mono">{row.linkage}</td>
+                <td className="border border-gray-300 px-3 py-2 text-center font-mono font-bold">
+                  {row.importance}
+                </td>
+                <td className={`border border-gray-300 px-3 py-2 text-center font-mono font-bold ${row.impactClass}`}>
+                  {row.impact}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-xs text-gray-500 italic mb-4">
+        Genocide row: 0.99 &times; 0.98 &times; 1.00 &times; 100 = +97.0. Rudeness row: 0.90
+        &times; 0.30 &times; 0.05 &times; 100 = +1.4. (Uniqueness is 1.0 for both &mdash; neither
+        restates the other.)
+      </p>
+
+      <p className="mb-3">
+        Both arguments are true. Both even point the same direction. But systematic genocide is
+        the reason the conclusion is true &mdash; scope in the millions, maximal magnitude,
+        irreversible. Rudeness in correspondence is a footnote: weakly linked to moral
+        catastrophe, and nearly weightless even where it connects. The impact column reflects a
+        70&times; difference that no amount of citation quality on the rudeness claim can close.
+      </p>
+      <p className="mb-4">
+        And if someone disagrees with that 0.05? They do not edit a number. They build the case
+        on the rudeness argument&apos;s importance belief &mdash; and either the reasons hold up
+        and the weight rises, or they do not and it stays a footnote. Importance is earned in
+        public, like every other score on the platform.
+      </p>
+
+      <hr className="my-6 border-gray-300" />
+
+      {/* ── Common objections ───────────────────────────────────────────── */}
+      <h2 className="text-2xl font-bold mb-3">Common Objections</h2>
+
+      <h3 className="text-xl font-bold mt-4 mb-2">
+        &ldquo;Isn&apos;t importance just linkage again?&rdquo;
+      </h3>
+      <p className="mb-4">
+        No. Linkage asks whether the argument, if true, forces movement on the conclusion.
+        Importance asks how large that movement should be. &ldquo;Nazi leaders were rude&rdquo;
+        has <em>some</em> linkage to moral character &mdash; the connection is real, just weak
+        and small. A perfectly linked argument about a tiny effect (a policy that provably saves
+        $12 a year) has high linkage and low importance. The two scores fail independently, which
+        is why both multiply into impact.
+      </p>
+
+      <h3 className="text-xl font-bold mt-4 mb-2">
+        &ldquo;Won&apos;t people just set their own arguments to 1.0?&rdquo;
+      </h3>
+      <p className="mb-4">
+        With manual weights, they can &mdash; which is exactly why the sourced path exists. An
+        argument coasting on a default 1.0 is an open invitation: create its importance belief,
+        add the reasons it does not matter, and let the derived score replace the assertion. The
+        long-run equilibrium is that every contested weight becomes a debate, and defaults only
+        survive where nobody objects.
+      </p>
+
+      <hr className="my-6 border-gray-300" />
+
+      {/* ── Related links ───────────────────────────────────────────────── */}
+      <div>
+        <p className="font-bold mb-2">Related Algorithms &amp; Documentation:</p>
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>
+            <Link href="/algorithms/reason-rank" className="text-blue-700 hover:underline">
+              ReasonRank Algorithm
+            </Link>{' '}
+            &mdash; How importance-weighted impacts aggregate into belief scores.
+          </li>
+          <li>
+            <Link href="/algorithms/truth-scores" className="text-blue-700 hover:underline">
+              Truth Scores
+            </Link>{' '}
+            &mdash; The accuracy dimension of argument impact.
+          </li>
+          <li>
+            <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">
+              Linkage Scores
+            </Link>{' '}
+            &mdash; The relevance dimension of argument impact.
+          </li>
+          <li>
+            <Link href="/algorithms/unique-scores" className="text-blue-700 hover:underline">
+              Uniqueness Scores
+            </Link>{' '}
+            &mdash; The redundancy discount that stops restatements from double-counting.
+          </li>
+          <li>
+            <Link href="/algorithms/objective-criteria" className="text-blue-700 hover:underline">
+              Objective Criteria
+            </Link>{' '}
+            &mdash; Agreeing on what counts as evidence before weighing it.
+          </li>
+        </ul>
+      </div>
+
+      <p className="mt-8 mb-2">
+        Browse the{' '}
+        <Link href="/beliefs" className="font-bold text-blue-700 hover:underline">
+          belief index
+        </Link>{' '}
+        to see Importance Scores in the argument tables, or start with the{' '}
+        <Link href="/algorithms" className="font-bold text-blue-700 hover:underline">
+          algorithms overview
+        </Link>
+        .
+      </p>
+    </main>
+  )
+}

--- a/src/app/algorithms/page.tsx
+++ b/src/app/algorithms/page.tsx
@@ -1,0 +1,271 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'The Scoring Algorithms — Idea Stock Exchange',
+  description:
+    'Index of every algorithm behind the numbers on a belief page: ReasonRank, linkage, truth, importance, uniqueness, evidence, and more.',
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function Breadcrumb() {
+  return (
+    <p className="text-right text-sm italic text-gray-600 mb-6">
+      <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+      {' > '}
+      <strong>Algorithms</strong>
+    </p>
+  )
+}
+
+function FormulaBox({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-gray-100 border border-gray-300 px-4 py-3 font-mono text-base my-4 rounded">
+      {children}
+    </div>
+  )
+}
+
+// ─── Algorithm index data ─────────────────────────────────────────────────────
+
+interface AlgorithmEntry {
+  name: string
+  href: string
+  description: string
+}
+
+interface AlgorithmGroup {
+  heading: string
+  blurb: string
+  entries: AlgorithmEntry[]
+}
+
+const groups: AlgorithmGroup[] = [
+  {
+    heading: 'The Core Pipeline',
+    blurb:
+      'Five multipliers decide how much weight an argument passes up to its conclusion. ReasonRank is the recursion that runs them over the whole tree.',
+    entries: [
+      {
+        name: 'ReasonRank',
+        href: '/algorithms/reason-rank',
+        description:
+          'The master algorithm: how pro and con argument trees recursively roll up into a belief score, PageRank-style.',
+      },
+      {
+        name: 'Truth Scores',
+        href: '/algorithms/truth-scores',
+        description:
+          'How well-supported a claim is by its own sub-arguments and evidence — accuracy, independent of relevance.',
+      },
+      {
+        name: 'Linkage Scores',
+        href: '/algorithms/linkage-scores',
+        description:
+          'Whether a true argument actually connects to its conclusion. A multiplier from −1.0 to +1.0, itself debatable.',
+      },
+      {
+        name: 'Importance Score',
+        href: '/algorithms/importance-score',
+        description:
+          'How much a true, relevant argument should move the needle — derived from a dedicated importance sub-debate.',
+      },
+      {
+        name: 'Uniqueness',
+        href: '/algorithms/unique-scores',
+        description:
+          'The redundancy penalty. Making one point five different ways scores as one point, not five.',
+      },
+      {
+        name: 'Evidence Scores',
+        href: '/algorithms/evidence-scores',
+        description:
+          'Grading raw data by source tier, replication count, replication consistency, and relevance to the conclusion.',
+      },
+    ],
+  },
+  {
+    heading: 'Debate Hygiene',
+    blurb:
+      'Before the multipliers run, these algorithms keep the inputs honest: shared yardsticks, calibrated claim strength, and explicit hidden premises.',
+    entries: [
+      {
+        name: 'Objective Criteria',
+        href: '/algorithms/objective-criteria',
+        description:
+          'Agreeing on the measurement yardstick before the fight, so evidence is weighed by standards set in advance.',
+      },
+      {
+        name: 'Claim Strength (Strong-to-Weak)',
+        href: '/algorithms/strong-to-weak',
+        description:
+          'Burden of proof scales with wording: “always” needs more support than “sometimes.”',
+      },
+      {
+        name: 'Assumptions',
+        href: '/algorithms/assumptions',
+        description:
+          'Surfacing the unstated premises that bridge low-linkage arguments, so each one becomes its own debatable node.',
+      },
+    ],
+  },
+  {
+    heading: 'Deduplication',
+    blurb:
+      'One question, one page. These algorithms stop the same debate from fragmenting across a dozen differently-worded copies.',
+    entries: [
+      {
+        name: 'Belief Equivalency',
+        href: '/algorithms/belief-equivalency',
+        description:
+          'Detecting differently-worded claims that make the same point, so their arguments and scores can be shared.',
+      },
+      {
+        name: 'Combining Similar Beliefs',
+        href: '/algorithms/combine-similar-beliefs',
+        description:
+          'How near-duplicate beliefs get merged once equivalency is established, and what happens to their argument trees.',
+      },
+    ],
+  },
+  {
+    heading: 'Decision Analysis',
+    blurb:
+      'For “should we” questions, scored arguments feed probability-weighted cost-benefit accounting.',
+    entries: [
+      {
+        name: 'CBA Likelihood',
+        href: '/cba/about',
+        description:
+          'How competing probability estimates for each predicted cost and benefit are scored, and the winner selected.',
+      },
+    ],
+  },
+]
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function AlgorithmsIndexPage() {
+  return (
+    <main className="max-w-[900px] mx-auto px-4 py-8 text-[#222]">
+      <Breadcrumb />
+
+      <h1 className="text-3xl font-bold mb-4 leading-tight">The Scoring Algorithms</h1>
+
+      <p className="mb-3">
+        Every score on a{' '}
+        <Link href="/beliefs" className="text-blue-700 hover:underline">belief page</Link>{' '}
+        is computed, never hand-assigned. Nobody at the Idea Stock Exchange decides that an
+        argument is worth 72 points. The community contributes arguments, evidence, and votes on
+        specific narrow questions; the algorithms turn those inputs into numbers through formulas
+        anyone can inspect and challenge.
+      </p>
+      <p className="mb-5">
+        Each page below explains one number you will meet on a belief page: what it measures, how
+        it is calculated, and a worked example. Some of these formulas run in the live scoring
+        engine today; others describe elicitation flows (voting interfaces, diagnostic wizards)
+        that are designed but still being wired to real data. Each page says which is which.
+      </p>
+
+      <hr className="my-6 border-gray-300" />
+
+      {/* ── Core formula ────────────────────────────────────────────────── */}
+      <h2 className="text-2xl font-bold mb-3">The Formula Everything Feeds Into</h2>
+      <p className="mb-3">
+        A belief&apos;s conclusion score is the weighted sum of the reasons to agree minus the
+        weighted sum of the reasons to disagree:
+      </p>
+
+      <FormulaBox>
+        Conclusion Score = &Sigma;(agree &times; linkage &times; uniqueness) &minus;
+        &Sigma;(disagree &times; linkage &times; uniqueness)
+      </FormulaBox>
+
+      <p className="mb-3">
+        The live engine computes this one edge at a time. For each argument attached to a belief,{' '}
+        <code className="bg-gray-100 px-1 rounded">computeArgumentImpactScore</code> in{' '}
+        <code className="bg-gray-100 px-1 rounded">src/core/scoring/scoring-engine.ts</code>{' '}
+        produces the term that argument contributes:
+      </p>
+
+      <FormulaBox>
+        impact = sign &times; truth &times; |linkage| &times; importance &times; uniqueness
+        &times; 100
+      </FormulaBox>
+
+      <p className="mb-3">
+        Where <strong>sign</strong> is +1 for a reason to agree and &minus;1 for a reason to
+        disagree, <strong>truth</strong> is the child belief&apos;s own truth score (0&ndash;1),{' '}
+        <strong>|linkage|</strong> is the absolute linkage score (0&ndash;1, so the side alone
+        controls direction), <strong>importance</strong> is the needle-moving weight
+        (0&ndash;1), and <strong>uniqueness</strong> is the redundancy penalty (0&ndash;1,
+        defaulting to 1). The result is scaled by 100 and rounded to one decimal, which is why
+        belief pages show impacts like 18.5 or &minus;12.4.
+      </p>
+      <p className="mb-4">
+        The multiplication is the point. An argument that is true but irrelevant scores zero.
+        Relevant but false scores zero. True, relevant, but a restatement of a point already made
+        scores near zero. Only arguments that clear every filter move the conclusion.
+      </p>
+
+      <hr className="my-6 border-gray-300" />
+
+      {/* ── Index ───────────────────────────────────────────────────────── */}
+      <h2 className="text-2xl font-bold mb-4">The Algorithms</h2>
+
+      {groups.map(group => (
+        <div key={group.heading} className="mb-8">
+          <h3 className="text-xl font-bold mb-2">{group.heading}</h3>
+          <p className="mb-3 text-gray-700">{group.blurb}</p>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse border border-gray-300 text-sm">
+              <thead className="bg-gray-100">
+                <tr>
+                  <th className="border border-gray-300 px-3 py-2 text-left w-[30%]">Algorithm</th>
+                  <th className="border border-gray-300 px-3 py-2 text-left">What it explains</th>
+                </tr>
+              </thead>
+              <tbody>
+                {group.entries.map(entry => (
+                  <tr key={entry.href} className="border-b border-gray-200 hover:bg-gray-50">
+                    <td className="border border-gray-300 px-3 py-2 font-semibold">
+                      <Link href={entry.href} className="text-blue-700 hover:underline">
+                        {entry.name}
+                      </Link>
+                    </td>
+                    <td className="border border-gray-300 px-3 py-2">{entry.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+
+      <hr className="my-6 border-gray-300" />
+
+      {/* ── Where to see them ───────────────────────────────────────────── */}
+      <h2 className="text-2xl font-bold mb-3">See Them in Action</h2>
+      <p className="mb-3">
+        The algorithms are not the product; the belief page is. Every number these pages explain
+        appears next to a real argument on a real page, where you can click into it, see the
+        sub-debate behind it, and challenge it.
+      </p>
+      <ul className="list-disc list-inside mb-5 space-y-1 text-sm">
+        <li>
+          <Link href="/beliefs" className="text-blue-700 hover:underline">
+            Browse the beliefs
+          </Link>{' '}
+          &mdash; every score you see traces back to one of the algorithms above.
+        </li>
+        <li>
+          <Link href="/faq" className="text-blue-700 hover:underline">
+            Read the FAQ
+          </Link>{' '}
+          &mdash; common questions about how scoring, voting, and merging work.
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/src/app/algorithms/topic-overlap/page.tsx
+++ b/src/app/algorithms/topic-overlap/page.tsx
@@ -1,0 +1,86 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Topic Overlap — Idea Stock Exchange',
+  description:
+    'The belief-level uniqueness readout: how little a page&apos;s arguments restate each other.',
+}
+
+const container = 'max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]'
+
+function Breadcrumb() {
+  return (
+    <p className="text-right text-sm italic text-gray-600 mb-6">
+      <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+      {' > '}
+      <Link href="/algorithms" className="text-blue-700 hover:underline">Algorithms</Link>
+      {' > '}
+      <strong>Topic Overlap</strong>
+    </p>
+  )
+}
+
+export default function TopicOverlapPage() {
+  return (
+    <div className={container}>
+      <Breadcrumb />
+      <h1 className="text-3xl font-bold mb-3">Topic Overlap</h1>
+      <p className="text-lg text-gray-600 mb-6">
+        The page-level uniqueness readout — dimension 10 of the twelve. It answers: is this
+        belief accumulating independent support, or restating one point?
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">What it computes</h2>
+      <p className="mb-4">
+        For each argument on the page, take its uniqueness — 1 minus its highest similarity to
+        any other argument text on the page — then average across the page. A score near 1
+        means the arguments are genuinely distinct considerations; a score near 0.5 or below
+        diagnoses a page whose apparent weight is mostly one point wearing several costumes.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Three scales of the same idea</h2>
+      <ul className="list-disc ml-6 mb-4 space-y-1">
+        <li>
+          <strong>Per-argument:</strong>{' '}
+          <Link href="/algorithms/unique-scores" className="text-blue-700 hover:underline">
+            uniqueness scores
+          </Link>{' '}
+          discount each restatement&apos;s impact at scoring time — this is what stops
+          repetition from adding weight.
+        </li>
+        <li>
+          <strong>Per-page:</strong> topic overlap (this page) reports the diagnostic average on
+          the belief&apos;s Scorecard.
+        </li>
+        <li>
+          <strong>Across pages:</strong>{' '}
+          <Link href="/algorithms/belief-equivalency" className="text-blue-700 hover:underline">
+            belief equivalency
+          </Link>{' '}
+          catches whole duplicate beliefs, so &ldquo;one page per topic&rdquo; stays true —
+          see{' '}
+          <Link href="/algorithms/combine-similar-beliefs" className="text-blue-700 hover:underline">
+            combining similar beliefs
+          </Link>
+          .
+        </li>
+      </ul>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Reading a low score</h2>
+      <p className="mb-4">
+        A low topic overlap score is not a verdict against the belief — it is a to-do list.
+        The page needs consolidation (merge the restatements, keep the earliest) or genuinely
+        new considerations. Because per-argument uniqueness already discounts the duplicates,
+        the belief&apos;s net is protected either way; the readout just tells editors where the
+        redundancy lives.
+      </p>
+
+      <p className="mt-8 text-sm text-gray-600">
+        Related: <Link href="/algorithms/unique-scores" className="text-blue-700 hover:underline">Uniqueness Scores</Link> ·{' '}
+        <Link href="/algorithms/belief-equivalency" className="text-blue-700 hover:underline">Belief Equivalency</Link> ·{' '}
+        <Link href="/algorithms/reason-rank" className="text-blue-700 hover:underline">ReasonRank</Link>
+      </p>
+    </div>
+  )
+}

--- a/src/app/algorithms/truth-scores/page.tsx
+++ b/src/app/algorithms/truth-scores/page.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Truth Scores — Idea Stock Exchange',
+  description:
+    'How a belief earns its truth score from its own argument tree and evidence ledger — recursively, never by assertion.',
+}
+
+const container = 'max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]'
+
+function Breadcrumb() {
+  return (
+    <p className="text-right text-sm italic text-gray-600 mb-6">
+      <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+      {' > '}
+      <Link href="/algorithms" className="text-blue-700 hover:underline">Algorithms</Link>
+      {' > '}
+      <strong>Truth Scores</strong>
+    </p>
+  )
+}
+
+export default function TruthScoresPage() {
+  return (
+    <div className={container}>
+      <Breadcrumb />
+      <h1 className="text-3xl font-bold mb-3">Truth Scores</h1>
+      <p className="text-lg text-gray-600 mb-6">
+        A belief never asserts its own truth. It earns a score from its own reasons to agree
+        and disagree, computed recursively down to raw evidence.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">The core computation</h2>
+      <p className="mb-4">
+        Every belief page carries a two-sided argument tree and a two-sided evidence ledger.
+        The net truth readout is the normalized balance of the two:
+      </p>
+      <div className="bg-gray-100 border border-gray-300 px-4 py-3 font-mono my-4 rounded">
+        net = (pro &minus; con) / (pro + con) &times; 100
+      </div>
+      <p className="mb-4">
+        where pro and con are the summed impact magnitudes of each side&apos;s arguments plus
+        evidence. Dividing by the belief&apos;s own total keeps the number honest — it says how
+        lopsided the debate is, not how loud it is. (Volume is reported alongside as mass, and
+        the belief&apos;s standing against its <em>rivals</em> is a separate readout — see the
+        Contrast Class on belief pages.)
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Two channels: logic and evidence</h2>
+      <ul className="list-disc ml-6 mb-4 space-y-1">
+        <li>
+          <strong>Logical validity</strong> — the argument channel: how the reasons to agree and
+          disagree balance. An argument can only fail logically, so it lives in the tree.
+        </li>
+        <li>
+          <strong>Verification</strong> — the evidence channel: how the supporting and weakening
+          evidence balances, each item weighted by its{' '}
+          <Link href="/algorithms/evidence-scores" className="text-blue-700 hover:underline">
+            evidence score
+          </Link>
+          . Evidence can fail empirically, so it lives in the ledger.
+        </li>
+      </ul>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">The turtle stack: truth is recursive</h2>
+      <p className="mb-4">
+        Each argument&apos;s contribution to a belief uses the <em>argument&apos;s own</em> truth
+        score — the score of the child belief page behind it — times its{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">linkage</Link>,{' '}
+        <Link href="/algorithms/importance-score" className="text-blue-700 hover:underline">importance</Link>, and{' '}
+        <Link href="/algorithms/unique-scores" className="text-blue-700 hover:underline">uniqueness</Link>.
+        That child is a full belief page with its own tree, whose arguments are belief pages in
+        turn. You can drill down as far as you want until you hit raw evidence at the bottom;
+        there is no hardcoded floor, on purpose. When anything below changes, propagation
+        recomputes every conclusion above it.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Unscored stays blank</h2>
+      <p className="mb-4">
+        A claim with no scored content has no truth score — the cell renders blank rather than
+        faking a neutral. Scores appear when real arguments and evidence exist to compute them
+        from, and never before. The same rule protects a belief&apos;s editorial framing: the
+        engine only writes a computed net over a page that actually has scored content.
+      </p>
+
+      <p className="mt-8 text-sm text-gray-600">
+        Related: <Link href="/algorithms/reason-rank" className="text-blue-700 hover:underline">ReasonRank</Link> ·{' '}
+        <Link href="/algorithms/evidence-scores" className="text-blue-700 hover:underline">Evidence Scores</Link> ·{' '}
+        <Link href="/algorithms/strong-to-weak" className="text-blue-700 hover:underline">Claim Strength</Link>
+      </p>
+    </div>
+  )
+}

--- a/src/app/algorithms/unique-scores/page.tsx
+++ b/src/app/algorithms/unique-scores/page.tsx
@@ -1,0 +1,114 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Uniqueness Scores — Idea Stock Exchange',
+  description:
+    'How the Idea Stock Exchange discounts restatements: uniqueness = 1 − max similarity to earlier same-side arguments, multiplied into every impact.',
+}
+
+const container = 'max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]'
+
+function Breadcrumb() {
+  return (
+    <p className="text-right text-sm italic text-gray-600 mb-6">
+      <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+      {' > '}
+      <Link href="/algorithms" className="text-blue-700 hover:underline">Algorithms</Link>
+      {' > '}
+      <strong>Uniqueness Scores</strong>
+    </p>
+  )
+}
+
+export default function UniqueScoresPage() {
+  return (
+    <div className={container}>
+      <Breadcrumb />
+      <h1 className="text-3xl font-bold mb-3">Uniqueness Scores</h1>
+      <p className="text-lg text-gray-600 mb-6">
+        How much new signal does this argument add versus the ones already on the page?
+        Nobody wins by making one point five different ways.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">The problem uniqueness solves</h2>
+      <p className="mb-4">
+        A bare sum of argument weights rewards repetition: state the same point five ways and a
+        naive tally counts it five times. Uniqueness closes that exploit. Each argument&apos;s
+        contribution is multiplied by how much it adds beyond the same-side arguments that were
+        there first — a ninety percent restatement contributes about ten percent of its weight.
+      </p>
+
+      <div className="bg-gray-100 border border-gray-300 px-4 py-3 font-mono my-4 rounded">
+        uniqueness = 1 &minus; max(similarity to each <em>earlier</em> same-side argument)
+      </div>
+      <p className="mb-4">
+        The maximum, not the average: one near-identical prior argument is enough to mark a new
+        one as redundant. The <strong>earliest</strong> statement of a point keeps full credit
+        (uniqueness 1.0); later restatements are discounted. Ordering by arrival keeps the rule
+        stable — posting a duplicate never damages the original.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Where it enters the score</h2>
+      <p className="mb-4">
+        Uniqueness multiplies into every argument&apos;s impact at scoring time, alongside truth,{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">linkage</Link>, and{' '}
+        <Link href="/algorithms/importance-score" className="text-blue-700 hover:underline">importance</Link>:
+      </p>
+      <div className="bg-gray-100 border border-gray-300 px-4 py-3 font-mono my-4 rounded">
+        impact = sign &times; truth &times; |linkage| &times; importance &times; uniqueness &times; 100
+      </div>
+      <p className="mb-4">
+        Every impact value on a belief page links to its provenance page, which shows this
+        argument&apos;s uniqueness trace: exactly which earlier same-side arguments it overlaps
+        and by how much. The number is engine output — challenge it by showing the overlap is
+        wrong, not by asking nicely.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">How similarity is measured</h2>
+      <p className="mb-2">Three layers, blended as they become available:</p>
+      <ul className="list-disc ml-6 mb-4 space-y-1">
+        <li>
+          <strong>Mechanical (live today):</strong> normalized token overlap — synonym groups
+          collapse (&ldquo;decrease&rdquo; = &ldquo;reduce&rdquo;), stopwords drop, negated
+          antonyms fold in, then a Jaccard similarity over what remains. Near-verbatim
+          restatements short-circuit to full similarity.
+        </li>
+        <li>
+          <strong>Semantic embeddings (input slot):</strong> the blend accepts an
+          embedding-based layer as it lands, weighted above the mechanical layer.
+        </li>
+        <li>
+          <strong>Community equivalence (input slot):</strong> &ldquo;are these the same
+          point?&rdquo; is itself debatable — equivalence sub-debates feed the third layer.
+        </li>
+      </ul>
+      <p className="mb-4">
+        The belief-level readout of the same idea is the{' '}
+        <Link href="/algorithms/topic-overlap" className="text-blue-700 hover:underline">
+          topic overlap score
+        </Link>{' '}
+        — the page-wide average of per-argument uniqueness — and duplicate{' '}
+        <em>beliefs</em> (rather than arguments) are handled by{' '}
+        <Link href="/algorithms/belief-equivalency" className="text-blue-700 hover:underline">
+          belief equivalency
+        </Link>
+        .
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">The novelty premium</h2>
+      <p className="mb-4">
+        A genuinely new point (uniqueness &ge; 0.5) can carry a small, decaying early bonus —
+        peaking at 1.25&times; and fading over about a day — so surfacing a fresh consideration
+        is worth slightly more than the thousandth confirmation of an old one. The premium never
+        drops a score below its base; it only rewards novelty, never punishes age.
+      </p>
+
+      <p className="mt-8 text-sm text-gray-600">
+        Related: <Link href="/algorithms/reason-rank" className="text-blue-700 hover:underline">ReasonRank</Link> ·{' '}
+        <Link href="/algorithms/topic-overlap" className="text-blue-700 hover:underline">Topic Overlap</Link> ·{' '}
+        <Link href="/algorithms/combine-similar-beliefs" className="text-blue-700 hover:underline">Combining Similar Beliefs</Link>
+      </p>
+    </div>
+  )
+}

--- a/src/app/api/beliefs/[id]/arguments/route.ts
+++ b/src/app/api/beliefs/[id]/arguments/route.ts
@@ -1,0 +1,226 @@
+/**
+ * Human posting endpoint: add a reason to agree or disagree to a belief.
+ *
+ * The two moves the belief page supports are "add a row" and "challenge a
+ * number" — this is the add-a-row move. The new reason becomes a full belief
+ * page of its own (the recursive tree has no hardcoded floor), joined to the
+ * parent by an Argument edge, and the scoring engine immediately propagates
+ * so every dependent conclusion updates.
+ *
+ * Audit lock: no score field is accepted. Scores are the engine's job.
+ *
+ * SPEED BUMPS (high-stakes beliefs only): before the API accepts a post it
+ * requires (1) acknowledging the strongest current argument on the OTHER
+ * side — verified server-side against the live ranking, not the client's
+ * word — and (2) a moral-principle consistency statement: name the principle
+ * the post rests on and affirm the proposal is consistent with it. GET this
+ * route to fetch what the speed bumps currently require.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { propagateBeliefScores } from '@/lib/propagate-belief-scores'
+import { slugify } from '@/lib/agent-ingest/slug'
+import { isGraphFrozen, GRAPH_FREEZE_MESSAGE } from '@/lib/markets/epoch'
+
+interface PostBody {
+  side?: string
+  statement?: string
+  claim?: string
+  rationale?: string
+  /** Speed bump 1: the id of the strongest opposing argument, as acknowledgment. */
+  steelmanArgumentId?: number
+  /** Speed bump 2: the moral principle claimed, plus explicit consistency. */
+  principle?: string
+  principleConsistent?: boolean
+}
+
+/** The strongest published argument on a side, by current impact magnitude. */
+async function strongestOnSide(beliefId: number, side: 'agree' | 'disagree') {
+  const args = await prisma.argument.findMany({
+    where: { parentBeliefId: beliefId, side, status: 'published' },
+    include: { belief: { select: { slug: true, statement: true } } },
+  })
+  if (args.length === 0) return null
+  return args.reduce((a, b) => (Math.abs(b.impactScore) > Math.abs(a.impactScore) ? b : a))
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const beliefId = Number(id)
+  if (!Number.isInteger(beliefId)) {
+    return NextResponse.json({ error: 'Invalid belief id.' }, { status: 400 })
+  }
+  const belief = await prisma.belief.findUnique({
+    where: { id: beliefId },
+    select: { id: true, slug: true, statement: true, highStakes: true },
+  })
+  if (!belief) return NextResponse.json({ error: 'Belief not found.' }, { status: 404 })
+
+  const [strongestAgree, strongestDisagree] = await Promise.all([
+    strongestOnSide(beliefId, 'agree'),
+    strongestOnSide(beliefId, 'disagree'),
+  ])
+
+  return NextResponse.json({
+    belief: { id: belief.id, slug: belief.slug, statement: belief.statement },
+    highStakes: belief.highStakes,
+    speedBumps: belief.highStakes
+      ? {
+          steelman:
+            'Acknowledge the strongest point on the other side: pass its id as steelmanArgumentId.',
+          principle:
+            'Name the moral principle your post rests on (principle) and affirm the proposal is consistent with it (principleConsistent: true).',
+          strongestAgree: strongestAgree && {
+            id: strongestAgree.id,
+            claim: strongestAgree.claim ?? strongestAgree.belief.statement,
+            impactScore: strongestAgree.impactScore,
+          },
+          strongestDisagree: strongestDisagree && {
+            id: strongestDisagree.id,
+            claim: strongestDisagree.claim ?? strongestDisagree.belief.statement,
+            impactScore: strongestDisagree.impactScore,
+          },
+        }
+      : null,
+    auditLock: 'No score field is accepted. Scores are computed by the engine, never submitted.',
+  })
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const beliefId = Number(id)
+  if (!Number.isInteger(beliefId)) {
+    return NextResponse.json({ error: 'Invalid belief id.' }, { status: 400 })
+  }
+
+  if (isGraphFrozen(new Date())) {
+    return NextResponse.json({ error: GRAPH_FREEZE_MESSAGE }, { status: 423 })
+  }
+
+  let body: PostBody
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  // Audit lock, enforced not just documented.
+  const forbidden = ['impactScore', 'linkageScore', 'importanceScore', 'argumentScore', 'uniquenessScore']
+  const submitted = Object.keys(body as Record<string, unknown>).filter((k) => forbidden.includes(k))
+  if (submitted.length > 0) {
+    return NextResponse.json(
+      { error: `Score fields are never accepted (${submitted.join(', ')}). The engine computes scores.` },
+      { status: 422 },
+    )
+  }
+
+  const side = body.side === 'agree' || body.side === 'disagree' ? body.side : null
+  if (!side) {
+    return NextResponse.json({ error: "side must be 'agree' or 'disagree'." }, { status: 422 })
+  }
+  const statement = body.statement?.trim()
+  if (!statement || statement.length < 10) {
+    return NextResponse.json(
+      { error: 'statement must be a standalone claim with a truth value (min 10 chars).' },
+      { status: 422 },
+    )
+  }
+
+  const belief = await prisma.belief.findUnique({
+    where: { id: beliefId },
+    select: { id: true, slug: true, highStakes: true },
+  })
+  if (!belief) return NextResponse.json({ error: 'Belief not found.' }, { status: 404 })
+
+  // ── Speed bumps for high-stakes beliefs ─────────────────────────────────
+  if (belief.highStakes) {
+    const opposingSide = side === 'agree' ? 'disagree' : 'agree'
+    const strongest = await strongestOnSide(beliefId, opposingSide)
+
+    if (strongest && body.steelmanArgumentId !== strongest.id) {
+      return NextResponse.json(
+        {
+          error:
+            'Speed bump: acknowledge the strongest point on the other side before posting. ' +
+            'Pass its id as steelmanArgumentId.',
+          strongestOpposing: {
+            id: strongest.id,
+            claim: strongest.claim ?? strongest.belief.statement,
+            impactScore: strongest.impactScore,
+          },
+        },
+        { status: 422 },
+      )
+    }
+
+    if (!body.principle?.trim() || body.principleConsistent !== true) {
+      return NextResponse.json(
+        {
+          error:
+            'Speed bump: name the moral principle your post rests on (principle) and confirm ' +
+            'your proposal is consistent with it (principleConsistent: true).',
+        },
+        { status: 422 },
+      )
+    }
+  }
+
+  // ── Create the child belief + edge (no scores), then let the engine run ─
+  const slug = slugify(statement)
+  const rationale = [
+    body.rationale?.trim() || null,
+    belief.highStakes && body.principle
+      ? `Speed bumps passed — acknowledged strongest opposing argument #${body.steelmanArgumentId ?? 'none'}; claimed principle: "${body.principle.trim()}"`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(' | ')
+
+  const created = await prisma.$transaction(async (tx) => {
+    const childBelief =
+      (await tx.belief.findUnique({ where: { slug } })) ??
+      (await tx.belief.create({ data: { slug, statement } }))
+
+    const argument = await tx.argument.create({
+      data: {
+        parentBeliefId: belief.id,
+        beliefId: childBelief.id,
+        side,
+        claim: body.claim?.trim() || null,
+        rationale: rationale || null,
+      },
+    })
+
+    await tx.auditLog.create({
+      data: {
+        action: 'post_argument',
+        targetType: 'Argument',
+        targetId: String(argument.id),
+        rationale: rationale || 'Human submission via belief page.',
+        payload: JSON.stringify({ beliefId: belief.id, side, statement }),
+      },
+    })
+
+    return { argument, childBelief }
+  })
+
+  // The engine's turn: the new edge changes the graph, so recompute the new
+  // claim's impact and everything upstream of it.
+  await propagateBeliefScores(created.childBelief.id)
+
+  return NextResponse.json(
+    {
+      argumentId: created.argument.id,
+      childBeliefSlug: created.childBelief.slug,
+      note: 'Scores are computed by the engine and will appear once propagation lands.',
+    },
+    { status: 201 },
+  )
+}

--- a/src/app/api/scoring/propagate-all/route.ts
+++ b/src/app/api/scoring/propagate-all/route.ts
@@ -22,7 +22,7 @@
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { propagateBeliefScores } from '@/lib/propagate-belief-scores'
+import { propagateAllBeliefScores } from '@/lib/propagate-belief-scores'
 
 // ─── GET (status check) ─────────────────────────────────────────────────────
 
@@ -41,55 +41,15 @@ export async function GET() {
 // ─── POST (run full propagation) ────────────────────────────────────────────
 
 export async function POST() {
-  // Find all beliefs that are never used as a reason (i.e., leaf beliefs).
-  // These have no outgoing "beliefId" references in the Argument table.
-  const allBeliefIds = await prisma.belief.findMany({ select: { id: true } })
-  const beliefIdsUsedAsChild = await prisma.argument.findMany({
-    select: { beliefId: true },
-    distinct: ['beliefId'],
-  })
-
-  const usedAsChildSet = new Set(beliefIdsUsedAsChild.map(a => a.beliefId))
-  const leafBeliefIds = allBeliefIds
-    .map(b => b.id)
-    .filter(id => !usedAsChildSet.has(id))
-
-  // Also include beliefs that have no children themselves — every belief
-  // that isn't a parent of another, so they won't be visited through a leaf.
-  const beliefIdsUsedAsParent = await prisma.argument.findMany({
-    select: { parentBeliefId: true },
-    distinct: ['parentBeliefId'],
-  })
-  const usedAsParentSet = new Set(beliefIdsUsedAsParent.map(a => a.parentBeliefId))
-
-  // True isolated beliefs (no arguments at all) — still need positivity updated
-  const isolatedBeliefIds = allBeliefIds
-    .map(b => b.id)
-    .filter(id => !usedAsChildSet.has(id) && !usedAsParentSet.has(id))
-
-  // Combine: start from leaves (propagates upward) + isolated beliefs
-  const startBeliefIds = Array.from(new Set([...leafBeliefIds, ...isolatedBeliefIds]))
-
-  const visited = new Set<number>()
-  let totalUpdatedArguments = 0
-  let totalUpdatedBeliefs = 0
-  let maxDepth = 0
-
-  for (const id of startBeliefIds) {
-    if (visited.has(id)) continue
-    const result = await propagateBeliefScores(id, visited)
-    totalUpdatedArguments += result.updatedArgumentIds.length
-    totalUpdatedBeliefs += result.updatedBeliefIds.length
-    maxDepth = Math.max(maxDepth, result.depth)
-  }
+  const result = await propagateAllBeliefScores()
 
   return NextResponse.json({
     success: true,
     summary: {
-      startBeliefCount: startBeliefIds.length,
-      totalUpdatedArguments,
-      totalUpdatedBeliefs,
-      maxDepth,
+      startBeliefCount: result.startedFrom,
+      totalUpdatedArguments: result.updatedArguments,
+      totalUpdatedBeliefs: result.updatedBeliefs,
+      maxDepth: result.maxDepth,
     },
     description:
       'Full score propagation complete. All belief positivity and stabilityScore ' +

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -2,6 +2,7 @@ import { agentJson } from '@/lib/agent-api'
 import { authenticateAgentKey } from '@/lib/agent-auth'
 import { runIngest } from '@/lib/agent-ingest/ingest'
 import { AUDIT_LOCK_MESSAGE, FAILURE_MODES } from '@/lib/agent-ingest/contract'
+import { propagateBeliefScores } from '@/lib/propagate-belief-scores'
 
 /**
  * POST /api/v1/ingest — the show-your-work firewall.
@@ -38,6 +39,15 @@ export async function POST(request: Request) {
       },
       { status: result.status },
     )
+  }
+
+  // The engine's turn. Ingestion writes no scores (audit lock) — but the batch
+  // changed the graph, so the scoring engine now recomputes every conclusion
+  // that depends on it: each new claim's edge impact, its parents' nets, and
+  // so on upward. Post evidence → every dependent conclusion updates.
+  const changedBeliefIds = [...new Set(result.claims.map((c) => c.beliefId))]
+  for (const beliefId of changedBeliefIds) {
+    await propagateBeliefScores(beliefId)
   }
 
   return agentJson(

--- a/src/app/api/v1/suggestions/[id]/accept/route.ts
+++ b/src/app/api/v1/suggestions/[id]/accept/route.ts
@@ -3,6 +3,7 @@ import { agentJson } from '@/lib/agent-api'
 import { authenticateAgentKey } from '@/lib/agent-auth'
 import { validateEvidenceInput } from '@/lib/agent-ingest/validate-claim'
 import { isGraphFrozen, GRAPH_FREEZE_MESSAGE } from '@/lib/markets/epoch'
+import { propagateBeliefScores } from '@/lib/propagate-belief-scores'
 
 /**
  * Explicit acceptance turns a suggestion into an Evidence row, through the
@@ -94,6 +95,10 @@ export async function POST(
     })
     return created
   })
+
+  // New evidence changed the belief's ledger — recompute its score and every
+  // conclusion upstream of it. The acceptance wrote no scores; the engine does.
+  await propagateBeliefScores(suggestion.beliefId)
 
   return agentJson({ evidence, beliefSlug: suggestion.belief.slug }, { status: 201 })
 }

--- a/src/app/arguments/[id]/linkage/page.tsx
+++ b/src/app/arguments/[id]/linkage/page.tsx
@@ -520,7 +520,7 @@ export default async function LinkagePage({ params }: PageProps) {
                 [X argument score] × [linkage score] — computed from{' '}
               </span>
             )}
-            {' '}<Link href="/Argument%20scores%20from%20sub-argument%20scores" className="text-[var(--accent)] hover:underline text-xs">
+            {' '}<Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline text-xs">
               sub-argument scores
             </Link>
           </p>
@@ -596,7 +596,7 @@ export default async function LinkagePage({ params }: PageProps) {
             has its own argument score; the Linkage Score for this page is the net aggregate of the
             two sides, (Agree total minus Disagree total) divided by (Agree total plus Disagree
             total), computed by the engine. The engine docs are canonical for the math. See{' '}
-            <Link href="/Argument%20scores%20from%20sub-argument%20scores" className="text-[var(--accent)] hover:underline">
+            <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">
               Argument Scores from Sub-Argument Scores
             </Link>.
           </p>
@@ -827,7 +827,7 @@ export default async function LinkagePage({ params }: PageProps) {
             conclusions it does not support. The wrong-parent failure mode is exactly this pattern.
             Each bias risk is a claim about this linkage&apos;s editors and evidence, scored like
             any other. See the{' '}
-            <Link href="/bias" className="text-[var(--accent)] hover:underline">Bias page</Link>.
+            Bias page.
           </p>
           <TwoSidedScoredTable
             leftHeader="Biases that inflate this linkage score"
@@ -861,7 +861,7 @@ export default async function LinkagePage({ params }: PageProps) {
               <strong>Contribution to parent:</strong> An argument&apos;s effect on its parent claim
               equals Argument Score × Linkage Score. A perfect argument with a 0.3 linkage
               contributes less than a moderate argument with a 0.9 linkage. See{' '}
-              <Link href="/Argument%20scores%20from%20sub-argument%20scores" className="text-[var(--accent)] hover:underline">
+              <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">
                 Argument scores from sub-argument scores
               </Link>.
             </p>

--- a/src/app/arguments/[id]/score/page.tsx
+++ b/src/app/arguments/[id]/score/page.tsx
@@ -1,0 +1,295 @@
+/**
+ * Score Provenance Page — the derivation of one argument edge's Impact,
+ * factor by factor. Every Impact value on a belief page links here.
+ *
+ * Impact = sign × Truth × |Linkage| × Importance × Uniqueness × 100
+ *
+ * Each factor is itself a doorway into the sub-debate that produced it:
+ * Truth is the child belief's own tree (click through to argue it), Linkage
+ * has its own debate page, Importance is sourced from a dedicated sub-belief
+ * when one exists, and Uniqueness shows exactly which earlier same-side
+ * arguments this one overlaps. Nothing on this page is hand-assigned — it is
+ * a read-only audit of engine output (Rule 6), and the way to change any
+ * number is to win the sub-debate behind it.
+ *
+ * Route: /arguments/[id]/score
+ */
+
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+import { computeArgumentImpactScore } from '@/core/scoring/scoring-engine'
+import { mechanicalSimilarity } from '@/core/scoring/duplication-scoring'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center font-mono text-sm'
+
+function fmt(v: number | null | undefined, digits = 2): string {
+  if (v == null) return ''
+  return v.toFixed(digits)
+}
+
+export default async function ArgumentScorePage({ params }: PageProps) {
+  const { id } = await params
+  const argumentId = Number(id)
+  if (!Number.isInteger(argumentId)) notFound()
+
+  const argument = await prisma.argument.findUnique({
+    where: { id: argumentId },
+    include: {
+      parentBelief: { select: { id: true, slug: true, statement: true } },
+      belief: { select: { id: true, slug: true, statement: true, positivity: true } },
+      importanceBelief: { select: { id: true, slug: true, statement: true } },
+      linkageArguments: { select: { id: true } },
+    },
+  })
+  if (!argument) notFound()
+
+  // The uniqueness trace: which earlier same-side siblings does this argument
+  // overlap, and by how much? Recomputed live with the same similarity the
+  // engine uses, so the audit always matches the method.
+  const siblings = await prisma.argument.findMany({
+    where: {
+      parentBeliefId: argument.parentBeliefId,
+      side: argument.side,
+      status: 'published',
+    },
+    orderBy: { createdAt: 'asc' },
+    select: {
+      id: true,
+      claim: true,
+      createdAt: true,
+      belief: { select: { slug: true, statement: true } },
+    },
+  })
+  const ownIndex = siblings.findIndex((s) => s.id === argument.id)
+  const ownText =
+    argument.claim ?? argument.belief.statement
+  const earlier = ownIndex >= 0 ? siblings.slice(0, ownIndex) : []
+  const overlaps = earlier
+    .map((s) => ({
+      id: s.id,
+      label: s.claim ?? s.belief.statement,
+      slug: s.belief.slug,
+      similarity: mechanicalSimilarity(ownText, s.claim ?? s.belief.statement),
+    }))
+    .sort((a, b) => b.similarity - a.similarity)
+
+  const truth = argument.argumentScore != null ? argument.argumentScore / 100 : null
+  const uniqueness = argument.uniquenessScore
+  const sign = argument.side === 'agree' ? 1 : -1
+
+  // Recompute the product from the stored factors so drift is visible.
+  const recomputed =
+    truth != null
+      ? computeArgumentImpactScore(
+          argument.side,
+          truth,
+          argument.linkageScore,
+          argument.importanceScore,
+          uniqueness ?? 1,
+        )
+      : null
+  const drifted = recomputed != null && Math.abs(recomputed - argument.impactScore) > 0.05
+
+  const label = argument.claim ?? argument.belief.statement
+
+  return (
+    <div className="max-w-[960px] mx-auto px-4 py-8">
+      <nav className="text-sm text-[var(--muted-foreground)] mb-6">
+        <Link href="/beliefs" className="text-[var(--accent)] hover:underline">Beliefs</Link>
+        {' › '}
+        <Link href={`/beliefs/${argument.parentBelief.slug}`} className="text-[var(--accent)] hover:underline">
+          {argument.parentBelief.statement}
+        </Link>
+        {' › '}
+        <span>Impact provenance</span>
+      </nav>
+
+      <h1 className="text-2xl font-bold mb-2">How this impact was computed</h1>
+      <p className="text-sm text-[var(--muted-foreground)] mb-6">
+        The {argument.side === 'agree' ? 'reason to agree' : 'reason to disagree'}{' '}
+        &ldquo;{label}&rdquo; contributes{' '}
+        <strong className="font-mono">
+          {argument.impactScore >= 0 ? '+' : ''}{argument.impactScore.toFixed(1)}
+        </strong>{' '}
+        to{' '}
+        <Link href={`/beliefs/${argument.parentBelief.slug}`} className="text-[var(--accent)] hover:underline">
+          {argument.parentBelief.statement}
+        </Link>
+        . Every factor below is a doorway: click it to enter the sub-debate that
+        produced it, post evidence there, and this number — and every conclusion
+        that depends on it — updates.
+      </p>
+
+      <div className="overflow-x-auto mb-6">
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr>
+              <th className={TH}>Factor</th>
+              <th className={`${TH} text-center w-[12%]`}>Value</th>
+              <th className={TH}>Where it comes from</th>
+              <th className={`${TH} w-[24%]`}>Argue with it</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className={TD}><strong>Truth</strong> (Argument Score)</td>
+              <td className={TDC}>{truth != null ? fmt(truth) : ''}</td>
+              <td className={TD}>
+                The child belief&apos;s own tree score: how well &ldquo;{argument.belief.statement}&rdquo;
+                holds up against its own reasons to agree and disagree.
+                {truth == null && (
+                  <span className="italic text-[var(--muted-foreground)]">
+                    {' '}Not yet computed — the engine fills this on the next propagation pass.
+                  </span>
+                )}
+              </td>
+              <td className={TD}>
+                <Link href={`/beliefs/${argument.belief.slug}`} className="text-[var(--accent)] hover:underline">
+                  Open the sub-debate
+                </Link>
+              </td>
+            </tr>
+            <tr>
+              <td className={TD}><strong>Linkage</strong></td>
+              <td className={TDC}>{fmt(argument.linkageScore)}</td>
+              <td className={TD}>
+                If the argument were true, how much would it actually support the
+                conclusion? Computed from this edge&apos;s own linkage debate
+                ({argument.linkageArguments.length} linkage argument{argument.linkageArguments.length === 1 ? '' : 's'} so far).
+              </td>
+              <td className={TD}>
+                <Link href={`/arguments/${argument.id}/linkage`} className="text-[var(--accent)] hover:underline">
+                  Debate this linkage
+                </Link>
+              </td>
+            </tr>
+            <tr>
+              <td className={TD}><strong>Importance</strong></td>
+              <td className={TDC}>{fmt(argument.importanceScore)}</td>
+              <td className={TD}>
+                {argument.importanceBelief ? (
+                  <>
+                    Derived from the net score of the dedicated importance sub-belief
+                    &ldquo;{argument.importanceBelief.statement}&rdquo; — the live debate
+                    about whether this argument matters.
+                  </>
+                ) : (
+                  <>
+                    Placement-time weight. No importance sub-belief is attached yet, so
+                    this factor is not yet debatable — attaching one turns it into a
+                    live sub-debate.
+                  </>
+                )}
+              </td>
+              <td className={TD}>
+                {argument.importanceBelief ? (
+                  <Link href={`/beliefs/${argument.importanceBelief.slug}`} className="text-[var(--accent)] hover:underline">
+                    Open the importance debate
+                  </Link>
+                ) : (
+                  <Link href="/algorithms/importance-score" className="text-[var(--accent)] hover:underline">
+                    How importance works
+                  </Link>
+                )}
+              </td>
+            </tr>
+            <tr>
+              <td className={TD}><strong>Uniqueness</strong></td>
+              <td className={TDC}>{fmt(uniqueness)}</td>
+              <td className={TD}>
+                How much new signal this argument adds versus the {argument.side === 'agree' ? 'agree' : 'disagree'}-side
+                arguments that were there first. A 90% restatement contributes ~10% of
+                its weight — nobody wins by making one point five different ways.
+                {uniqueness == null && (
+                  <span className="italic text-[var(--muted-foreground)]">
+                    {' '}Not yet computed — the engine fills this on the next propagation pass.
+                  </span>
+                )}
+              </td>
+              <td className={TD}>
+                <Link href="/algorithms/unique-scores" className="text-[var(--accent)] hover:underline">
+                  How uniqueness works
+                </Link>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div className="text-sm p-3 bg-gray-100 border border-gray-300 mb-8 font-mono">
+        Impact = {sign > 0 ? '+1' : '−1'} × {truth != null ? fmt(truth) : 'truth'} ×{' '}
+        {fmt(Math.abs(argument.linkageScore))} × {fmt(argument.importanceScore)} ×{' '}
+        {uniqueness != null ? fmt(uniqueness) : '1.00'} × 100 ={' '}
+        <strong>{recomputed != null ? `${recomputed >= 0 ? '+' : ''}${recomputed.toFixed(1)}` : '[pending]'}</strong>
+        {drifted && (
+          <span className="block mt-1 not-italic font-sans text-[var(--muted-foreground)]">
+            Stored impact is {argument.impactScore.toFixed(1)} — the graph changed since the
+            last engine pass; the next propagation reconciles them.
+          </span>
+        )}
+      </div>
+
+      <h2 className="text-lg font-bold mb-2">Uniqueness trace</h2>
+      {earlier.length === 0 ? (
+        <p className="text-sm text-[var(--muted-foreground)] mb-8">
+          This is the earliest {argument.side === 'agree' ? 'agree' : 'disagree'}-side argument on
+          its parent — there is nothing before it to overlap, so it keeps full credit.
+        </p>
+      ) : (
+        <div className="overflow-x-auto mb-8">
+          <table className="w-full border-collapse border border-gray-300 text-sm">
+            <thead>
+              <tr>
+                <th className={TH}>Earlier same-side argument</th>
+                <th className={`${TH} text-center w-[16%]`}>Similarity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {overlaps.map((o) => (
+                <tr key={o.id}>
+                  <td className={TD}>
+                    <Link href={`/beliefs/${o.slug}`} className="text-[var(--accent)] hover:underline">
+                      {o.label}
+                    </Link>
+                  </td>
+                  <td className={TDC}>{Math.round(o.similarity * 100)}%</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="text-xs text-[var(--muted-foreground)] mt-2">
+            Uniqueness = 1 − the highest similarity above. The earliest statement of a
+            point keeps full credit; later restatements are discounted.
+          </p>
+        </div>
+      )}
+
+      <div className="text-sm p-3 border border-gray-300 bg-gray-50">
+        <p className="font-semibold mb-1">Challenge a number</p>
+        <p>
+          Scores on this page are engine output, never hand-assigned. To move one:
+          add a reason on the{' '}
+          <Link href={`/beliefs/${argument.belief.slug}`} className="text-[var(--accent)] hover:underline">
+            child belief&apos;s page
+          </Link>
+          , post a linkage argument on{' '}
+          <Link href={`/arguments/${argument.id}/linkage`} className="text-[var(--accent)] hover:underline">
+            the linkage page
+          </Link>
+          , or read{' '}
+          <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">
+            how the ranking works
+          </Link>
+          .
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/beliefs/[slug]/page.tsx
+++ b/src/app/beliefs/[slug]/page.tsx
@@ -238,8 +238,13 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
 
           <hr className="border-gray-200" />
 
-          {/* 14. Contribute / footer */}
-          <ContributeSection />
+          {/* 14. Contribute / footer — the add-a-row move, with speed bumps on
+              high-stakes beliefs (steelman acknowledgment + principle check). */}
+          <ContributeSection
+            beliefId={belief.id}
+            highStakes={belief.highStakes ?? false}
+            arguments={belief.arguments}
+          />
         </div>
       </main>
     </div>

--- a/src/app/beliefs/[slug]/page.tsx
+++ b/src/app/beliefs/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { fetchBeliefBySlug, computeBeliefScores } from '@/features/belief-analysis/data/fetch-belief'
+import { computeConflictReadout, deriveCbaItems } from '@/features/belief-analysis/lib/conflict-pipeline'
 import ScorecardSection from '@/features/belief-analysis/components/ScorecardSection'
 import ArgumentTreesSection from '@/features/belief-analysis/components/ArgumentTreesSection'
 import ContrastClassSection from '@/features/belief-analysis/components/ContrastClassSection'
@@ -47,6 +48,15 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
   const related = splitList(belief.relatedBeliefs)
   const supports = splitList(belief.supportsBeliefs)
   const category = belief.category || 'Uncategorized'
+
+  // The conflict-resolution pipeline reads the scored rows sideways; the CBA
+  // rows get their likelihood derived from each claim's own belief tree.
+  const derivedCbaItems = deriveCbaItems(belief.costBenefitItems ?? [])
+  const conflictReadout = computeConflictReadout(
+    belief.interestEntries,
+    belief.valueRankings,
+    belief.costBenefitItems ?? [],
+  )
 
   return (
     <div className="min-h-screen bg-white">
@@ -112,6 +122,7 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
             bottomLine={belief.bottomLine ?? null}
             scoreMover={belief.scoreMover ?? null}
             falsifiabilityItems={belief.falsifiabilityItems ?? []}
+            scores={scores}
           />
 
           <hr className="border-gray-200" />
@@ -149,6 +160,7 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
             disputeTypes={belief.disputeTypes}
             obstacles={belief.obstacles}
             interestsDashboardHref={`/beliefs/${belief.slug}/interests`}
+            readout={conflictReadout}
           />
 
           <hr className="border-gray-200" />
@@ -181,7 +193,7 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
           {/* 7. Cost-Benefit Analysis (+ Short/Long-Term + Best Compromise Solutions) */}
           <CostBenefitSection
             cba={belief.costBenefitAnalysis}
-            items={belief.costBenefitItems ?? []}
+            items={derivedCbaItems}
             impact={belief.impactAnalysis}
             impactEntries={belief.impactEntries ?? []}
             compromises={belief.compromises}

--- a/src/app/beliefs/[slug]/page.tsx
+++ b/src/app/beliefs/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { fetchBeliefBySlug, computeBeliefScores } from '@/features/belief-analysis/data/fetch-belief'
 import ArgumentTreesSection from '@/features/belief-analysis/components/ArgumentTreesSection'
+import ContrastClassSection from '@/features/belief-analysis/components/ContrastClassSection'
 import EvidenceSection from '@/features/belief-analysis/components/EvidenceSection'
 import ConflictResolutionSection from '@/features/belief-analysis/components/ConflictResolutionSection'
 import ObjectiveCriteriaSection from '@/features/belief-analysis/components/ObjectiveCriteriaSection'
@@ -109,6 +110,14 @@ export default async function BeliefAnalysisPage({ params }: BeliefPageProps) {
             totalCon={scores.totalCon}
             netInterpretation={belief.netInterpretation}
           />
+
+          {belief.contrastClass && belief.contrastClass.options.length > 0 && (
+            <>
+              <hr className="border-gray-200" />
+              {/* The denominator, made visible — rivals this belief is priced against. */}
+              <ContrastClassSection contrastClass={belief.contrastClass} />
+            </>
+          )}
 
           <hr className="border-gray-200" />
 

--- a/src/app/beliefs/set-aside-distractions-for-real-solutions/page.tsx
+++ b/src/app/beliefs/set-aside-distractions-for-real-solutions/page.tsx
@@ -65,7 +65,7 @@ export default async function DistractionsBeliefPage() {
           <div className="text-right space-y-1">
             <p className="text-sm">
               <Link
-                href="/One%20Page%20Per%20Topic"
+                href="/how-it-works"
                 className="text-[var(--accent)] hover:underline"
               >
                 Topic
@@ -79,7 +79,7 @@ export default async function DistractionsBeliefPage() {
             <p className="text-sm">
               Belief{' '}
               <Link
-                href="/beliefs%20grouped%20and%20eventually%20sorted%20along%20the%20the%20positivity%20continuum"
+                href="/beliefs"
                 className="text-[var(--accent)] hover:underline"
               >
                 Positivity
@@ -138,18 +138,18 @@ export default async function DistractionsBeliefPage() {
           </p>
           <p>
             Distraction isn&apos;t just inefficient here. It&apos;s structurally blocked.{' '}
-            <Link href="/Scoring" className="text-[var(--accent)] hover:underline">
+            <Link href="/algorithms" className="text-[var(--accent)] hover:underline">
               Truth Scores
             </Link>{' '}
             don&apos;t respond to charisma.{' '}
             <Link
-              href="/cost-benefit%20analysis"
+              href="/cba/about"
               className="text-[var(--accent)] hover:underline"
             >
               Cost-Benefit Analysis
             </Link>{' '}
             doesn&apos;t care who&apos;s more entertaining.{' '}
-            <Link href="/ReasonRank" className="text-[var(--accent)] hover:underline">
+            <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">
               ReasonRank
             </Link>{' '}
             rewards evidence, not outrage.
@@ -195,7 +195,7 @@ export default async function DistractionsBeliefPage() {
           <div>
             <h1 className="text-2xl font-bold text-[var(--foreground)] mb-6">
               <Link
-                href="/automate%20conflict%20resolution"
+                href="/how-it-works"
                 className="text-[var(--accent)] hover:underline"
               >
                 Conflict Resolution
@@ -266,7 +266,7 @@ export default async function DistractionsBeliefPage() {
             <p className="text-lg font-bold">
               Score:{' '}
               <Link
-                href="/Argument%20scores%20from%20sub-argument%20scores"
+                href="/algorithms/reason-rank"
                 className="text-[var(--accent)] hover:underline"
               >
                 {scores.overallScore >= 0 ? '+' : ''}

--- a/src/app/candidate-evaluation/page.tsx
+++ b/src/app/candidate-evaluation/page.tsx
@@ -198,22 +198,22 @@ export default function CandidateEvaluationPage() {
               </code>{' '}
               and instantly inherits the same structural template every belief on the platform
               uses:{' '}
-              <Link href="/Argument%20Trees" className="text-[var(--accent)] hover:underline">Argument Trees</Link>,{' '}
-              <Link href="/Evidence%20Scoring" className="text-[var(--accent)] hover:underline">Evidence Scoring</Link>,{' '}
+              <Link href="/how-it-works" className="text-[var(--accent)] hover:underline">Argument Trees</Link>,{' '}
+              <Link href="/algorithms/evidence-scores" className="text-[var(--accent)] hover:underline">Evidence Scoring</Link>,{' '}
               <Link
-                href="/w/page/159351732/Objective%20criteria%20scores"
+                href="/algorithms/objective-criteria"
                 className="text-[var(--accent)] hover:underline"
               >
                 Objective Criteria weighting
               </Link>,{' '}
               <Link
-                href="/w/page/156187122/cost-benefit%20analysis"
+                href="/cba/about"
                 className="text-[var(--accent)] hover:underline"
               >
                 Cost-Benefit Analysis
               </Link>, and{' '}
               <Link
-                href="/w/page/156186840/automate%20conflict%20resolution"
+                href="/how-it-works"
                 className="text-[var(--accent)] hover:underline"
               >
                 Conflict Resolution mapping
@@ -260,7 +260,7 @@ export default function CandidateEvaluationPage() {
             Before any candidate&apos;s belief page exists, the office node (e.g.,{' '}
             <em>Colorado → Senate</em>) already contains a scored, community-built set of{' '}
             <Link
-              href="/w/page/159351732/Objective%20criteria%20scores"
+              href="/algorithms/objective-criteria"
               className="text-[var(--accent)] hover:underline"
             >
               Objective Criteria
@@ -298,7 +298,7 @@ export default function CandidateEvaluationPage() {
                   </th>
                   <th className="px-3 py-2 text-center font-semibold w-[16%]">
                     <Link
-                      href="/Linkage%20Scores"
+                      href="/algorithms/linkage-scores"
                       className="text-[var(--accent)] hover:underline"
                     >
                       Linkage
@@ -432,7 +432,7 @@ export default function CandidateEvaluationPage() {
               <li>Sub-arguments adjust the Truth Score of their parent argument — recursively.</li>
               <li>
                 The final{' '}
-                <Link href="/Scoring" className="text-[var(--accent)] hover:underline">
+                <Link href="/algorithms" className="text-[var(--accent)] hover:underline">
                   Belief Score
                 </Link>{' '}
                 is the sum of all propagated impacts.
@@ -467,7 +467,7 @@ export default function CandidateEvaluationPage() {
             <p className="text-sm">
               Belief{' '}
               <Link
-                href="/beliefs%20grouped%20and%20eventually%20sorted%20along%20the%20the%20positivity%20continuum"
+                href="/beliefs"
                 className="text-[var(--accent)] hover:underline"
               >
                 Positivity
@@ -492,7 +492,7 @@ export default function CandidateEvaluationPage() {
                   </th>
                   <th className="px-3 py-2 text-center w-[14%] font-semibold">Arg Score</th>
                   <th className="px-3 py-2 text-center w-[18%] font-semibold">
-                    <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">
+                    <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">
                       Linkage
                     </Link>
                   </th>
@@ -533,7 +533,7 @@ export default function CandidateEvaluationPage() {
                   </th>
                   <th className="px-3 py-2 text-center w-[14%] font-semibold">Arg Score</th>
                   <th className="px-3 py-2 text-center w-[18%] font-semibold">
-                    <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">
+                    <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">
                       Linkage
                     </Link>
                   </th>
@@ -578,7 +578,7 @@ export default function CandidateEvaluationPage() {
           <div className="mt-6 text-right space-y-1">
             <p className="text-lg font-bold">
               Score:{' '}
-              <Link href="/Argument%20scores%20from%20sub-argument%20scores" className="text-[var(--accent)] hover:underline">
+              <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">
                 {(totalPro + totalCon) >= 0 ? '+' : ''}
                 {(totalPro + totalCon).toFixed(1)}
               </Link>{' '}
@@ -695,7 +695,7 @@ export default function CandidateEvaluationPage() {
           </p>
           <div className="flex gap-4 flex-wrap">
             <Link
-              href="/w/page/160433328/Contact%20Me"
+              href="/contact"
               className="text-[var(--accent)] hover:underline"
             >
               Contact the maintainer
@@ -708,7 +708,7 @@ export default function CandidateEvaluationPage() {
             >
               GitHub repository
             </a>
-            <Link href="/Argument%20Trees" className="text-[var(--accent)] hover:underline">
+            <Link href="/how-it-works" className="text-[var(--accent)] hover:underline">
               How Argument Trees work
             </Link>
           </div>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Contact — Idea Stock Exchange',
+  description: 'How to reach the founder and contribute to the Idea Stock Exchange.',
+}
+
+export default function ContactPage() {
+  return (
+    <div className="max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]">
+      <p className="text-right text-sm italic text-gray-600 mb-6">
+        <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+        {' > '}
+        <strong>Contact</strong>
+      </p>
+      <h1 className="text-3xl font-bold mb-3">Contact</h1>
+      <p className="mb-4">
+        The Idea Stock Exchange is built by{' '}
+        <a
+          href="https://github.com/myklob"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-700 hover:underline"
+        >
+          Mike Laub (myklob)
+        </a>
+        . The fastest way to reach the project:
+      </p>
+      <ul className="list-disc ml-6 mb-4 space-y-1">
+        <li>
+          <a
+            href="https://github.com/myklob/ideastockexchange/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-700 hover:underline"
+          >
+            Open an issue on GitHub
+          </a>{' '}
+          — bugs, feature ideas, or questions about the method.
+        </li>
+        <li>
+          <a
+            href="https://github.com/myklob/ideastockexchange"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-700 hover:underline"
+          >
+            Contribute code or arguments via the repository
+          </a>
+          .
+        </li>
+        <li>
+          Add a reason directly on any{' '}
+          <Link href="/beliefs" className="text-blue-700 hover:underline">belief page</Link> —
+          well-formed pro and con arguments are the contribution the project needs most.
+        </li>
+      </ul>
+      <p className="text-sm text-gray-600">
+        New here? Start with{' '}
+        <Link href="/how-it-works" className="text-blue-700 hover:underline">how it works</Link>.
+      </p>
+    </div>
+  )
+}

--- a/src/app/equivalence/[slug]/page.tsx
+++ b/src/app/equivalence/[slug]/page.tsx
@@ -60,7 +60,7 @@ export default async function EquivalencePage({ params }: EquivalencePageProps) 
           <h1 className="text-2xl font-bold mb-1">Belief Equivalence Scorecard</h1>
           <p className="text-sm text-[var(--muted-foreground)]">
             This scorecard determines whether two beliefs should be merged, linked, or kept separate
-            using the 17-step <Link href="/Belief%20Equivalence%20Engine" className="text-[var(--accent)] hover:underline">Belief Equivalence Engine</Link> pipeline.
+            using the 17-step <Link href="/algorithms/belief-equivalency" className="text-[var(--accent)] hover:underline">Belief Equivalence Engine</Link> pipeline.
           </p>
         </div>
 

--- a/src/app/how-it-works/page.tsx
+++ b/src/app/how-it-works/page.tsx
@@ -1,0 +1,379 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { prisma } from '@/lib/prisma'
+
+export const metadata: Metadata = {
+  title: 'How It Works — The Engine of Reason — Idea Stock Exchange',
+  description:
+    'How structured argument, evidence-weighted ranking, and one permanent page per idea turn scattered opinion into cumulative knowledge.',
+}
+
+export const dynamic = 'force-dynamic'
+
+const container = 'max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]'
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold bg-gray-100'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+
+interface LiveExample {
+  slug: string
+  statement: string
+  net: number
+  topClaim: string
+  topImpact: number
+}
+
+/** A live engine readout for the status box — the placeholders became scores. */
+async function liveExample(): Promise<LiveExample | null> {
+  try {
+    const belief = await prisma.belief.findUnique({
+      where: { slug: 'universal-basic-income-should-be-implemented' },
+      select: {
+        slug: true,
+        statement: true,
+        positivity: true,
+        arguments: {
+          where: { status: 'published' },
+          orderBy: { impactScore: 'desc' },
+          take: 1,
+          select: { claim: true, impactScore: true, belief: { select: { statement: true } } },
+        },
+      },
+    })
+    if (!belief || belief.arguments.length === 0) return null
+    const top = belief.arguments[0]
+    return {
+      slug: belief.slug,
+      statement: belief.statement,
+      net: belief.positivity,
+      topClaim: top.claim ?? top.belief.statement,
+      topImpact: top.impactScore,
+    }
+  } catch {
+    return null
+  }
+}
+
+export default async function HowItWorksPage() {
+  const example = await liveExample()
+
+  return (
+    <div className={container}>
+      <p className="text-right text-sm italic text-gray-600 mb-6">
+        <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+        {' › '}
+        <Link href="/beliefs" className="text-blue-700 hover:underline">Topics</Link>
+        {' › '}
+        <strong>How It Works</strong>
+      </p>
+
+      <h1 className="text-3xl font-bold mb-2">The Engine of Reason: How the Idea Stock Exchange Works</h1>
+      <p className="text-lg text-gray-600 mb-6">
+        How structured argument, evidence-weighted ranking, and one permanent page per idea turn
+        scattered opinion into cumulative knowledge.
+      </p>
+
+      <div className="bg-gray-50 border-l-4 border-gray-500 px-4 py-3 mb-5">
+        <p>
+          <strong>Where this stands, honestly.</strong> The method on this page is real and the
+          site you are reading runs it. The scoring engine computes every number: each
+          argument&apos;s impact is sign &times; truth &times; linkage &times; importance &times;
+          uniqueness, recursively, and posting new content propagates through every dependent
+          conclusion automatically. Every score is clickable — the click-into-the-score
+          interaction this page used to promise is live, as are the conflict-resolution pipeline
+          and the posting speed bumps on high-stakes beliefs.{' '}
+          {example ? (
+            <>
+              For instance, right now the engine scores{' '}
+              <Link href={`/beliefs/${example.slug}`} className="text-blue-700 hover:underline">
+                {example.statement}
+              </Link>{' '}
+              at a net of <strong>{example.net >= 0 ? '+' : ''}{example.net.toFixed(1)}</strong>,
+              led by &ldquo;{example.topClaim}&rdquo; (impact{' '}
+              {example.topImpact >= 0 ? '+' : ''}{example.topImpact.toFixed(1)}) — live output,
+              not a bracketed placeholder.
+            </>
+          ) : (
+            <>
+              Numbers on belief pages are engine output, not hand-typed placeholders; seed the
+              database to see live examples.
+            </>
+          )}{' '}
+          What remains early is scale: the graph is young, and a young graph&apos;s scores are
+          only as good as the arguments on it. We do not pretend otherwise.
+        </p>
+      </div>
+
+      <div className="bg-gray-50 border-l-4 border-gray-300 px-4 py-3 mb-6 italic">
+        <p>
+          &ldquo;No concept you form is valid unless you integrate it without contradiction into
+          the sum of human knowledge.&rdquo; A modified version of a line from Ayn Rand, and as
+          good a one-sentence statement of the whole project as any.
+        </p>
+      </div>
+
+      <hr className="my-8" />
+
+      <h2 className="text-2xl font-bold mb-3">1. The Core Problem: The Chaos of Threads</h2>
+      <p className="mb-4">
+        The flaw in the modern internet is not that people are stupid. It is structural. Bad
+        arguments are never actually defeated, they just move to a new thread. Because every
+        discussion lives on its own disconnected page, humanity has no long-term memory for
+        debate. We refute the same nonsense every morning, forever, like a civilization with
+        amnesia.
+      </p>
+      <div className="overflow-x-auto mb-4">
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr>
+              <th className={TH}>Format</th>
+              <th className={TH}>Structural Flaw</th>
+              <th className={TH}>Result</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className={TD}>Forums and social media</td>
+              <td className={TD}>Topic drift. Anyone can change the subject in one reply. It is a car with fifty steering wheels.</td>
+              <td className={TD}>Endless noise, no resolution.</td>
+            </tr>
+            <tr>
+              <td className={TD}>Chat rooms</td>
+              <td className={TD}>Amnesia. The discussion resets to zero every time someone new walks in.</td>
+              <td className={TD}>The same arguments, repeated forever.</td>
+            </tr>
+            <tr>
+              <td className={TD}>News media</td>
+              <td className={TD}>Fragmentation. Information is siloed to manufacture conflict, not to resolve it.</td>
+              <td className={TD}>Echo chambers and polarization.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p className="mb-4">
+        The fix is almost boringly simple to state. There should be{' '}
+        <Link href="/beliefs" className="text-blue-700 hover:underline">one page per topic</Link>.
+        When an argument is debunked there, it stays debunked, and the next person who shows up
+        starts from the current state of the evidence instead of from scratch.
+      </p>
+
+      <hr className="my-8" />
+
+      <h2 className="text-2xl font-bold mb-3">2. The Solution: Structured Argumentation</h2>
+      <p className="mb-4">
+        The Idea Stock Exchange replaces the linear thread with a recursive argument tree.
+        Instead of a comment box where remarks pile up and scroll away, every belief has a
+        structured page, and you contribute by acting on its logic directly rather than talking
+        near it.
+      </p>
+      <p className="mb-4">
+        That means two kinds of moves. You <strong>add a row</strong> — a new reason to agree or
+        disagree, through the form on every belief page. Or you{' '}
+        <strong>challenge a number</strong>. Every score on the page, including{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">linkage</Link>,{' '}
+        <Link href="/algorithms/objective-criteria" className="text-blue-700 hover:underline">objective criteria</Link>, and{' '}
+        <Link href="/algorithms/importance-score" className="text-blue-700 hover:underline">importance</Link>, is a
+        doorway. Click it and you drop into the sub-debate that produced it, where you post
+        evidence that strengthens or weakens the claim, and every conclusion that depends on it
+        updates. The impact value on each argument row opens a provenance page showing the full
+        factor-by-factor derivation — truth, linkage, importance, uniqueness — each factor
+        itself a door.
+      </p>
+
+      <hr className="my-8" />
+
+      <h2 className="text-2xl font-bold mb-3">3. The Database: A Family Tree of Ideas</h2>
+      <p className="mb-4">
+        Under the hood, the structure is a genealogy chart, except it tracks logic instead of
+        people. Arguments are parents that combine to support a conclusion. Those conclusions
+        become parents in turn, premises for larger ideas built on top of them. The link between
+        any two of them is not a bare hyperlink, it carries a{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">linkage score</Link>{' '}
+        that says whether this is a reason to agree or a reason to disagree, and how strongly.
+      </p>
+      <p className="mb-4">
+        Call it the turtle stack. A child has parents, and those parents have parents, and every
+        argument on the exchange is itself a full belief page with its own pros and cons. You can
+        drill down as far as you want until you hit raw evidence at the bottom. There is no
+        hardcoded floor, on purpose.
+      </p>
+
+      <hr className="my-8" />
+
+      <h2 className="text-2xl font-bold mb-3">
+        4. The Ranking:{' '}
+        <Link href="/algorithms/reason-rank" className="text-blue-700 hover:underline">ReasonRank</Link>
+      </h2>
+      <p className="mb-4">
+        How do we know which side is winning? Not by counting upvotes, because a vote measures
+        how many people showed up, not whether they are right. ReasonRank weighs the evidence
+        instead. It is the same insight that made PageRank beat keyword-counting for web search,
+        pointed at arguments: a claim is strong when strong claims support it, recursively, all
+        the way down to evidence.
+      </p>
+      <div className="bg-gray-50 border-l-4 border-gray-300 px-4 py-3 mb-4">
+        <p className="font-mono text-sm">
+          Conclusion Score = &sum;(Agree Arguments &times; Linkage &times; Uniqueness) &minus;
+          &sum;(Disagree Arguments &times; Linkage &times; Uniqueness)
+        </p>
+      </div>
+      <p className="mb-4">
+        That is the readable summary. The exact per-edge formula the engine runs is sign &times;
+        truth &times; |linkage| &times; importance &times; uniqueness &times; 100, and the full
+        recursive definition with normalization and the twelve score dimensions lives on the{' '}
+        <Link href="/algorithms/reason-rank" className="text-blue-700 hover:underline">ReasonRank</Link>{' '}
+        page and the{' '}
+        <Link href="/algorithms" className="text-blue-700 hover:underline">algorithms index</Link>.
+        Two terms are worth a sentence here:
+      </p>
+      <div className="overflow-x-auto mb-4">
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr>
+              <th className={`${TH} w-[22%]`}>Term</th>
+              <th className={TH}>In one sentence</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className={TD}>
+                <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">Linkage</Link>
+              </td>
+              <td className={TD}>
+                If the argument were true, how much would it actually support the conclusion? A
+                true but irrelevant fact has a linkage near zero and therefore contributes
+                nothing, no matter how loudly it is stated.
+              </td>
+            </tr>
+            <tr>
+              <td className={TD}>
+                <Link href="/algorithms/unique-scores" className="text-blue-700 hover:underline">Uniqueness</Link>
+              </td>
+              <td className={TD}>
+                How much new signal does this argument add versus ones already on the page? If it
+                is ninety percent a restatement of an existing point, it contributes about ten
+                percent of its score. Nobody wins by making one point five different ways.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3 className="text-xl font-bold mb-2">A worked illustration: should we have joined World War II?</h3>
+      <p className="mb-2">Consider two arguments for entering the war, both of which happen to be true.</p>
+      <ul className="list-disc ml-6 mb-4 space-y-1">
+        <li>
+          <strong>&ldquo;Nazi leaders were rude and unpleasant.&rdquo;</strong> True, and almost
+          irrelevant to a decision to go to war. Low linkage — with truth 1.0 but linkage 0.02,
+          the engine&apos;s formula yields an impact around <strong>+2</strong>.
+        </li>
+        <li>
+          <strong>&ldquo;Germany was carrying out systematic genocide.&rdquo;</strong> True,
+          highly relevant, backed by overwhelming evidence. High linkage — truth 1.0 at linkage
+          0.95 yields an impact around <strong>+95</strong>.
+        </li>
+      </ul>
+      <p className="mb-4">
+        The second argument dominates the first by structure, not by whoever repeats their point
+        most often. This is the same computation that runs on every live belief page — click any
+        impact value to see it worked for that argument.
+      </p>
+
+      <hr className="my-8" />
+
+      <h2 className="text-2xl font-bold mb-3">5. From Argument to Agreement: Conflict Resolution</h2>
+      <p className="mb-4">
+        Once beliefs are decomposed into scored trees, something useful falls out almost for
+        free. You can read the same trees sideways and turn a shouting match into a map. This
+        runs live through the{' '}
+        <Link href="/cba/about" className="text-blue-700 hover:underline">cost-benefit analysis</Link>{' '}
+        workflow, and it borrows its logic from Fisher and Ury&apos;s &ldquo;Getting to
+        Yes,&rdquo; run at internet scale.
+      </p>
+      <p className="mb-4">
+        Most debates get stuck on positions, the &ldquo;I want X&rdquo; surface. The exchange
+        pushes past that to interests, the &ldquo;I need X because of Y&rdquo; underneath,
+        because interests are where the overlap hides. Once both sides&apos; costs and benefits
+        are scored, the conflict resolution pipeline computes four things on every belief page:
+        the interests both sides actually share, the single primary conflict pair that is really
+        driving the disagreement, the genuine value conflicts where one side prices freedom and
+        the other prices safety, and the compromise candidates where a small achievable shift
+        would flip a category&apos;s net. That last one is the payoff. It points you at the
+        winnable disagreements instead of the symbolic ones.
+      </p>
+      <p className="mb-4">
+        The design also adds friction where it helps. For the highest-stakes fights, the posting
+        flow imposes speed bumps before your submission is accepted: acknowledge the strongest
+        point on the other side first — verified against the live ranking, not your word for it
+        — and check that your proposed solution is consistent with the moral principle you
+        claimed a paragraph ago. Both are enforced by the API, not just the interface.
+      </p>
+
+      <hr className="my-8" />
+
+      <h2 className="text-2xl font-bold mb-3">6. The Vision, Scoped Honestly</h2>
+      <p className="mb-4">
+        It is tempting to say we are building the collective consciousness of the internet. We
+        are not, and promising that would burn exactly the people we need. Here is the honest
+        version of the ambition, which is still large enough to be worth twenty years.
+      </p>
+      <p className="mb-4">
+        Wikipedia gave the world one shared, cumulative page for facts. The Idea Stock Exchange
+        aims to do the same thing for reasoning: one shared, cumulative, evidence-ranked page for
+        the arguments on each idea. That is a narrower claim than &ldquo;fix democracy,&rdquo;
+        and it is one the mechanism on this page can actually deliver. If it works, three things
+        follow. A refuted argument stops circulating instead of respawning in the next thread.
+        Each round of debate builds on the last instead of restarting from zero. And anyone can
+        see the whole map of reasons to agree and disagree with a claim in one place, ranked by
+        evidence rather than by volume. Whether that adds up to better collective decisions is
+        the horizon we are aiming at, not a result we are claiming.
+      </p>
+
+      <hr className="my-8" />
+
+      <h2 className="text-2xl font-bold mb-3">Get Involved</h2>
+      <p className="mb-3">
+        This is an open-source project with a real repository and, honestly, not enough hands
+        yet. If you are a developer, the useful entry point is not the grand vision, it is a
+        concrete first issue: the stack is Next.js and TypeScript, the scoring engine and market
+        layer have written specs and passing test suites, and the issues list has work waiting.
+        If you are a thinker rather than a coder, the exchange needs well-formed pro and con
+        arguments and clean belief pages far more than it needs another manifesto — start with
+        the add-a-reason form on any{' '}
+        <Link href="/beliefs" className="text-blue-700 hover:underline">belief page</Link>.
+      </p>
+      <ul className="list-disc ml-6 mb-4 space-y-1">
+        <li>
+          <a
+            href="https://github.com/myklob/ideastockexchange"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-700 hover:underline"
+          >
+            View and contribute on GitHub
+          </a>
+        </li>
+        <li>
+          <Link href="/beliefs" className="text-blue-700 hover:underline">
+            Browse the belief pages and add a reason
+          </Link>
+        </li>
+      </ul>
+
+      <hr className="my-8" />
+
+      <h2 className="text-2xl font-bold mb-3">Related scoring pages</h2>
+      <p className="mb-4">
+        The scores referenced above each have their own methodology page:{' '}
+        <Link href="/algorithms/reason-rank" className="text-blue-700 hover:underline">ReasonRank</Link>,{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">Linkage</Link>,{' '}
+        <Link href="/algorithms/truth-scores" className="text-blue-700 hover:underline">Truth</Link>,{' '}
+        <Link href="/algorithms/evidence-scores" className="text-blue-700 hover:underline">Evidence</Link>,{' '}
+        <Link href="/algorithms/importance-score" className="text-blue-700 hover:underline">Importance</Link>,{' '}
+        <Link href="/algorithms/unique-scores" className="text-blue-700 hover:underline">Uniqueness</Link>,{' '}
+        <Link href="/algorithms/objective-criteria" className="text-blue-700 hover:underline">Objective Criteria</Link>,{' '}
+        <Link href="/cba/about" className="text-blue-700 hover:underline">Likelihood</Link>, and the full{' '}
+        <Link href="/algorithms" className="text-blue-700 hover:underline">algorithms index</Link>.
+      </p>
+    </div>
+  )
+}

--- a/src/app/media/[id]/quality/page.tsx
+++ b/src/app/media/[id]/quality/page.tsx
@@ -81,9 +81,9 @@ export default async function MediaQualityPage({ params }: MediaQualityPageProps
             </h2>
             <p className="text-sm text-[var(--muted-foreground)] mb-4">
               Each reason is itself a belief with its own ISE page. Scoring is recursive based on{' '}
-              <Link href="/truth" className="text-[var(--accent)] hover:underline">truth</Link>,{' '}
-              <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">linkage</Link>, and{' '}
-              <Link href="/Importance%20Score" className="text-[var(--accent)] hover:underline">importance</Link>.
+              <Link href="/algorithms/truth-scores" className="text-[var(--accent)] hover:underline">truth</Link>,{' '}
+              <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">linkage</Link>, and{' '}
+              <Link href="/algorithms/importance-score" className="text-[var(--accent)] hover:underline">importance</Link>.
             </p>
 
             {/* Pro quality */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -229,7 +229,7 @@ export default function Home() {
           </ul>
 
           <Link
-            href="/proposal/new"
+            href="/beliefs"
             className="inline-block bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white px-6 py-3 rounded-lg font-medium transition-colors"
           >
             Create a Proposal
@@ -621,10 +621,10 @@ export default function Home() {
           </p>
           <div className="flex gap-4 justify-center flex-wrap">
             <Link
-              href="/laws"
+              href="/beliefs"
               className="bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white px-8 py-3 rounded-lg font-medium transition-colors"
             >
-              Browse Laws
+              Browse Beliefs
             </Link>
             <Link
               href="/product-reviews"
@@ -661,11 +661,11 @@ export default function Home() {
             <div>
               <h3 className="font-bold mb-4">Resources</h3>
               <ul className="space-y-2 text-sm">
+                <li><Link href="/how-it-works" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">How It Works</Link></li>
                 <li><Link href="/protocol" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Schlicht Protocol</Link></li>
                 <li><Link href="/product-reviews" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Product Reviews</Link></li>
                 <li><Link href="/cba" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Cost-Benefit Analysis</Link></li>
-                <li><Link href="/laws" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Browse Laws</Link></li>
-                <li><Link href="/markets" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Prediction Markets</Link></li>
+                                <li><Link href="/markets" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Prediction Markets</Link></li>
                 <li><Link href="/prediction-markets-comparison" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Idea Stock Exchange vs Polymarket</Link></li>
                 <li><Link href="/faq" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">FAQ &amp; Criticisms</Link></li>
                 <li><a href="https://github.com/myklob/ideastockexchange/wiki" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]" target="_blank" rel="noopener noreferrer">Framework Wiki</a></li>
@@ -674,11 +674,12 @@ export default function Home() {
             <div>
               <h3 className="font-bold mb-4">Framework</h3>
               <ul className="space-y-2 text-sm">
-                <li><a href="https://github.com/myklob/ideastockexchange/wiki/Truth-Score" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]" target="_blank" rel="noopener noreferrer">Truth</a></li>
+                <li><Link href="/algorithms/truth-scores" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Truth</Link></li>
                 <li><a href="https://github.com/myklob/ideastockexchange/wiki" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]" target="_blank" rel="noopener noreferrer">Interests</a></li>
-                <li><a href="https://github.com/myklob/ideastockexchange/wiki/Evidence-Verification-Score-(EVS)" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]" target="_blank" rel="noopener noreferrer">Evidence</a></li>
-                <li><a href="https://github.com/myklob/ideastockexchange/wiki" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]" target="_blank" rel="noopener noreferrer">Assumptions</a></li>
+                <li><Link href="/algorithms/evidence-scores" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Evidence</Link></li>
+                <li><Link href="/algorithms/assumptions" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Assumptions</Link></li>
                 <li><Link href="/algorithms/strong-to-weak" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">Strong-to-Weak Spectrum</Link></li>
+                <li><Link href="/algorithms" className="text-[var(--muted-foreground)] hover:text-[var(--accent)]">All Scoring Algorithms</Link></li>
               </ul>
             </div>
           </div>

--- a/src/components/TopicObjectiveCriteria.tsx
+++ b/src/components/TopicObjectiveCriteria.tsx
@@ -28,7 +28,7 @@ export default function TopicObjectiveCriteria({ criteria }: TopicObjectiveCrite
       <h2 className="text-2xl font-bold mb-2">
         📏{' '}
         <Link
-          href="/w/page/159351732/Objective%20criteria%20scores"
+          href="/algorithms/objective-criteria"
           className="text-blue-700 hover:underline"
         >
           Best Objective Criteria
@@ -40,7 +40,7 @@ export default function TopicObjectiveCriteria({ criteria }: TopicObjectiveCrite
         <em>what good measurement looks like</em>. This section lists proposed criteria,
         sorted by their community-assigned{' '}
         <Link
-          href="/w/page/159351732/Objective%20criteria%20scores"
+          href="/algorithms/objective-criteria"
           className="text-blue-600 hover:underline"
         >
           Objective Criteria Score
@@ -70,7 +70,7 @@ export default function TopicObjectiveCriteria({ criteria }: TopicObjectiveCrite
           <li>
             <strong>
               <Link
-                href="/w/page/159338766/Linkage%20Scores"
+                href="/algorithms/linkage-scores"
                 className="text-blue-600 hover:underline"
               >
                 Linkage
@@ -82,7 +82,7 @@ export default function TopicObjectiveCriteria({ criteria }: TopicObjectiveCrite
           <li>
             <strong>
               <Link
-                href="/w/page/162731388/Importance%20Score"
+                href="/algorithms/importance-score"
                 className="text-blue-600 hover:underline"
               >
                 Importance
@@ -101,7 +101,7 @@ export default function TopicObjectiveCriteria({ criteria }: TopicObjectiveCrite
               <th className="px-3 py-2 text-left font-semibold w-[28%]">Proposed Criterion</th>
               <th className="px-3 py-2 text-center font-semibold w-[12%]">
                 <Link
-                  href="/w/page/159351732/Objective%20criteria%20scores"
+                  href="/algorithms/objective-criteria"
                   className="text-blue-700 hover:underline"
                 >
                   Criteria Score
@@ -115,7 +115,7 @@ export default function TopicObjectiveCriteria({ criteria }: TopicObjectiveCrite
               <th className="px-3 py-2 text-center font-semibold w-[15%]">Reliability</th>
               <th className="px-3 py-2 text-center font-semibold w-[15%]">
                 <Link
-                  href="/w/page/159338766/Linkage%20Scores"
+                  href="/algorithms/linkage-scores"
                   className="text-blue-700 hover:underline"
                 >
                   Linkage
@@ -123,7 +123,7 @@ export default function TopicObjectiveCriteria({ criteria }: TopicObjectiveCrite
               </th>
               <th className="px-3 py-2 text-center font-semibold w-[15%]">
                 <Link
-                  href="/w/page/162731388/Importance%20Score"
+                  href="/algorithms/importance-score"
                   className="text-blue-700 hover:underline"
                 >
                   Importance
@@ -162,7 +162,7 @@ export default function TopicObjectiveCriteria({ criteria }: TopicObjectiveCrite
             <tr className="bg-gray-50">
               <td colSpan={6} className="px-3 py-2 text-xs text-gray-500 italic">
                 Don&apos;t see a criterion that belongs here?{' '}
-                <Link href="/Contact%20Me" className="text-blue-600 hover:underline">
+                <Link href="/contact" className="text-blue-600 hover:underline">
                   Submit a proposal
                 </Link>{' '}
                 with reasons to support its validity, reliability, linkage, and importance. The
@@ -184,7 +184,7 @@ export default function TopicObjectiveCriteria({ criteria }: TopicObjectiveCrite
       <p className="text-right text-sm mt-2">
         See:{' '}
         <Link
-          href="/w/page/159351732/Objective%20criteria%20scores"
+          href="/algorithms/objective-criteria"
           className="text-blue-600 hover:underline"
         >
           Full Objective Criteria Scoring Methodology

--- a/src/components/debate-topic/CommonGround.tsx
+++ b/src/components/debate-topic/CommonGround.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { DebateCommonGround } from '@/core/types/debate-topic';
 
 interface Props {
@@ -13,7 +14,7 @@ export default function CommonGround({ commonGround }: Props) {
         🤝 Common Ground and Compromise
       </h2>
       <p className="text-sm text-gray-600 mb-3">
-        The scored <a href="/cba/about" className="text-blue-600 hover:underline">cost-benefit</a>{' '}
+        The scored <Link href="/cba/about" className="text-blue-600 hover:underline">cost-benefit</Link>{' '}
         trees read sideways. Compromise Candidates are the winnable disagreements, the ones a small
         likelihood shift can flip, as opposed to the symbolic value conflicts no negotiation resolves. That
         is the payoff of scoring both sides with equal rigor.

--- a/src/components/debate-topic/CommonGround.tsx
+++ b/src/components/debate-topic/CommonGround.tsx
@@ -13,7 +13,7 @@ export default function CommonGround({ commonGround }: Props) {
         🤝 Common Ground and Compromise
       </h2>
       <p className="text-sm text-gray-600 mb-3">
-        The scored <a href="/w/page/156187122/cost-benefit%20analysis" className="text-blue-600 hover:underline">cost-benefit</a>{' '}
+        The scored <a href="/cba/about" className="text-blue-600 hover:underline">cost-benefit</a>{' '}
         trees read sideways. Compromise Candidates are the winnable disagreements, the ones a small
         likelihood shift can flip, as opposed to the symbolic value conflicts no negotiation resolves. That
         is the payoff of scoring both sides with equal rigor.

--- a/src/components/debate-topic/CoreValuesConflict.tsx
+++ b/src/components/debate-topic/CoreValuesConflict.tsx
@@ -14,7 +14,7 @@ export default function CoreValuesConflict({ coreValues }: Props) {
       <p className="text-sm text-gray-600 mb-3">
         Advertised values each side claims, and the motivation critics attribute.{' '}
         <span className="text-gray-500">
-          See: <a href="/w/page/21956745/American%20values" className="text-blue-600 hover:underline">American Values</a>.
+          See: <a href="/how-it-works" className="text-blue-600 hover:underline">American Values</a>.
         </span>
       </p>
       <div className="overflow-x-auto">

--- a/src/components/debate-topic/Spectrum3Escalation.tsx
+++ b/src/components/debate-topic/Spectrum3Escalation.tsx
@@ -109,7 +109,7 @@ export default function Spectrum3Escalation({ escalationLevels, topicTitle }: Pr
         <a href="/escalation-spectrum" className="text-blue-600 hover:underline">Escalation Spectrum</a>.
       </p>
       <p className="text-right text-xs mt-2 text-gray-500">
-        <a href="/w/page/21956745/American%20values" className="text-blue-600 hover:underline">Core Values Framework</a>
+        <a href="/how-it-works" className="text-blue-600 hover:underline">Core Values Framework</a>
       </p>
     </div>
   );

--- a/src/components/debate-topic/TopicMetrics.tsx
+++ b/src/components/debate-topic/TopicMetrics.tsx
@@ -21,13 +21,13 @@ export default function TopicMetrics({ importanceScore, evidenceDepth, controver
     <div className="border border-gray-300 p-3 bg-gray-50 mb-6 text-center text-sm">
       <strong>Topic Metrics</strong>
       <br />
-      <a href="/w/page/162731388/Importance%20Score" className="text-blue-600 hover:underline">
+      <a href="/algorithms/importance-score" className="text-blue-600 hover:underline">
         Importance
       </a>
       :{' '}
       <strong className={scoreColor(importanceScore)}>{importanceScore}</strong>
       {' | '}
-      <a href="/w/page/159353568/Evidence%20Scores" className="text-blue-600 hover:underline">
+      <a href="/algorithms/evidence-scores" className="text-blue-600 hover:underline">
         Evidence Depth
       </a>
       :{' '}

--- a/src/core/scoring/conflict-resolution.ts
+++ b/src/core/scoring/conflict-resolution.ts
@@ -1,0 +1,322 @@
+/**
+ * Conflict Resolution Pipeline — reading scored trees sideways.
+ *
+ * Once a belief's costs, benefits, values, and interests are decomposed and
+ * scored, four outputs fall out almost for free, and none of them needs a
+ * human to hand-author a verdict:
+ *
+ *   1. SHARED INTERESTS — interests both sides actually hold, found by
+ *      cross-side similarity over the interest statements, kept only when
+ *      both sides' validity clears the Resolution Floor.
+ *   2. PRIMARY CONFLICT PAIR — the single interest on each side that is
+ *      really driving the disagreement: the highest validity-weighted
+ *      linkage-accuracy interest that is NOT shared.
+ *   3. GENUINE VALUE CONFLICTS — shared values the two sides rank far
+ *      apart (one side prices freedom, the other prices safety).
+ *   4. COMPROMISE CANDIDATES — the payoff: cost/benefit categories where a
+ *      small, achievable likelihood shift would flip the category's net.
+ *      These are the winnable disagreements, as opposed to the symbolic ones.
+ *
+ * Everything here is a read-only OUTPUT over already-scored rows (the same
+ * one-way valve as the contrast class): nothing feeds back into any score.
+ * Follows Fisher & Ury — push past positions ("I want X") to interests
+ * ("I need X because of Y"), because interests are where the overlap hides.
+ */
+
+import { mechanicalSimilarity } from './duplication-scoring'
+
+// ─── Shared constants ──────────────────────────────────────────────────────
+
+/** Both sides of a shared interest must clear this validity (0-100). */
+export const RESOLUTION_FLOOR = 70
+
+/** Cross-side interest statements at or above this similarity pair up. */
+export const SHARED_INTEREST_SIMILARITY = 0.5
+
+/** A likelihood shift at or below this is "small and achievable". */
+export const ACHIEVABLE_SHIFT = 0.15
+
+// ─── 1. Shared interests ───────────────────────────────────────────────────
+
+export interface InterestInput {
+  id: number
+  side: 'supporter' | 'opponent'
+  interest: string
+  /** Legitimacy of the interest by objective criteria (0-100); null = unscored. */
+  validityScore: number | null
+  /** How well the interest explains the side's actual behavior (0-100). */
+  linkageAccuracy: number | null
+  /** Estimated share of the side driven by this interest (0-100). */
+  prevalenceScore: number | null
+}
+
+export interface SharedInterestCandidate {
+  supporterId: number
+  opponentId: number
+  supporterInterest: string
+  opponentInterest: string
+  /** Cross-side statement similarity (0-1) that paired them. */
+  similarity: number
+  /** Harmonic mean of the two validities — a lopsided pair sinks. */
+  pairedValidity: number
+}
+
+/**
+ * Find the interests both sides actually share: cross-side pairs whose
+ * statements are similar and whose validity clears the Resolution Floor on
+ * BOTH sides. Compromise gets built on these.
+ */
+export function findSharedInterests(
+  interests: InterestInput[],
+  opts: { similarityThreshold?: number; floor?: number } = {},
+): SharedInterestCandidate[] {
+  const threshold = opts.similarityThreshold ?? SHARED_INTEREST_SIMILARITY
+  const floor = opts.floor ?? RESOLUTION_FLOOR
+
+  const supporters = interests.filter(
+    (i) => i.side === 'supporter' && (i.validityScore ?? 0) >= floor,
+  )
+  const opponents = interests.filter(
+    (i) => i.side === 'opponent' && (i.validityScore ?? 0) >= floor,
+  )
+
+  const candidates: SharedInterestCandidate[] = []
+  for (const s of supporters) {
+    for (const o of opponents) {
+      const similarity = mechanicalSimilarity(s.interest, o.interest)
+      if (similarity < threshold) continue
+      const sv = s.validityScore ?? 0
+      const ov = o.validityScore ?? 0
+      candidates.push({
+        supporterId: s.id,
+        opponentId: o.id,
+        supporterInterest: s.interest,
+        opponentInterest: o.interest,
+        similarity,
+        pairedValidity: sv + ov > 0 ? (2 * sv * ov) / (sv + ov) : 0,
+      })
+    }
+  }
+  return candidates.sort((a, b) => b.pairedValidity - a.pairedValidity)
+}
+
+// ─── 2. Primary conflict pair ──────────────────────────────────────────────
+
+export interface PrimaryConflictPair {
+  supporter: InterestInput
+  opponent: InterestInput
+  /** Drive score per side: linkage accuracy weighted by validity (0-100). */
+  supporterDrive: number
+  opponentDrive: number
+}
+
+function driveScore(i: InterestInput): number {
+  const linkage = i.linkageAccuracy ?? 0
+  const validity = i.validityScore ?? 50
+  return (linkage * validity) / 100
+}
+
+/**
+ * The single interest pair that is really driving the disagreement: the
+ * highest-drive unshared interest on each side. Drive = how well the interest
+ * explains the side's actual behavior, weighted by its standalone validity —
+ * a pretext with no legitimacy cannot be the primary conflict, and neither
+ * can a legitimate interest nobody acts on.
+ */
+export function derivePrimaryConflictPair(
+  interests: InterestInput[],
+  shared: SharedInterestCandidate[] = [],
+): PrimaryConflictPair | null {
+  const sharedIds = new Set<number>()
+  for (const s of shared) {
+    sharedIds.add(s.supporterId)
+    sharedIds.add(s.opponentId)
+  }
+
+  const pick = (side: 'supporter' | 'opponent') =>
+    interests
+      .filter((i) => i.side === side && !sharedIds.has(i.id) && i.linkageAccuracy != null)
+      .sort((a, b) => driveScore(b) - driveScore(a))[0] ?? null
+
+  const supporter = pick('supporter')
+  const opponent = pick('opponent')
+  if (!supporter || !opponent) return null
+
+  return {
+    supporter,
+    opponent,
+    supporterDrive: driveScore(supporter),
+    opponentDrive: driveScore(opponent),
+  }
+}
+
+// ─── 3. Genuine value conflicts ────────────────────────────────────────────
+
+export interface ValueRankingInput {
+  id: number
+  value: string
+  supporterRank: number | null
+  opponentRank: number | null
+}
+
+export interface ValueConflict {
+  id: number
+  value: string
+  supporterRank: number
+  opponentRank: number
+  /** Ranking gap — how differently the two sides price this shared value. */
+  gap: number
+}
+
+/**
+ * The genuine value conflicts: shared values the two sides rank far apart.
+ * Both sides hold the value — the fight is over its PRICE relative to the
+ * others (freedom vs. safety, prosperity vs. equality). Sorted by gap, so the
+ * top row is the value disagreement most likely to be the real fault line.
+ */
+export function findValueConflicts(
+  rankings: ValueRankingInput[],
+  opts: { minGap?: number } = {},
+): ValueConflict[] {
+  const minGap = opts.minGap ?? 2
+  return rankings
+    .filter((r) => r.supporterRank != null && r.opponentRank != null)
+    .map((r) => ({
+      id: r.id,
+      value: r.value,
+      supporterRank: r.supporterRank as number,
+      opponentRank: r.opponentRank as number,
+      gap: Math.abs((r.supporterRank as number) - (r.opponentRank as number)),
+    }))
+    .filter((r) => r.gap >= minGap)
+    .sort((a, b) => b.gap - a.gap)
+}
+
+// ─── 4. Compromise candidates ──────────────────────────────────────────────
+
+export interface CbaItemInput {
+  id: number
+  side: 'benefit' | 'cost'
+  claim: string
+  category: string | null
+  /** Magnitude in the category's own units. */
+  magnitude: number | null
+  /** Likelihood (0-1), computed from the claim's own tree when linked. */
+  likelihood: number | null
+}
+
+export interface CategoryNet {
+  category: string
+  benefitEv: number
+  costEv: number
+  /** Net expected value: benefits minus costs, in the category's units. */
+  net: number
+}
+
+/** Per-category nets: expected benefits minus expected costs, like units only. */
+export function categoryNets(items: CbaItemInput[]): CategoryNet[] {
+  const byCategory = new Map<string, { benefitEv: number; costEv: number }>()
+  for (const item of items) {
+    if (item.category == null || item.magnitude == null || item.likelihood == null) continue
+    const entry = byCategory.get(item.category) ?? { benefitEv: 0, costEv: 0 }
+    const ev = Math.abs(item.magnitude) * item.likelihood
+    if (item.side === 'benefit') entry.benefitEv += ev
+    else entry.costEv += ev
+    byCategory.set(item.category, entry)
+  }
+  return [...byCategory.entries()].map(([category, { benefitEv, costEv }]) => ({
+    category,
+    benefitEv,
+    costEv,
+    net: benefitEv - costEv,
+  }))
+}
+
+export interface CompromiseCandidate {
+  category: string
+  /** The category's current net (benefits minus costs). */
+  net: number
+  itemId: number
+  claim: string
+  side: 'benefit' | 'cost'
+  /** Which way this item's likelihood must move to flip the category. */
+  direction: 'raise' | 'lower'
+  /** The likelihood shift that flips the category's net sign. */
+  requiredShift: number
+}
+
+/**
+ * The payoff of the pipeline: cost/benefit items where a small, achievable
+ * likelihood shift flips their category's net. These point at the winnable
+ * disagreements — a debate over one likelihood estimate, resolvable with
+ * evidence — instead of the symbolic ones. A candidate must (a) flip the sign
+ * with a shift ≤ maxShift and (b) keep the shifted likelihood inside [0, 1].
+ */
+export function findCompromiseCandidates(
+  items: CbaItemInput[],
+  opts: { maxShift?: number } = {},
+): CompromiseCandidate[] {
+  const maxShift = opts.maxShift ?? ACHIEVABLE_SHIFT
+  const nets = new Map(categoryNets(items).map((n) => [n.category, n]))
+
+  const candidates: CompromiseCandidate[] = []
+  for (const item of items) {
+    if (item.category == null || item.magnitude == null || item.likelihood == null) continue
+    const net = nets.get(item.category)
+    if (!net || net.net === 0) continue
+
+    const magnitude = Math.abs(item.magnitude)
+    if (magnitude === 0) continue
+
+    // Moving this item's likelihood by δ moves the category net by ±δ×|magnitude|.
+    // To flip the sign the move must oppose the current net.
+    const requiredShift = Math.abs(net.net) / magnitude
+    if (requiredShift > maxShift) continue
+
+    const netIsPositive = net.net > 0
+    const opposesNet =
+      (item.side === 'benefit' && netIsPositive) || (item.side === 'cost' && !netIsPositive)
+    const direction: 'raise' | 'lower' = opposesNet ? 'lower' : 'raise'
+
+    const shifted =
+      direction === 'raise' ? item.likelihood + requiredShift : item.likelihood - requiredShift
+    if (shifted < 0 || shifted > 1) continue
+
+    candidates.push({
+      category: item.category,
+      net: net.net,
+      itemId: item.id,
+      claim: item.claim,
+      side: item.side,
+      direction,
+      requiredShift,
+    })
+  }
+  return candidates.sort((a, b) => a.requiredShift - b.requiredShift)
+}
+
+// ─── Combined readout ──────────────────────────────────────────────────────
+
+export interface ConflictResolutionReadout {
+  sharedInterests: SharedInterestCandidate[]
+  primaryConflictPair: PrimaryConflictPair | null
+  valueConflicts: ValueConflict[]
+  categoryNets: CategoryNet[]
+  compromiseCandidates: CompromiseCandidate[]
+}
+
+/** Run the whole pipeline over one belief's scored rows. */
+export function analyzeConflict(
+  interests: InterestInput[],
+  rankings: ValueRankingInput[],
+  cbaItems: CbaItemInput[],
+): ConflictResolutionReadout {
+  const sharedInterests = findSharedInterests(interests)
+  return {
+    sharedInterests,
+    primaryConflictPair: derivePrimaryConflictPair(interests, sharedInterests),
+    valueConflicts: findValueConflicts(rankings),
+    categoryNets: categoryNets(cbaItems),
+    compromiseCandidates: findCompromiseCandidates(cbaItems),
+  }
+}

--- a/src/core/scoring/contrast-class.ts
+++ b/src/core/scoring/contrast-class.ts
@@ -1,0 +1,375 @@
+/**
+ * The Denominator — Scoring a Belief Against Its Counterclaims
+ *
+ * A bare pro-minus-con score is a numerator with nothing under the line:
+ * "+9.2" relative to what? This module supplies the denominator. There are
+ * two layers, and they stack rather than compete:
+ *
+ *   Layer 1 (internal denominator) — the JUSTIFICATION score. Divide the net
+ *   by the belief's OWN total argument weight: (Pro − Con) / (Pro + Con).
+ *   Answers "how lopsided is this claim versus its own rebuttals?" Range −1..+1.
+ *   Doubles as the Rule 9 inversion trigger (negative ⇒ net-refuted).
+ *
+ *   Layer 2 (external denominator) — the COMPARATIVE score. Divide against the
+ *   best RIVAL in the contrast class: OCV(oi) = S(oi) − max_{j≠i} S(oj).
+ *   Answers "does this claim beat the alternatives?" Exactly one option in a
+ *   contrast class has OCV > 0 (the winner); every other option's negative
+ *   magnitude is what you give up by choosing it instead of the best rival.
+ *
+ * Layer 1 produces the quantity Layer 2 compares: Layer 1 runs inside each
+ * node, Layer 2 across the siblings. Nothing here introduces a new scoring
+ * primitive — every term under the line is itself an audited, scored value, so
+ * the engine's traceability invariant holds end to end. These are OUTPUTS
+ * (read-only readouts); they must never feed back into any argument's score.
+ *
+ * Spec: docs/THE_DENOMINATOR.md
+ */
+
+// ─── Layer 1: internal denominator (justification) ────────────────────────
+
+/**
+ * Justification score J(X) = (Pro − Con) / (Pro + Con), range −1..+1.
+ *
+ * The net-margin view of how decisively a belief's own arguments favor it over
+ * its own rebuttals. Negative means the belief is net-refuted (Rule 9 trigger).
+ * Returns 0 when there is no argument weight at all (undefined, not refuted).
+ *
+ * Identity worth knowing: J = 2·share − 1, where share = Pro/(Pro+Con). The two
+ * carry identical information on different scales; the margin form is the more
+ * useful default because its sign does work.
+ */
+export function justificationScore(pro: number, con: number): number {
+  const total = pro + con
+  if (total <= 0) return 0
+  return (pro - con) / total
+}
+
+/**
+ * Truth share p = Pro / (Pro + Con), range 0..1 — the implied-probability /
+ * market-share view of a single belief's internal balance. Returns null when
+ * there is no argument weight (a share of nothing is undefined, not 0.5).
+ */
+export function truthShare(pro: number, con: number): number | null {
+  const total = pro + con
+  if (total <= 0) return null
+  return pro / total
+}
+
+/**
+ * A confidence figure to report ALONGSIDE the ratio, never folded into it.
+ * The justification ratio washes out volume — [Pro 9, Con 1] and
+ * [Pro 90, Con 10] both score +0.8 — so conviction must track evidence volume
+ * separately. This returns the total argument mass (Pro + Con); pair it with a
+ * count of independent items at the call site if available.
+ */
+export function argumentMass(pro: number, con: number): number {
+  return pro + con
+}
+
+// ─── Layer 2: external denominator (opportunity cost) ─────────────────────
+
+/** A mutually exclusive option in a contrast class, carrying its tree score S. */
+export interface ContrastOption {
+  id: string
+  label: string
+  /** S(o): the argument-tree / ReasonRank score. May be signed. */
+  score: number
+}
+
+/** Pairwise margin M(oi, oj) = S(oi) − S(oj). */
+export function pairwiseMargin(a: number, b: number): number {
+  return a - b
+}
+
+/**
+ * Opportunity-cost value OCV(oi) = S(oi) − max_{j≠i} S(oj).
+ *
+ * The value of an option is what it delivers MINUS what the best alternative
+ * would have delivered. Sign tells you win/lose against the field; magnitude
+ * tells you by how much. With a single option (no rivals) OCV is undefined —
+ * there is no denominator — so this returns null.
+ */
+export function opportunityCostValue(
+  optionScore: number,
+  rivalScores: number[],
+): number | null {
+  if (rivalScores.length === 0) return null
+  return optionScore - Math.max(...rivalScores)
+}
+
+/** One option's place in the field after the comparative layer is applied. */
+export interface ComparativeResult extends ContrastOption {
+  /** OCV against the best rival; null only when the class has a single option. */
+  ocv: number | null
+  /** The rival that set the bar (the best other option); null if none. */
+  bestRivalId: string | null
+  /** True for the single option with OCV > 0 — the current winner of the field. */
+  isWinner: boolean
+}
+
+/**
+ * Run the comparative layer across a whole contrast class. Returns each option
+ * with its OCV against its own best rival, the id of that rival, and a winner
+ * flag. Exactly one option wins when scores are distinct; ties produce no
+ * strict winner (no option has OCV strictly > 0).
+ */
+export function comparativeScores(options: ContrastOption[]): ComparativeResult[] {
+  return options.map((option) => {
+    const rivals = options.filter((o) => o.id !== option.id)
+    const ocv = opportunityCostValue(option.score, rivals.map((r) => r.score))
+
+    let bestRivalId: string | null = null
+    if (rivals.length > 0) {
+      const best = rivals.reduce((a, b) => (b.score > a.score ? b : a))
+      bestRivalId = best.id
+    }
+
+    return {
+      ...option,
+      ocv,
+      bestRivalId,
+      isWinner: ocv !== null && ocv > 0,
+    }
+  })
+}
+
+// ─── Layer 2b: criteria-normalized denominator ────────────────────────────
+
+/**
+ * Min-max normalize a criterion's raw scores across the rivals:
+ *   n(oi,k) = (r(oi,k) − min_j) / (max_j − min_j)
+ *
+ * The denominator on each criterion is the SPREAD of the rivals, so a flat 0.6
+ * means nothing while a 0.6 in a field running 0.1..0.7 means a lot. This is an
+ * affine rescaling of real rival scores, not a sigmoid clamp — the range is set
+ * by the actual spread, so a lopsided field stays lopsided. When every option
+ * scores identically (zero spread) the criterion can't discriminate; we return
+ * a neutral 0.5 for each rather than dividing by zero.
+ */
+export function normalizeCriterion(values: number[]): number[] {
+  if (values.length === 0) return []
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const spread = max - min
+  if (spread === 0) return values.map(() => 0.5)
+  return values.map((v) => (v - min) / spread)
+}
+
+/** A shared yardstick scored across every option in the contrast class. */
+export interface Criterion {
+  key: string
+  /**
+   * Importance weight (≥ 0), itself a debatable/scored quantity that lives on
+   * the TOPIC, not the belief — "how much does civilian welfare matter relative
+   * to deterrence" is the same question for every option. This is the real home
+   * for the otherwise-blank Importance column.
+   */
+  importance: number
+  /** Raw score per option id, on any common scale (normalized internally). */
+  raw: Record<string, number>
+}
+
+/** A criteria-decomposed weighted score for one option. */
+export interface WeightedCriteriaResult {
+  optionId: string
+  /** W(oi) = Σ_k importance_k · n(oi,k). */
+  weighted: number
+  /** Per-criterion normalized contribution, for decomposing the margin. */
+  perCriterion: { key: string; normalized: number; contribution: number }[]
+}
+
+/**
+ * Score every option on the shared criteria and weight by per-criterion
+ * importance: W(oi) = Σ_k importance_k · n(oi,k). Use W to DECOMPOSE a margin —
+ * it shows which criterion drove a win or loss — not as a second headline.
+ */
+export function weightedCriteriaScores(
+  options: ContrastOption[],
+  criteria: Criterion[],
+): WeightedCriteriaResult[] {
+  // Pre-normalize each criterion once across the whole field.
+  const normalizedByKey = new Map<string, Map<string, number>>()
+  for (const c of criteria) {
+    const ids = options.map((o) => o.id)
+    const rawValues = ids.map((id) => c.raw[id] ?? 0)
+    const normValues = normalizeCriterion(rawValues)
+    normalizedByKey.set(c.key, new Map(ids.map((id, i) => [id, normValues[i]])))
+  }
+
+  return options.map((option) => {
+    const perCriterion = criteria.map((c) => {
+      const normalized = normalizedByKey.get(c.key)?.get(option.id) ?? 0
+      return { key: c.key, normalized, contribution: c.importance * normalized }
+    })
+    const weighted = perCriterion.reduce((s, p) => s + p.contribution, 0)
+    return { optionId: option.id, weighted, perCriterion }
+  })
+}
+
+// ─── Field share (optional readout) ───────────────────────────────────────
+
+/** Result of attempting a 0..1 market-share view of the field. */
+export interface FieldShareResult {
+  /** Share per option id, summing to 1; null when shares are undefined. */
+  shares: Record<string, number> | null
+  /** True when a rank-shift was applied to make signed scores shareable. */
+  shifted: boolean
+  /**
+   * Why shares are null / shifted, for honest readouts. "ok" | "signed" |
+   * "shifted" | "empty".
+   */
+  status: 'ok' | 'signed' | 'shifted' | 'empty'
+}
+
+/**
+ * Field share Price(oi) = S(oi) / Σ_j S(oj), a market-share view — but ONLY
+ * meaningful for non-negative inputs. ReasonRank scores can go negative, and a
+ * share of signed quantities is nonsense (a near-zero denominator blows up, a
+ * negative share is meaningless).
+ *
+ * Default behaviour (preferred per spec): refuse to fake a probability — return
+ * shares: null with status 'signed', and let the caller report OCV instead.
+ *
+ * With { allowShift: true } a rank-shift S'(o) = S(o) − min + ε is applied
+ * first and status is 'shifted', so nobody mistakes the result for a real
+ * probability.
+ */
+export function fieldShares(
+  options: ContrastOption[],
+  opts: { allowShift?: boolean; epsilon?: number } = {},
+): FieldShareResult {
+  if (options.length === 0) {
+    return { shares: null, shifted: false, status: 'empty' }
+  }
+
+  const scores = options.map((o) => o.score)
+  const hasNegative = scores.some((s) => s < 0)
+
+  if (!hasNegative) {
+    const sum = scores.reduce((a, b) => a + b, 0)
+    if (sum <= 0) return { shares: null, shifted: false, status: 'empty' }
+    const shares: Record<string, number> = {}
+    options.forEach((o) => { shares[o.id] = o.score / sum })
+    return { shares, shifted: false, status: 'ok' }
+  }
+
+  if (!opts.allowShift) {
+    return { shares: null, shifted: false, status: 'signed' }
+  }
+
+  const epsilon = opts.epsilon ?? 1e-6
+  const min = Math.min(...scores)
+  const shifted = options.map((o) => o.score - min + epsilon)
+  const sum = shifted.reduce((a, b) => a + b, 0)
+  const shares: Record<string, number> = {}
+  options.forEach((o, i) => { shares[o.id] = shifted[i] / sum })
+  return { shares, shifted: true, status: 'shifted' }
+}
+
+// ─── Argument sorting: intrinsic vs comparative ───────────────────────────
+
+/**
+ * "Intrinsic" arguments ("X is true / good on its own terms") feed Layer 1's
+ * (Pro − Con)/(Pro + Con) ratio. "Comparative" arguments ("rival Y beats X")
+ * are NOT strikes against the belief — they are statements about the
+ * denominator — and must be pulled out of the pro/con tally entirely and moved
+ * to Layer 2. Left in the con column, a comparative argument double-counts the
+ * rival: it pads Pro + Con AND reappears as a rival option. Sorting first makes
+ * the Layer 1 ratio cleaner, not merely rescaled.
+ */
+export type ArgumentKind = 'intrinsic' | 'comparative'
+
+export interface SortableArgument {
+  kind: ArgumentKind
+  side: 'pro' | 'con'
+  /** Weight this argument contributes (impact / score magnitude). */
+  weight: number
+}
+
+export interface ArgumentSortResult {
+  /** Pro weight from intrinsic arguments only. */
+  intrinsicPro: number
+  /** Con weight from intrinsic arguments only. */
+  intrinsicCon: number
+  /** Weight diverted to the comparative layer (excluded from Layer 1). */
+  comparativeWeight: number
+  /** Layer 1 justification on the cleaned, intrinsic-only totals. */
+  justification: number
+}
+
+/**
+ * Partition arguments into the intrinsic totals that feed Layer 1 and the
+ * comparative weight that belongs in Layer 2, then compute the cleaned Layer 1
+ * justification score from the intrinsic-only totals.
+ */
+export function sortArguments(args: SortableArgument[]): ArgumentSortResult {
+  let intrinsicPro = 0
+  let intrinsicCon = 0
+  let comparativeWeight = 0
+
+  for (const arg of args) {
+    if (arg.kind === 'comparative') {
+      comparativeWeight += arg.weight
+      continue
+    }
+    if (arg.side === 'pro') intrinsicPro += arg.weight
+    else intrinsicCon += arg.weight
+  }
+
+  return {
+    intrinsicPro,
+    intrinsicCon,
+    comparativeWeight,
+    justification: justificationScore(intrinsicPro, intrinsicCon),
+  }
+}
+
+// ─── Combined readout ─────────────────────────────────────────────────────
+
+/** The full denominator readout for one focal option within its contrast class. */
+export interface ContrastClassReadout {
+  /** The comparative layer for every option (OCV, winner flag, best rival). */
+  comparative: ComparativeResult[]
+  /** Pairwise margins of the focal option against each rival. */
+  focalMargins: { rivalId: string; rivalLabel: string; margin: number }[]
+  /** The focal option's OCV against its best rival (the headline number). */
+  focalOcv: number | null
+  /** The best rival's id, the named denominator for the headline. */
+  focalBestRivalId: string | null
+  /** Optional criteria decomposition when criteria are supplied. */
+  criteria: WeightedCriteriaResult[] | null
+  /** Optional market-share view of the field. */
+  fieldShare: FieldShareResult
+}
+
+/**
+ * Assemble the complete contrast-class readout for a focal option. This is the
+ * "state the denominator next to the verdict" payload: the OCV against the
+ * named best rival, the full pairwise-margin table, the optional criteria
+ * decomposition, and the optional field share.
+ */
+export function analyzeContrastClass(
+  focalId: string,
+  options: ContrastOption[],
+  criteria: Criterion[] = [],
+): ContrastClassReadout {
+  const comparative = comparativeScores(options)
+  const focal = comparative.find((o) => o.id === focalId)
+
+  const focalMargins = options
+    .filter((o) => o.id !== focalId)
+    .map((rival) => ({
+      rivalId: rival.id,
+      rivalLabel: rival.label,
+      margin: pairwiseMargin(focal?.score ?? 0, rival.score),
+    }))
+
+  return {
+    comparative,
+    focalMargins,
+    focalOcv: focal?.ocv ?? null,
+    focalBestRivalId: focal?.bestRivalId ?? null,
+    criteria: criteria.length > 0 ? weightedCriteriaScores(options, criteria) : null,
+    fieldShare: fieldShares(options),
+  }
+}

--- a/src/core/scoring/index.ts
+++ b/src/core/scoring/index.ts
@@ -29,6 +29,10 @@ export {
 // Duplication scoring — solves the Redundancy Problem (Topic Overlap Scores)
 export * from './duplication-scoring';
 
+// The Denominator — score a belief against its counterclaims (contrast class).
+// Layer 1 (justification, internal) + Layer 2 (opportunity cost, external).
+export * from './contrast-class';
+
 // All-scores module — remaining ReasonRank score dimensions:
 //   Objective Criteria, Confidence Stability, Media Truth, Media Genre,
 //   Topic Overlap helpers, Belief Equivalency, and combined computeAllBeliefScores

--- a/src/core/scoring/index.ts
+++ b/src/core/scoring/index.ts
@@ -33,6 +33,11 @@ export * from './duplication-scoring';
 // Layer 1 (justification, internal) + Layer 2 (opportunity cost, external).
 export * from './contrast-class';
 
+// Conflict Resolution Pipeline — read the scored trees sideways: shared
+// interests, the primary conflict pair, genuine value conflicts, and
+// compromise candidates (a small likelihood shift flips a category's net).
+export * from './conflict-resolution';
+
 // All-scores module — remaining ReasonRank score dimensions:
 //   Objective Criteria, Confidence Stability, Media Truth, Media Genre,
 //   Topic Overlap helpers, Belief Equivalency, and combined computeAllBeliefScores

--- a/src/core/scoring/scoring-engine.ts
+++ b/src/core/scoring/scoring-engine.ts
@@ -736,12 +736,19 @@ export function calculateArgumentImpact(
  * Used by the recursive propagation system when a child belief's truth score
  * changes and its contribution to parent beliefs must be updated.
  *
- * Formula: sign × childTruthScore × |linkageScore| × importanceScore × 100
+ * Formula: sign × childTruthScore × |linkageScore| × importanceScore × uniqueness × 100
+ *
+ * This is the conclusion-score core: Σ(agree × linkage × uniqueness) −
+ * Σ(disagree × linkage × uniqueness), one term at a time.
  *
  * - sign is +1 for 'agree' arguments, -1 for 'disagree' arguments.
  * - childTruthScore (0–1): how well-supported the child belief is by its own arguments.
  * - |linkageScore| (0–1): abs value used so the side alone controls direction.
  * - importanceScore (0–1): how much this argument moves the probability needle.
+ * - uniquenessScore (0–1): how much new signal the argument adds versus its
+ *   earlier same-side siblings. A 90% restatement contributes ~10% of its
+ *   weight — nobody wins by making one point five different ways. Defaults to
+ *   1 so callers without sibling context (and pre-uniqueness data) are unchanged.
  * - Multiplied by 100 to match the stored scale (e.g. 18.5, 22.1, 12.4).
  * - Rounded to one decimal place to limit floating-point noise.
  */
@@ -750,9 +757,11 @@ export function computeArgumentImpactScore(
   childTruthScore: number,
   linkageScore: number,
   importanceScore: number,
+  uniquenessScore: number = 1,
 ): number {
   const sign = side === 'agree' ? 1 : -1
-  const raw = sign * childTruthScore * Math.abs(linkageScore) * importanceScore * 100
+  const raw =
+    sign * childTruthScore * Math.abs(linkageScore) * importanceScore * uniquenessScore * 100
   return Math.round(raw * 10) / 10
 }
 

--- a/src/features/belief-analysis/components/AddArgumentForm.tsx
+++ b/src/features/belief-analysis/components/AddArgumentForm.tsx
@@ -1,0 +1,226 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface StrongestOpposing {
+  id: number
+  claim: string
+  impactScore: number
+}
+
+interface AddArgumentFormProps {
+  beliefId: number
+  /** High-stakes beliefs route the post through the speed-bump flow. */
+  highStakes: boolean
+  /** Strongest current argument per side, for the steelman acknowledgment. */
+  strongestAgree: StrongestOpposing | null
+  strongestDisagree: StrongestOpposing | null
+}
+
+/**
+ * The add-a-row move: post a new reason to agree or disagree. The reason
+ * becomes a belief page of its own and the engine scores it — no score is
+ * ever submitted from here (audit lock).
+ *
+ * On high-stakes beliefs the form walks the two speed bumps the API enforces:
+ * acknowledge the strongest point on the other side, and check the proposal
+ * against the moral principle it claims to rest on.
+ */
+export default function AddArgumentForm({
+  beliefId,
+  highStakes,
+  strongestAgree,
+  strongestDisagree,
+}: AddArgumentFormProps) {
+  const router = useRouter()
+  const [side, setSide] = useState<'agree' | 'disagree'>('agree')
+  const [statement, setStatement] = useState('')
+  const [claim, setClaim] = useState('')
+  const [rationale, setRationale] = useState('')
+  const [steelmanAcknowledged, setSteelmanAcknowledged] = useState(false)
+  const [principle, setPrinciple] = useState('')
+  const [principleConsistent, setPrincipleConsistent] = useState(false)
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'error' | 'done'>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const strongestOpposing = side === 'agree' ? strongestDisagree : strongestAgree
+  const bumpsRequired = highStakes
+  const bumpsSatisfied =
+    !bumpsRequired ||
+    ((strongestOpposing == null || steelmanAcknowledged) &&
+      principle.trim().length > 0 &&
+      principleConsistent)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus('submitting')
+    setError(null)
+    try {
+      const res = await fetch(`/api/beliefs/${beliefId}/arguments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          side,
+          statement,
+          claim: claim || undefined,
+          rationale: rationale || undefined,
+          ...(bumpsRequired
+            ? {
+                steelmanArgumentId: strongestOpposing?.id,
+                principle,
+                principleConsistent,
+              }
+            : {}),
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setStatus('error')
+        setError(data.error ?? 'Submission failed.')
+        return
+      }
+      setStatus('done')
+      setStatement('')
+      setClaim('')
+      setRationale('')
+      router.refresh()
+    } catch {
+      setStatus('error')
+      setError('Network error — try again.')
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="border border-gray-300 p-4 text-sm space-y-3 bg-gray-50">
+      <p className="font-semibold">
+        Add a reason {highStakes && <span className="text-xs font-normal text-[var(--muted-foreground)]">(high-stakes belief — speed bumps apply)</span>}
+      </p>
+
+      <div className="flex gap-4">
+        <label className="flex items-center gap-1">
+          <input
+            type="radio"
+            name="side"
+            checked={side === 'agree'}
+            onChange={() => setSide('agree')}
+          />
+          Reason to agree
+        </label>
+        <label className="flex items-center gap-1">
+          <input
+            type="radio"
+            name="side"
+            checked={side === 'disagree'}
+            onChange={() => setSide('disagree')}
+          />
+          Reason to disagree
+        </label>
+      </div>
+
+      <label className="block">
+        <span className="text-xs text-[var(--muted-foreground)]">
+          The claim — a standalone statement with a truth value. It becomes a belief page of its own.
+        </span>
+        <textarea
+          className="mt-1 w-full border border-gray-300 p-2"
+          rows={2}
+          value={statement}
+          onChange={(e) => setStatement(e.target.value)}
+          placeholder="e.g. Cash transfers reduce recipient stress measurably"
+          required
+          minLength={10}
+        />
+      </label>
+
+      <label className="block">
+        <span className="text-xs text-[var(--muted-foreground)]">Short table label (2–6 words, optional)</span>
+        <input
+          className="mt-1 w-full border border-gray-300 p-2"
+          value={claim}
+          onChange={(e) => setClaim(e.target.value)}
+          placeholder="e.g. Reduces recipient stress"
+        />
+      </label>
+
+      <label className="block">
+        <span className="text-xs text-[var(--muted-foreground)]">Why does this belong here? (rationale, stored in the audit log)</span>
+        <textarea
+          className="mt-1 w-full border border-gray-300 p-2"
+          rows={2}
+          value={rationale}
+          onChange={(e) => setRationale(e.target.value)}
+        />
+      </label>
+
+      {bumpsRequired && (
+        <div className="border-l-4 border-amber-400 bg-amber-50 p-3 space-y-2">
+          <p className="font-medium">Speed bumps</p>
+          {strongestOpposing ? (
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                className="mt-1"
+                checked={steelmanAcknowledged}
+                onChange={(e) => setSteelmanAcknowledged(e.target.checked)}
+              />
+              <span>
+                I have read the strongest point on the other side —{' '}
+                <em>&ldquo;{strongestOpposing.claim}&rdquo;</em>{' '}
+                (impact {strongestOpposing.impactScore >= 0 ? '+' : ''}
+                {strongestOpposing.impactScore.toFixed(1)}) — and my reason is not already
+                answered by it.
+              </span>
+            </label>
+          ) : (
+            <p className="text-xs text-[var(--muted-foreground)]">
+              No opposing arguments yet — the steelman acknowledgment is waived.
+            </p>
+          )}
+          <label className="block">
+            <span className="text-xs text-[var(--muted-foreground)]">
+              The moral principle this reason rests on
+            </span>
+            <input
+              className="mt-1 w-full border border-gray-300 p-2"
+              value={principle}
+              onChange={(e) => setPrinciple(e.target.value)}
+              placeholder="e.g. No one who works full-time should live in poverty"
+            />
+          </label>
+          <label className="flex items-start gap-2">
+            <input
+              type="checkbox"
+              className="mt-1"
+              checked={principleConsistent}
+              onChange={(e) => setPrincipleConsistent(e.target.checked)}
+            />
+            <span>
+              I have checked that what I am proposing is consistent with this principle —
+              including where it cuts against my side.
+            </span>
+          </label>
+        </div>
+      )}
+
+      {error && <p className="text-red-700">{error}</p>}
+      {status === 'done' && (
+        <p className="text-green-700">
+          Posted. The engine has scored it and updated every dependent conclusion.
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === 'submitting' || !bumpsSatisfied || statement.trim().length < 10}
+        className="px-4 py-2 border border-gray-400 bg-white font-medium disabled:opacity-50 hover:bg-gray-100"
+      >
+        {status === 'submitting' ? 'Posting…' : 'Post — the engine scores it'}
+      </button>
+      <p className="text-xs text-[var(--muted-foreground)]">
+        No score is submitted from this form. Linkage starts at the schema default and is
+        debatable on the argument&apos;s linkage page; impact is computed by the engine.
+      </p>
+    </form>
+  )
+}

--- a/src/features/belief-analysis/components/ArgumentTreesSection.tsx
+++ b/src/features/belief-analysis/components/ArgumentTreesSection.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import type { ArgumentWithBelief } from '../types'
+import { justificationScore, truthShare, argumentMass } from '@/core/scoring/contrast-class'
 
 interface ArgumentTreesSectionProps {
   arguments: ArgumentWithBelief[]
@@ -88,6 +89,14 @@ export default function ArgumentTreesSection({
   const net = totalPro - totalCon
   const netLabel = `${net >= 0 ? '+' : ''}${net.toFixed(1)}`
 
+  // §4 of THE_DENOMINATOR: a bare net "+9.2" floats free. Divide it by the
+  // belief's own total argument weight to get the justification score — the
+  // share (implied probability) and margin a reader can actually act on.
+  const hasArgs = totalPro > 0 || totalCon > 0
+  const share = truthShare(totalPro, totalCon)
+  const margin = justificationScore(totalPro, totalCon)
+  const mass = argumentMass(totalPro, totalCon)
+
   return (
     <section>
       <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
@@ -149,10 +158,24 @@ export default function ArgumentTreesSection({
       </div>
 
       <p className="text-sm mt-4 p-2 bg-gray-100 border border-gray-300">
-        <strong>Net Belief Score: {totalPro > 0 || totalCon > 0 ? netLabel : '[pending]'}.</strong>{' '}
+        <strong>Net Belief Score: {hasArgs ? netLabel : '[pending]'}.</strong>{' '}
+        {hasArgs && share != null && (
+          <span>
+            The agree-case holds{' '}
+            <strong>{Math.round(share * 100)}%</strong> of the argument weight, a{' '}
+            <strong>{margin >= 0 ? '+' : ''}{Math.round(margin * 100)}-point</strong>{' '}
+            margin{' '}
+            <span className="text-[var(--muted-foreground)]">
+              (mass {mass.toFixed(1)})
+            </span>
+            .{' '}
+          </span>
+        )}
         {netInterpretation ?? (
           <span className="text-[var(--muted-foreground)] italic">
-            Interpretation appears once arguments are scored.
+            {hasArgs
+              ? 'This is the internal denominator only — how lopsided the belief is versus its own rebuttals, not whether it beats its rivals.'
+              : 'Interpretation appears once arguments are scored.'}
           </span>
         )}
       </p>

--- a/src/features/belief-analysis/components/ArgumentTreesSection.tsx
+++ b/src/features/belief-analysis/components/ArgumentTreesSection.tsx
@@ -139,7 +139,22 @@ function HalfRow({ arg }: { arg: ArgumentWithBelief | undefined }) {
   return (
     <>
       <td className="border border-gray-300 px-3 py-2 align-top"><ArgumentCell arg={arg} /></td>
-      <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs">{scoreCell(arg)}</td>
+      <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs">
+        {/* Every score is a doorway (Rule 6 keeps unscored cells blank, so a
+            blank is never a link). The Score is the child belief's own tree
+            score — clicking it drops into the sub-debate that produced it. */}
+        {scoreCell(arg) ? (
+          <Link
+            href={`/beliefs/${arg.belief.slug}`}
+            className="text-[var(--accent)] hover:underline"
+            title="The sub-debate that produced this score"
+          >
+            {scoreCell(arg)}
+          </Link>
+        ) : (
+          ''
+        )}
+      </td>
       <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs">
         {/* The linkage value links to the edge's own page: the debate about
             whether this argument actually bears on this belief. */}
@@ -155,8 +170,35 @@ function HalfRow({ arg }: { arg: ArgumentWithBelief | undefined }) {
           ''
         )}
       </td>
-      <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs">{impCell(arg)}</td>
-      <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs font-semibold">{impactCell(arg)}</td>
+      <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs">
+        {/* Importance links to the sub-belief that sources it, when one exists. */}
+        {impCell(arg) && arg.importanceBelief ? (
+          <Link
+            href={`/beliefs/${arg.importanceBelief.slug}`}
+            className="text-[var(--accent)] hover:underline"
+            title="The sub-debate about whether this argument matters"
+          >
+            {impCell(arg)}
+          </Link>
+        ) : (
+          impCell(arg)
+        )}
+      </td>
+      <td className="border border-gray-300 px-2 py-2 text-center align-top font-mono text-xs font-semibold">
+        {/* Impact links to the score-provenance page: the full derivation of
+            this edge's contribution, factor by factor. */}
+        {impactCell(arg) ? (
+          <Link
+            href={`/arguments/${arg.id}/score`}
+            className="text-[var(--accent)] hover:underline"
+            title="How this impact was computed"
+          >
+            {impactCell(arg)}
+          </Link>
+        ) : (
+          ''
+        )}
+      </td>
     </>
   )
 }
@@ -189,13 +231,15 @@ export default function ArgumentTreesSection({
     <section>
       <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
         <span>&#128269;</span>
-        <Link href="/Reasons" className="text-[var(--accent)] hover:underline">Argument Trees</Link>
+        Argument Trees
       </h2>
       <p className="text-sm text-[var(--muted-foreground)] mb-4">
         Each argument is a belief with its own page. Scores are recursive: Argument Score ×{' '}
-        <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Linkage</Link> ×{' '}
-        <Link href="/importance%20score" className="text-[var(--accent)] hover:underline">Importance</Link>{' '}
-        = Impact. Pro and con impacts sum to the Net Belief Score.
+        <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">Linkage</Link> ×{' '}
+        <Link href="/algorithms/importance-score" className="text-[var(--accent)] hover:underline">Importance</Link> ×{' '}
+        <Link href="/algorithms/unique-scores" className="text-[var(--accent)] hover:underline">Uniqueness</Link>{' '}
+        = Impact. Every score is a doorway — click it to enter the sub-debate that
+        produced it. Pro and con impacts sum to the Net Belief Score.
       </p>
 
       <div className="overflow-x-auto">
@@ -213,19 +257,19 @@ export default function ArgumentTreesSection({
               <th className="border border-gray-300 px-2 py-1.5 text-left w-[22%]">Argument</th>
               <th className="border border-gray-300 px-2 py-1.5 w-[5%]">Score</th>
               <th className="border border-gray-300 px-2 py-1.5 w-[5%]">
-                <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Link</Link>
+                <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">Link</Link>
               </th>
               <th className="border border-gray-300 px-2 py-1.5 w-[5%]">
-                <Link href="/importance%20score" className="text-[var(--accent)] hover:underline">Imp</Link>
+                <Link href="/algorithms/importance-score" className="text-[var(--accent)] hover:underline">Imp</Link>
               </th>
               <th className="border border-gray-300 px-2 py-1.5 w-[6%]">Impact</th>
               <th className="border border-gray-300 px-2 py-1.5 text-left w-[22%]">Argument</th>
               <th className="border border-gray-300 px-2 py-1.5 w-[5%]">Score</th>
               <th className="border border-gray-300 px-2 py-1.5 w-[5%]">
-                <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Link</Link>
+                <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">Link</Link>
               </th>
               <th className="border border-gray-300 px-2 py-1.5 w-[5%]">
-                <Link href="/importance%20score" className="text-[var(--accent)] hover:underline">Imp</Link>
+                <Link href="/algorithms/importance-score" className="text-[var(--accent)] hover:underline">Imp</Link>
               </th>
               <th className="border border-gray-300 px-2 py-1.5 w-[6%]">Impact</th>
             </tr>

--- a/src/features/belief-analysis/components/BeliefMappingSection.tsx
+++ b/src/features/belief-analysis/components/BeliefMappingSection.tsx
@@ -92,7 +92,7 @@ export default function BeliefMappingSection({ upstreamMappings, downstreamMappi
       <SectionHeading
         emoji="&#x1F9ED;"
         title="General to Specific Belief Mapping"
-        href="/Belief%20Sorting"
+        href="/beliefs"
       />
 
       <h3 className="text-base font-bold text-[var(--foreground)] mb-3">Most General (Upstream)</h3>

--- a/src/features/belief-analysis/components/BiasesSection.tsx
+++ b/src/features/belief-analysis/components/BiasesSection.tsx
@@ -55,7 +55,6 @@ export default function BiasesSection({
       <SectionHeading
         emoji="&#x1F9E0;"
         title="Biases"
-        href="/bias"
       />
 
       <div className="overflow-x-auto">

--- a/src/features/belief-analysis/components/CompromisesSection.tsx
+++ b/src/features/belief-analysis/components/CompromisesSection.tsx
@@ -11,7 +11,7 @@ export default function CompromisesSection({ compromises }: CompromisesSectionPr
       <SectionHeading
         emoji="&#x1F91D;"
         title="Best Compromise Solutions"
-        href="/Compromise"
+        href="/how-it-works"
       />
 
       <div className="overflow-x-auto">

--- a/src/features/belief-analysis/components/ConflictResolutionSection.tsx
+++ b/src/features/belief-analysis/components/ConflictResolutionSection.tsx
@@ -8,6 +8,7 @@ import type {
   DisputeTypeItem,
   ObstacleItem,
 } from '../types'
+import type { ConflictResolutionReadout } from '@/core/scoring/conflict-resolution'
 import { byScoreDesc, formatScore, rankByScore, TABLE_TOP_LIMIT } from '../lib/ranking'
 import ExpandableRows from './ExpandableRows'
 
@@ -21,6 +22,10 @@ interface ConflictResolutionSectionProps {
   obstacles: ObstacleItem[]
   /** Deep-dive link to the interests-and-motivation dashboard, when one exists. */
   interestsDashboardHref?: string
+  /** The computed pipeline readout (shared interests, primary conflict pair,
+   *  value conflicts, compromise candidates). Optional so reuse sites keep
+   *  working without it. */
+  readout?: ConflictResolutionReadout | null
 }
 
 function lines(text: string | null | undefined): React.ReactNode {
@@ -57,7 +62,7 @@ function SharedValuesTable({ rows, whatWouldShift }: { rows: ValueRankingItem[];
       <thead>
         <tr className="bg-gray-100">
           <th className={`${TH} w-[24%]`}>
-            <Link href="/American%20values" className="text-[var(--accent)] hover:underline">Value</Link>
+            Value
           </th>
           <th className={`${TH} text-center w-[10%]`}>Supporter Rank</th>
           <th className={`${TH} text-center w-[10%]`}>Opponent Rank</th>
@@ -109,11 +114,11 @@ function InterestTable({ entries, headerClass }: { entries: InterestEntryItem[];
       <thead>
         <tr className={headerClass}>
           <th className={`${TH} w-[30%]`}>
-            <Link href="/Interests" className="text-[var(--accent)] hover:underline">Interest</Link>
+            Interest
           </th>
           <th className={`${TH} text-center w-[10%]`}>Prevalence</th>
           <th className={`${TH} text-center w-[12%]`}>
-            <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Linkage Confidence</Link>
+            <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">Linkage Confidence</Link>
           </th>
           <th className={`${TH} text-center w-[12%]`}>Validity</th>
           <th className={`${TH} w-[18%]`}>Evidence Basis</th>
@@ -336,6 +341,95 @@ function ObstaclesTable({ obstacles }: { obstacles: ObstacleItem[] }) {
   )
 }
 
+/* ── The computed pipeline readout ──────────────────────────────────────── */
+function PipelineReadout({ readout }: { readout: ConflictResolutionReadout }) {
+  const {
+    sharedInterests: shared,
+    primaryConflictPair: pair,
+    valueConflicts,
+    compromiseCandidates,
+  } = readout
+  const hasAny =
+    shared.length > 0 || pair != null || valueConflicts.length > 0 || compromiseCandidates.length > 0
+
+  return (
+    <div className="border border-gray-300 bg-gray-50 p-3 text-sm space-y-3">
+      <p className="font-semibold">
+        Pipeline readout{' '}
+        <span className="font-normal text-xs text-[var(--muted-foreground)]">
+          — computed from the scored rows below, never hand-authored
+        </span>
+      </p>
+      {!hasAny && (
+        <p className="text-[var(--muted-foreground)] italic">
+          Appears once this page carries scored interests, value rankings, and
+          cost/benefit rows for the pipeline to read.
+        </p>
+      )}
+      {shared.length > 0 && (
+        <div>
+          <p className="font-medium">Interests both sides actually share</p>
+          <ul className="list-disc ml-5">
+            {shared.slice(0, TABLE_TOP_LIMIT).map(s => (
+              <li key={`${s.supporterId}-${s.opponentId}`}>
+                &ldquo;{s.supporterInterest}&rdquo; ↔ &ldquo;{s.opponentInterest}&rdquo;{' '}
+                <span className="font-mono text-xs">
+                  (similarity {Math.round(s.similarity * 100)}%, paired validity{' '}
+                  {s.pairedValidity.toFixed(0)})
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {pair && (
+        <div>
+          <p className="font-medium">Primary conflict pair (what actually drives the disagreement)</p>
+          <p>
+            Supporters: &ldquo;{pair.supporter.interest}&rdquo;{' '}
+            <span className="font-mono text-xs">(drive {pair.supporterDrive.toFixed(0)})</span>{' '}
+            vs. opponents: &ldquo;{pair.opponent.interest}&rdquo;{' '}
+            <span className="font-mono text-xs">(drive {pair.opponentDrive.toFixed(0)})</span>.
+            Drive = how well the interest explains the side&apos;s actual behavior, weighted by
+            its standalone validity.
+          </p>
+        </div>
+      )}
+      {valueConflicts.length > 0 && (
+        <div>
+          <p className="font-medium">Genuine value conflicts (same values, priced apart)</p>
+          <ul className="list-disc ml-5">
+            {valueConflicts.slice(0, TABLE_TOP_LIMIT).map(v => (
+              <li key={v.id}>
+                {v.value}: supporters rank it #{v.supporterRank}, opponents #{v.opponentRank}{' '}
+                <span className="font-mono text-xs">(gap {v.gap})</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {compromiseCandidates.length > 0 && (
+        <div>
+          <p className="font-medium">
+            Compromise candidates — a small likelihood shift flips a category&apos;s net
+          </p>
+          <ul className="list-disc ml-5">
+            {compromiseCandidates.slice(0, TABLE_TOP_LIMIT).map(c => (
+              <li key={c.itemId}>
+                In <strong>{c.category}</strong> (net {c.net >= 0 ? '+' : ''}
+                {c.net.toFixed(1)}): {c.direction === 'raise' ? 'raising' : 'lowering'} the
+                likelihood of &ldquo;{c.claim}&rdquo; by just{' '}
+                <span className="font-mono">{(c.requiredShift * 100).toFixed(0)}%</span> flips the
+                category. This is a winnable, evidence-resolvable disagreement.
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function ConflictResolutionSection({
   values,
   interests,
@@ -345,6 +439,7 @@ export default function ConflictResolutionSection({
   disputeTypes,
   obstacles,
   interestsDashboardHref,
+  readout,
 }: ConflictResolutionSectionProps) {
   const supporterInterests = interestEntries.filter(e => e.side === 'supporter')
   const opponentInterests = interestEntries.filter(e => e.side === 'opponent')
@@ -354,16 +449,17 @@ export default function ConflictResolutionSection({
       <div>
         <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
           <span>&#129309;</span>
-          <Link href="/automate%20conflict%20resolution" className="text-[var(--accent)] hover:underline">Conflict Resolution</Link>{' '}Framework
+          Conflict Resolution Framework
         </h2>
         <p className="text-sm text-[var(--muted-foreground)]">
-          Both sides of most debates share the same{' '}
-          <Link href="/American%20values" className="text-[var(--accent)] hover:underline">values</Link>. They disagree about how to{' '}
+          Both sides of most debates share the same values. They disagree about how to{' '}
           <strong>rank</strong> them, and that ranking shifts based on perceived{' '}
-          <Link href="/cost-benefit%20analysis" className="text-[var(--accent)] hover:underline">costs, benefits</Link>, and{' '}
-          <Link href="/Likelihood" className="text-[var(--accent)] hover:underline">likelihood of success</Link>.
+          <Link href="/cba/about" className="text-[var(--accent)] hover:underline">costs, benefits</Link>, and{' '}
+          <Link href="/cba/about" className="text-[var(--accent)] hover:underline">likelihood of success</Link>.
         </p>
       </div>
+
+      {readout && <PipelineReadout readout={readout} />}
 
       <div>
         <h3 className="text-base font-semibold mb-1 flex items-center gap-2">

--- a/src/features/belief-analysis/components/ContrastClassSection.tsx
+++ b/src/features/belief-analysis/components/ContrastClassSection.tsx
@@ -1,0 +1,131 @@
+import Link from 'next/link'
+import type { ContrastClassData } from '../types'
+import {
+  comparativeScores,
+  type ContrastOption,
+} from '@/core/scoring/contrast-class'
+
+interface ContrastClassSectionProps {
+  contrastClass: ContrastClassData | null | undefined
+}
+
+const TH = 'border border-gray-300 px-3 py-2 text-left font-semibold'
+const TD = 'border border-gray-300 px-3 py-2 align-top'
+const TDC = 'border border-gray-300 px-3 py-2 align-top text-center font-mono text-xs'
+
+function fmtScore(v: number | null): string {
+  if (v == null) return ''
+  return v.toFixed(2)
+}
+
+function fmtOcv(v: number | null): string {
+  if (v == null) return ''
+  return `${v >= 0 ? '+' : ''}${v.toFixed(2)}`
+}
+
+/**
+ * The Contrast Class block — the denominator made visible. Lists the mutually
+ * exclusive rivals the focal belief is priced against, and (once their tree
+ * scores exist) the opportunity-cost value of each against its best rival. A
+ * bare pro-minus-con score silently picks "do nothing" as the denominator;
+ * this section names the real one. See docs/THE_DENOMINATOR.md.
+ */
+export default function ContrastClassSection({ contrastClass }: ContrastClassSectionProps) {
+  if (!contrastClass || contrastClass.options.length === 0) return null
+
+  const { question, options } = contrastClass
+
+  // Only run the comparative layer when every option carries a real score
+  // (Rule 6: no fabricated OCV from missing scores).
+  const allScored = options.every(o => o.score != null)
+  const scored: ContrastOption[] = options.map(o => ({
+    id: o.id,
+    label: o.label,
+    score: o.score ?? 0,
+  }))
+  const comparative = allScored ? comparativeScores(scored) : null
+
+  const focal = options.find(o => o.isFocal)
+  const focalResult = comparative && focal
+    ? comparative.find(r => r.id === focal.id)
+    : null
+  const bestRival = focalResult?.bestRivalId
+    ? options.find(o => o.id === focalResult.bestRivalId)
+    : null
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
+        <span>&#9878;&#65039;</span>
+        Contrast Class
+      </h2>
+      <p className="text-sm text-[var(--muted-foreground)] mb-4">
+        The denominator, made visible. A score is always{' '}
+        <em>compared to what</em> — these are the mutually exclusive rivals that
+        answer the same question and compete for the same slot. The{' '}
+        <Link href="/algorithms/strong-to-weak" className="text-[var(--accent)] hover:underline">value</Link>{' '}
+        of an option is what it delivers minus what the best alternative would
+        have delivered.
+      </p>
+      <p className="text-sm mb-4">
+        <strong>Question:</strong> {question}
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse border border-gray-300 text-sm">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className={`${TH} w-[28%]`}>Option</th>
+              <th className={`${TH} w-[40%]`}>One-line</th>
+              <th className={`${TH} text-center w-[16%]`}>Score</th>
+              <th className={`${TH} text-center w-[16%]`}>vs. best rival</th>
+            </tr>
+          </thead>
+          <tbody>
+            {options.map(o => {
+              const r = comparative?.find(c => c.id === o.id)
+              return (
+                <tr key={o.id} className={o.isFocal ? 'bg-yellow-50 font-semibold' : ''}>
+                  <td className={TD}>
+                    {o.slug ? (
+                      <Link href={`/beliefs/${o.slug}`} className="text-[var(--accent)] hover:underline">
+                        {o.label}
+                      </Link>
+                    ) : (
+                      o.label
+                    )}
+                    {o.isFocal && (
+                      <span className="text-xs text-[var(--muted-foreground)] font-normal"> (this belief)</span>
+                    )}
+                  </td>
+                  <td className={TD}>{o.oneLine ?? <span>&nbsp;</span>}</td>
+                  <td className={TDC}>{fmtScore(o.score)}</td>
+                  <td className={`${TDC} ${r && r.ocv != null ? (r.ocv > 0 ? 'text-green-700' : 'text-red-700') : ''}`}>
+                    {r ? fmtOcv(r.ocv) : ''}
+                    {r?.isWinner && <span className="text-green-700"> ★</span>}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {focalResult && focalResult.ocv != null && bestRival ? (
+        <p className="text-sm mt-4 p-2 bg-gray-100 border border-gray-300">
+          <strong>
+            Opportunity-cost value: {fmtOcv(focalResult.ocv)} vs. {bestRival.label}.
+          </strong>{' '}
+          {focalResult.ocv > 0
+            ? `This is the best option in the field — it beats its strongest rival (${bestRival.label}) by ${focalResult.ocv.toFixed(2)}.`
+            : `This option loses to its best rival (${bestRival.label}) by ${Math.abs(focalResult.ocv).toFixed(2)} — the verdict is "worse than ${bestRival.label}", not "good or bad in the abstract".`}
+        </p>
+      ) : (
+        <p className="text-sm mt-4 text-[var(--muted-foreground)] italic">
+          Opportunity-cost value appears once every option in the class carries a
+          scored argument tree.
+        </p>
+      )}
+    </section>
+  )
+}

--- a/src/features/belief-analysis/components/ContributeSection.tsx
+++ b/src/features/belief-analysis/components/ContributeSection.tsx
@@ -1,6 +1,33 @@
 import Link from 'next/link'
+import type { ArgumentWithBelief } from '../types'
+import AddArgumentForm from './AddArgumentForm'
 
-export default function ContributeSection() {
+interface ContributeSectionProps {
+  /** When set, the section renders the live add-a-reason form. Optional so
+   *  reuse sites (legacy routes) keep the static footer. */
+  beliefId?: number
+  highStakes?: boolean
+  arguments?: ArgumentWithBelief[]
+}
+
+function strongest(args: ArgumentWithBelief[], side: string) {
+  const onSide = args.filter(a => a.side === side)
+  if (onSide.length === 0) return null
+  const best = onSide.reduce((a, b) =>
+    Math.abs(b.impactScore) > Math.abs(a.impactScore) ? b : a,
+  )
+  return {
+    id: best.id,
+    claim: best.claim ?? best.belief.statement,
+    impactScore: best.impactScore,
+  }
+}
+
+export default function ContributeSection({
+  beliefId,
+  highStakes = false,
+  arguments: args = [],
+}: ContributeSectionProps) {
   return (
     <section>
       <h1 className="text-2xl font-bold text-[var(--foreground)] mb-4 flex items-center gap-2">
@@ -8,9 +35,22 @@ export default function ContributeSection() {
       </h1>
 
       <p className="text-sm mb-3">
-        Posted by ~<Link href="/Myclob" className="text-[var(--accent)] hover:underline">Myclob</Link>.{' '}
-        <Link href="/Contact%20Me" className="text-[var(--accent)] hover:underline">Contact me</Link> to contribute to the Idea Stock Exchange.
+        Two moves are supported: <strong>add a row</strong> — a new reason to agree or
+        disagree, below — or <strong>challenge a number</strong>: every score on this page is a
+        doorway into the sub-debate that produced it, so click the score you disagree with and
+        argue there.
       </p>
+
+      {beliefId != null && (
+        <div className="mb-4">
+          <AddArgumentForm
+            beliefId={beliefId}
+            highStakes={highStakes}
+            strongestAgree={strongest(args, 'agree')}
+            strongestDisagree={strongest(args, 'disagree')}
+          />
+        </div>
+      )}
 
       <p className="text-sm mb-4">
         <a
@@ -26,10 +66,10 @@ export default function ContributeSection() {
 
       <p className="text-sm mb-2">Start by exploring how we:</p>
       <ul className="list-disc list-inside text-sm space-y-1 mb-4 text-[var(--muted-foreground)]">
-        <li>Calculate <Link href="/Argument%20scores%20from%20sub-argument%20scores" className="text-[var(--accent)] hover:underline">argument scores from sub-arguments</Link></li>
-        <li>Measure <Link href="/truth" className="text-[var(--accent)] hover:underline">truth</Link> and <Link href="/Evidence" className="text-[var(--accent)] hover:underline">evidence quality</Link></li>
-        <li>Apply <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">linkage scores</Link> to weight relevance</li>
-        <li>Implement <Link href="/ReasonRank" className="text-[var(--accent)] hover:underline">ReasonRank</Link> for quality-based sorting</li>
+        <li>Calculate <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">argument scores from sub-arguments</Link></li>
+        <li>Measure <Link href="/algorithms/truth-scores" className="text-[var(--accent)] hover:underline">truth</Link> and <Link href="/algorithms/evidence-scores" className="text-[var(--accent)] hover:underline">evidence quality</Link></li>
+        <li>Apply <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">linkage scores</Link> to weight relevance</li>
+        <li>Discount restatements with <Link href="/algorithms/unique-scores" className="text-[var(--accent)] hover:underline">uniqueness scores</Link></li>
       </ul>
 
       <p className="text-sm text-[var(--muted-foreground)]">

--- a/src/features/belief-analysis/components/CostBenefitSection.tsx
+++ b/src/features/belief-analysis/components/CostBenefitSection.tsx
@@ -164,7 +164,7 @@ export default function CostBenefitSection({
       <div>
         <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
           <span>&#9878;</span>
-          <Link href="/cost-benefit%20analysis" className="text-[var(--accent)] hover:underline">Cost-Benefit Analysis</Link>
+          <Link href="/cba/about" className="text-[var(--accent)] hover:underline">Cost-Benefit Analysis</Link>
         </h2>
         <p className="text-sm text-[var(--muted-foreground)] mb-3">
           Every cost and benefit is itself a debatable claim with its own argument tree. Magnitude is
@@ -244,7 +244,7 @@ export default function CostBenefitSection({
       <div>
         <h3 className="text-base font-semibold mb-2 flex items-center gap-2">
           <span>&#129309;</span>
-          <Link href="/Compromise" className="text-[var(--accent)] hover:underline">Best Compromise Solutions</Link>
+          <Link href="/how-it-works" className="text-[var(--accent)] hover:underline">Best Compromise Solutions</Link>
         </h3>
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>

--- a/src/features/belief-analysis/components/DefinitionsSection.tsx
+++ b/src/features/belief-analysis/components/DefinitionsSection.tsx
@@ -27,12 +27,12 @@ export default function DefinitionsSection({ definitions }: DefinitionsSectionPr
       <div className="text-sm text-[var(--foreground)] space-y-3 mb-5">
         <p>
           <strong>Arguments vs. Evidence.</strong>{' '}
-          <Link href="/Reasons" className="text-[var(--accent)] hover:underline">Arguments</Link>{' '}
+          <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">Arguments</Link>{' '}
           are logical claims — scored by{' '}
-          <Link href="/Logical%20Validity%20Scores" className="text-[var(--accent)] hover:underline">logical validity</Link>{' '}
+          <Link href="/algorithms/truth-scores" className="text-[var(--accent)] hover:underline">logical validity</Link>{' '}
           and{' '}
-          <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">linkage strength</Link>.{' '}
-          <Link href="/Evidence" className="text-[var(--accent)] hover:underline">Evidence</Link>{' '}
+          <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">linkage strength</Link>.{' '}
+          <Link href="/algorithms/evidence-scores" className="text-[var(--accent)] hover:underline">Evidence</Link>{' '}
           is empirical data — scored by source tier and conclusion relevance. The scoring
           formula is <em>Argument Score = Evidence Quality x Logical Validity x Linkage Strength</em>.
           An argument with great evidence but a logical fallacy still scores low. Evidence
@@ -48,13 +48,13 @@ export default function DefinitionsSection({ definitions }: DefinitionsSectionPr
         </p>
         <p>
           <strong>Scoring Concepts.</strong>{' '}
-          <Link href="/Argument%20scores%20from%20sub-argument%20scores" className="text-[var(--accent)] hover:underline">Argument Scores</Link>{' '}
+          <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">Argument Scores</Link>{' '}
           are computed recursively — never manually assigned.{' '}
-          <Link href="/truth" className="text-[var(--accent)] hover:underline">Truth Scores</Link>{' '}
+          <Link href="/algorithms/truth-scores" className="text-[var(--accent)] hover:underline">Truth Scores</Link>{' '}
           integrate validity, evidence, and linkage.{' '}
-          <Link href="/Importance%20Score" className="text-[var(--accent)] hover:underline">Importance Scores</Link>{' '}
+          <Link href="/algorithms/importance-score" className="text-[var(--accent)] hover:underline">Importance Scores</Link>{' '}
           weight arguments by how much they move the needle.{' '}
-          <Link href="/ReasonRank" className="text-[var(--accent)] hover:underline">ReasonRank</Link>{' '}
+          <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">ReasonRank</Link>{' '}
           sorts by quality, not volume or recency.
         </p>
       </div>

--- a/src/features/belief-analysis/components/EvidenceSection.tsx
+++ b/src/features/belief-analysis/components/EvidenceSection.tsx
@@ -63,7 +63,7 @@ export default function EvidenceSection({ evidence }: EvidenceSectionProps) {
     <section>
       <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
         <span>&#128202;</span>
-        <Link href="/Evidence" className="text-[var(--accent)] hover:underline">Evidence Ledger</Link>
+        <Link href="/algorithms/evidence-scores" className="text-[var(--accent)] hover:underline">Evidence Ledger</Link>
       </h2>
       <p className="text-sm text-[var(--muted-foreground)] mb-4 italic">
         Key: <strong>T1</strong>=Peer-reviewed/Official, <strong>T2</strong>=Expert/Institutional,{' '}
@@ -85,13 +85,13 @@ export default function EvidenceSection({ evidence }: EvidenceSectionProps) {
               <th className="border border-gray-300 px-2 py-1.5 text-left w-[22%]">Evidence</th>
               <th className="border border-gray-300 px-2 py-1.5 w-[7%]">Type</th>
               <th className="border border-gray-300 px-2 py-1.5 w-[7%]">
-                <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Link</Link>
+                <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">Link</Link>
               </th>
               <th className="border border-gray-300 px-2 py-1.5 w-[7%]">Impact</th>
               <th className="border border-gray-300 px-2 py-1.5 text-left w-[22%]">Evidence</th>
               <th className="border border-gray-300 px-2 py-1.5 w-[7%]">Type</th>
               <th className="border border-gray-300 px-2 py-1.5 w-[7%]">
-                <Link href="/Linkage%20Scores" className="text-[var(--accent)] hover:underline">Link</Link>
+                <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">Link</Link>
               </th>
               <th className="border border-gray-300 px-2 py-1.5 w-[7%]">Impact</th>
             </tr>

--- a/src/features/belief-analysis/components/ISEExampleSection.tsx
+++ b/src/features/belief-analysis/components/ISEExampleSection.tsx
@@ -26,30 +26,30 @@ export default function ISEExampleSection() {
         </code>{' '}
         and instantly inherits the same structural template every belief on the platform
         uses:{' '}
-        <Link href="/Argument%20Trees" className="text-[var(--accent)] hover:underline">
+        <Link href="/how-it-works" className="text-[var(--accent)] hover:underline">
           Argument Trees
         </Link>
         ,{' '}
-        <Link href="/Evidence%20Scoring" className="text-[var(--accent)] hover:underline">
+        <Link href="/algorithms/evidence-scores" className="text-[var(--accent)] hover:underline">
           Evidence Scoring
         </Link>
         ,{' '}
         <Link
-          href="/w/page/159351732/Objective%20criteria%20scores"
+          href="/algorithms/objective-criteria"
           className="text-[var(--accent)] hover:underline"
         >
           Objective Criteria weighting
         </Link>
         ,{' '}
         <Link
-          href="/w/page/156187122/cost-benefit%20analysis"
+          href="/cba/about"
           className="text-[var(--accent)] hover:underline"
         >
           Cost-Benefit Analysis
         </Link>
         , and{' '}
         <Link
-          href="/w/page/156186840/automate%20conflict%20resolution"
+          href="/how-it-works"
           className="text-[var(--accent)] hover:underline"
         >
           Conflict Resolution mapping
@@ -68,7 +68,7 @@ export default function ISEExampleSection() {
         Before Jane Smith&apos;s page existed, the Colorado Senate node already contained
         a scored, community-built set of{' '}
         <Link
-          href="/w/page/159351732/Objective%20criteria%20scores"
+          href="/algorithms/objective-criteria"
           className="text-[var(--accent)] hover:underline"
         >
           Objective Criteria

--- a/src/features/belief-analysis/components/LegalSection.tsx
+++ b/src/features/belief-analysis/components/LegalSection.tsx
@@ -46,7 +46,7 @@ export default function LegalSection({ legal }: LegalSectionProps) {
       <SectionHeading
         emoji="&#x2696;&#xFE0F;"
         title="Legal Framework"
-        href="/Local%2C%20federal%2C%20and%20international%20laws%20that%20agree"
+        href="/how-it-works"
       />
 
       <div className="overflow-x-auto">

--- a/src/features/belief-analysis/components/ObjectiveCriteriaSection.tsx
+++ b/src/features/belief-analysis/components/ObjectiveCriteriaSection.tsx
@@ -38,7 +38,7 @@ export default function ObjectiveCriteriaSection({ criteria }: ObjectiveCriteria
     <section>
       <h2 className="text-xl font-bold text-[var(--foreground)] flex items-center gap-2 mb-2">
         <span>&#127919;</span>
-        <Link href="/Objective%20criteria%20scores" className="text-[var(--accent)] hover:underline">Objective Criteria</Link>
+        <Link href="/algorithms/objective-criteria" className="text-[var(--accent)] hover:underline">Objective Criteria</Link>
       </h2>
       <p className="text-sm text-[var(--muted-foreground)] mb-3">
         These are the measurements that would settle this debate if both sides committed to them in

--- a/src/features/belief-analysis/components/ObstaclesSection.tsx
+++ b/src/features/belief-analysis/components/ObstaclesSection.tsx
@@ -14,7 +14,7 @@ export default function ObstaclesSection({ obstacles }: ObstaclesSectionProps) {
       <SectionHeading
         emoji="&#x1F6A7;"
         title="Primary Obstacles to Resolution"
-        href="/Obstacles%20to%20Resolution"
+        href="/how-it-works"
       />
 
       <div className="overflow-x-auto">

--- a/src/features/belief-analysis/components/ScorecardSection.tsx
+++ b/src/features/belief-analysis/components/ScorecardSection.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import type { ArgumentWithBelief, FalsifiabilityItemRow } from '../types'
+import type { ArgumentWithBelief, BeliefScores, FalsifiabilityItemRow } from '../types'
 import { byScoreDesc } from '../lib/ranking'
 
 interface ScorecardSectionProps {
@@ -12,6 +12,25 @@ interface ScorecardSectionProps {
   scoreMover: string | null
   /** Fallback for scoreMover: the top-ranked falsifiability score-movers. */
   falsifiabilityItems: FalsifiabilityItemRow[]
+  /** The full twelve-dimension engine readout. Optional so reuse sites
+   *  (product reviews, legacy routes) keep working without it. */
+  scores?: BeliefScores
+}
+
+/** One row of the twelve-dimension readout. */
+interface DimensionRow {
+  name: string
+  value: number | null
+  format: 'ratio' | 'signed' | 'percent'
+  href: string | null
+  note: string
+}
+
+function formatDimension(row: DimensionRow): string {
+  if (row.value == null) return ''
+  if (row.format === 'signed') return `${row.value >= 0 ? '+' : ''}${row.value.toFixed(1)}`
+  if (row.format === 'percent') return `${Math.round(row.value * 100)}%`
+  return row.value.toFixed(2)
 }
 
 const TD = 'border border-gray-300 px-3 py-2 align-top'
@@ -39,6 +58,7 @@ export default function ScorecardSection({
   bottomLine,
   scoreMover,
   falsifiabilityItems,
+  scores,
 }: ScorecardSectionProps) {
   const impact = (a: ArgumentWithBelief) => (a.impactScore ? Math.abs(a.impactScore) : null)
   const bestPro = args.filter(a => a.side === 'agree').sort(byScoreDesc(impact))[0] ?? null
@@ -49,6 +69,26 @@ export default function ScorecardSection({
   const netLabel = hasArgs ? `${net >= 0 ? '+' : ''}${net.toFixed(1)}` : '[pending]'
 
   const topMover = scoreMover ?? falsifiabilityItems[0]?.description ?? null
+
+  // The twelve score dimensions, straight from the engine (computeBeliefScores).
+  // Null values render blank (Rule 6); dimensions with an explainer route link
+  // to it, so every number here is a doorway too.
+  const dimensions: DimensionRow[] | null = scores
+    ? [
+        { name: 'Truth (net)', value: hasArgs ? scores.overallScore : null, format: 'signed', href: '/algorithms/truth-scores', note: 'normalized pro-vs-con balance, arguments + evidence' },
+        { name: 'Logical validity', value: hasArgs ? scores.logicalValidityScore : null, format: 'ratio', href: '/algorithms/truth-scores', note: 'argument-side share of the truth score' },
+        { name: 'Linkage (avg)', value: hasArgs ? scores.avgLinkageScore : null, format: 'ratio', href: '/algorithms/linkage-scores', note: 'mean relevance of the arguments on this page' },
+        { name: 'Importance-weighted', value: hasArgs ? scores.importanceWeightedScore : null, format: 'ratio', href: '/algorithms/importance-score', note: 'pro share after weighting by how much each argument matters' },
+        { name: 'Evidence (EVS)', value: hasArgs ? scores.aggregateEvidenceScore : null, format: 'ratio', href: '/algorithms/evidence-scores', note: 'supporting share of evidence-verification weight' },
+        { name: 'CBA likelihood', value: scores.cbaLikelihoodScore, format: 'ratio', href: '/cba/about', note: 'benefit-vs-cost likelihood balance' },
+        { name: 'Objective criteria', value: scores.objectiveCriteriaScore, format: 'ratio', href: '/algorithms/objective-criteria', note: 'pre-committed measurements, scored' },
+        { name: 'Confidence stability', value: hasArgs ? scores.stabilityScore : null, format: 'ratio', href: null, note: `how settled the score is under scrutiny (${scores.stabilityStatus})` },
+        { name: 'Media truth', value: scores.mediaTruthScore, format: 'ratio', href: null, note: 'average truth score of linked media' },
+        { name: 'Media genre', value: scores.mediaGenreScore, format: 'ratio', href: null, note: 'reporting-vs-opinion mix of linked media' },
+        { name: 'Uniqueness (avg)', value: hasArgs ? scores.topicOverlapScore : null, format: 'ratio', href: '/algorithms/unique-scores', note: 'how little the arguments restate each other' },
+        { name: 'Strength-adjusted', value: hasArgs ? scores.strengthAdjustedScore : null, format: 'ratio', href: '/algorithms/strong-to-weak', note: `truth after the claim-strength penalty (claims ${scores.claimStrength.toFixed(1)})` },
+      ]
+    : null
 
   return (
     <section>
@@ -66,7 +106,7 @@ export default function ScorecardSection({
               )}{' '}
               <span className="text-xs text-[#555]">
                 · scores are the{' '}
-                <Link href="/ReasonRank" className="text-[var(--accent)] hover:underline">ReasonRank</Link>{' '}
+                <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">ReasonRank</Link>{' '}
                 performance of each row&apos;s pro/con sub-debate
               </span>
             </td>
@@ -99,10 +139,36 @@ export default function ScorecardSection({
           </tr>
         </tbody>
       </table>
+      {dimensions && (
+        <details className="mt-3 text-sm border border-gray-300">
+          <summary className="cursor-pointer px-3 py-2 bg-[#f0f3f6] font-semibold hover:text-[var(--accent)]">
+            The twelve score dimensions (engine readout)
+          </summary>
+          <table className="w-full border-collapse text-sm">
+            <tbody>
+              {dimensions.map((d, i) => (
+                <tr key={d.name} className={i % 2 === 1 ? 'bg-gray-50' : ''}>
+                  <td className="border-t border-gray-300 px-3 py-1.5 w-1/4 font-medium">
+                    {d.href ? (
+                      <Link href={d.href} className="text-[var(--accent)] hover:underline">{d.name}</Link>
+                    ) : (
+                      d.name
+                    )}
+                  </td>
+                  <td className="border-t border-gray-300 px-3 py-1.5 w-[12%] text-center font-mono text-xs">
+                    {formatDimension(d)}
+                  </td>
+                  <td className="border-t border-gray-300 px-3 py-1.5 text-xs text-[#555]">{d.note}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      )}
       <p className="text-sm mt-3 p-2 bg-[#f0f3f6] border border-gray-300">
         <strong>How to read this page:</strong> nothing here is placed by editorial choice. Every row
         in every table is itself a claim, and its Score is the{' '}
-        <Link href="/ReasonRank" className="text-[var(--accent)] hover:underline">ReasonRank</Link>{' '}
+        <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">ReasonRank</Link>{' '}
         performance of the pro/con sub-debate about that claim, computed recursively down to the
         evidence. Every table sorts by Score, best content first; each table shows its top rows and
         collapses the rest until expanded. Score cells stay blank until real content exists to score.

--- a/src/features/belief-analysis/components/SpectrumsHeader.tsx
+++ b/src/features/belief-analysis/components/SpectrumsHeader.tsx
@@ -81,7 +81,7 @@ export default function SpectrumsHeader({ positivity, specificity, claimStrength
       <div className="text-xs font-semibold text-[var(--muted-foreground)] mb-2 flex items-center gap-2">
         <span>Three Spectrums</span>
         <Link
-          href="/One%20Page%20Per%20Belief"
+          href="/how-it-works"
           className="text-[var(--accent)] hover:underline text-[10px] font-normal"
         >
           (what is this?)

--- a/src/features/belief-analysis/components/ValuesSection.tsx
+++ b/src/features/belief-analysis/components/ValuesSection.tsx
@@ -162,7 +162,7 @@ export default function ValuesSection({ values }: ValuesSectionProps) {
       <SectionHeading
         emoji="&#x2696;&#xFE0F;"
         title="Values Conflict Analysis"
-        href="/American%20values"
+        href="/how-it-works"
         subtitle="Most disagreements are not value conflicts. They are priority conflicts. Both sides usually hold the same values but rank them differently on this topic."
       />
 

--- a/src/features/belief-analysis/data/contrast-classes.ts
+++ b/src/features/belief-analysis/data/contrast-classes.ts
@@ -1,0 +1,111 @@
+import { prisma } from '@/lib/prisma'
+import type { ContrastClassData, ContrastClassOption } from '../types'
+
+/**
+ * Static contrast-class definitions, keyed by the focal belief's slug.
+ *
+ * A contrast class is the set of mutually exclusive rivals that answer the same
+ * topic question and compete for the same slot — the denominator a belief is
+ * priced against (docs/THE_DENOMINATOR.md). The option SCORES are not stored
+ * here: each option points at its own belief by slug, and its score is resolved
+ * from that belief's own argument tree at fetch time, so every number under the
+ * line stays traceable (invariant §8.7). This lives as a static overlay (like
+ * spectrum-coordinates.ts) so existing Prisma data keeps flowing untouched; a
+ * future schema can promote it to a first-class topic relation.
+ */
+interface ContrastClassTemplate {
+  question: string
+  options: Array<{
+    id: string
+    label: string
+    oneLine?: string
+    /** Slug of the belief whose tree supplies this option's score. */
+    slug?: string
+    isFocal?: boolean
+  }>
+}
+
+const CONTRAST_CLASSES: Record<string, ContrastClassTemplate> = {
+  'universal-basic-income-should-be-implemented': {
+    question:
+      'What mechanism should guarantee a basic income floor in a developed economy?',
+    options: [
+      {
+        id: 'ubi',
+        label: 'Universal Basic Income',
+        oneLine: 'Unconditional flat cash payment to every adult',
+        slug: 'universal-basic-income-should-be-implemented',
+        isFocal: true,
+      },
+      {
+        id: 'nit',
+        label: 'Negative income tax',
+        oneLine: 'A transfer that phases out as earnings rise',
+        slug: 'negative-income-tax',
+      },
+      {
+        id: 'falc',
+        label: 'Fully automated luxury communism',
+        oneLine: 'Abolish wage labor once automation is total',
+        slug: 'fully-automated-luxury-communism',
+      },
+    ],
+  },
+}
+
+/** Net score (−100..+100) of a belief computed from its own argument + evidence tree. */
+function netScore(
+  args: Array<{ side: string; impactScore: number }>,
+  evidence: Array<{ side: string; impactScore: number }>,
+): number {
+  const sum = (items: Array<{ side: string; impactScore: number }>, side: string) =>
+    items.filter(i => i.side === side).reduce((s, i) => s + Math.abs(i.impactScore), 0)
+
+  const pos = sum(args, 'agree') + sum(evidence, 'supporting')
+  const neg = sum(args, 'disagree') + sum(evidence, 'weakening')
+  const total = pos + neg
+  return total > 0 ? ((pos - neg) / total) * 100 : 0
+}
+
+/**
+ * Resolve the contrast class for a focal belief, computing each option's score
+ * from its own belief's argument tree. Returns null when no contrast class is
+ * defined for the slug (the section then renders nothing). An option whose
+ * referenced belief is missing or unscored keeps score: null (Rule 6 — blank,
+ * never a fabricated zero).
+ */
+export async function resolveContrastClass(
+  focalSlug: string,
+): Promise<ContrastClassData | null> {
+  const template = CONTRAST_CLASSES[focalSlug]
+  if (!template) return null
+
+  const slugs = template.options
+    .map(o => o.slug)
+    .filter((s): s is string => Boolean(s))
+
+  const beliefs = await prisma.belief.findMany({
+    where: { slug: { in: slugs } },
+    select: {
+      slug: true,
+      arguments: { select: { side: true, impactScore: true } },
+      evidence: { select: { side: true, impactScore: true } },
+    },
+  })
+
+  const scoreBySlug = new Map<string, number>()
+  for (const b of beliefs) {
+    scoreBySlug.set(b.slug, netScore(b.arguments, b.evidence))
+  }
+
+  const options: ContrastClassOption[] = template.options.map(o => ({
+    id: o.id,
+    label: o.label,
+    oneLine: o.oneLine ?? null,
+    slug: o.slug ?? null,
+    isFocal: o.isFocal ?? false,
+    score: o.slug && scoreBySlug.has(o.slug) ? scoreBySlug.get(o.slug)! : null,
+  }))
+
+  return { question: template.question, options }
+}

--- a/src/features/belief-analysis/data/fetch-belief.ts
+++ b/src/features/belief-analysis/data/fetch-belief.ts
@@ -48,7 +48,7 @@ const BELIEF_INCLUDE = {
   impactEntries: { orderBy: SCORE_RANKED },
   costBenefitItems: {
     include: {
-      claimBelief: { select: { id: true, slug: true, statement: true } },
+      claimBelief: { select: { id: true, slug: true, statement: true, positivity: true } },
     },
     orderBy: EXPECTED_VALUE_RANKED,
   },

--- a/src/features/belief-analysis/data/fetch-belief.ts
+++ b/src/features/belief-analysis/data/fetch-belief.ts
@@ -10,6 +10,7 @@ import {
 } from '@/core/scoring/all-scores'
 import { calculateEVS, getEvidenceTypeWeight } from '@/core/scoring/scoring-engine'
 import { applyStrengthPenalty } from '@/core/scoring/claim-strength'
+import { resolveContrastClass } from './contrast-classes'
 
 /** Shared include clause for all belief queries — includes all score-related fields. */
 const BELIEF_INCLUDE = {
@@ -81,7 +82,14 @@ export async function fetchBeliefBySlug(slug: string): Promise<BeliefWithRelatio
     include: BELIEF_INCLUDE,
   })
 
-  return belief as BeliefWithRelations | null
+  if (!belief) return null
+
+  // Resolve the contrast class (the denominator): each rival option's score is
+  // computed from its own argument tree, so OCV stays traceable. Null when no
+  // contrast class is defined for this belief.
+  const contrastClass = await resolveContrastClass(slug)
+
+  return { ...belief, contrastClass } as BeliefWithRelations | null
 }
 
 /** Fetch a belief by numeric ID */

--- a/src/features/belief-analysis/lib/conflict-pipeline.ts
+++ b/src/features/belief-analysis/lib/conflict-pipeline.ts
@@ -1,0 +1,83 @@
+/**
+ * Adapter between the belief page's Prisma rows and the conflict-resolution
+ * pipeline (src/core/scoring/conflict-resolution.ts). Read-only: the readout
+ * renders beside the hand-curated tables and never writes back.
+ */
+
+import {
+  analyzeConflict,
+  type CbaItemInput,
+  type ConflictResolutionReadout,
+  type InterestInput,
+} from '@/core/scoring/conflict-resolution'
+import type {
+  CostBenefitItemRow,
+  InterestEntryItem,
+  ValueRankingItem,
+} from '../types'
+
+/**
+ * A cost/benefit row with its likelihood derived from the claim's own belief
+ * page when one is linked — "computed from how THAT belief's pro/con arguments
+ * score, never assigned by gut". Falls back to the stored value otherwise.
+ */
+export interface DerivedCbaItem extends CostBenefitItemRow {
+  /** True when likelihood came from the linked claim belief's computed net. */
+  likelihoodDerived: boolean
+}
+
+/** Map a belief net score (−100..+100) onto a likelihood (0..1). */
+function likelihoodFromNet(net: number): number {
+  return Math.max(0, Math.min(1, (net + 100) / 200))
+}
+
+export function deriveCbaItems(items: CostBenefitItemRow[]): DerivedCbaItem[] {
+  return items.map((item) => {
+    const net = item.claimBelief?.positivity
+    if (net == null) return { ...item, likelihoodDerived: false }
+    const likelihood = likelihoodFromNet(net)
+    return {
+      ...item,
+      likelihood,
+      expectedValue: item.magnitude != null ? Math.abs(item.magnitude) * likelihood : null,
+      likelihoodDerived: true,
+    }
+  })
+}
+
+export function computeConflictReadout(
+  interestEntries: InterestEntryItem[],
+  valueRankings: ValueRankingItem[],
+  costBenefitItems: CostBenefitItemRow[],
+): ConflictResolutionReadout {
+  const interests: InterestInput[] = interestEntries
+    .filter((e) => e.side === 'supporter' || e.side === 'opponent')
+    .map((e) => ({
+      id: e.id,
+      side: e.side as 'supporter' | 'opponent',
+      interest: e.interest,
+      validityScore: e.validityScore ?? null,
+      linkageAccuracy: e.linkageAccuracy ?? null,
+      prevalenceScore: e.prevalenceScore ?? null,
+    }))
+
+  const rankings = valueRankings.map((r) => ({
+    id: r.id,
+    value: r.value,
+    supporterRank: r.supporterRank,
+    opponentRank: r.opponentRank,
+  }))
+
+  const cbaItems: CbaItemInput[] = deriveCbaItems(costBenefitItems)
+    .filter((i) => i.side === 'benefit' || i.side === 'cost')
+    .map((i) => ({
+      id: i.id,
+      side: i.side as 'benefit' | 'cost',
+      claim: i.claim,
+      category: i.category,
+      magnitude: i.magnitude,
+      likelihood: i.likelihood,
+    }))
+
+  return analyzeConflict(interests, rankings, cbaItems)
+}

--- a/src/features/belief-analysis/types.ts
+++ b/src/features/belief-analysis/types.ts
@@ -175,6 +175,10 @@ export interface ArgumentWithBelief {
   argumentScore: number | null
   /** Importance Score (0-1): how much this argument moves the probability needle. */
   importanceScore: number
+  /** Uniqueness factor (0-1): signal added versus earlier same-side siblings.
+   *  Null until the engine computes it at scoring time (Rule 6). Optional so
+   *  existing Prisma data still flows. */
+  uniquenessScore?: number | null
   linkageType: string
   /** ECLS = Evidence-to-Conclusion, ACLS = Argument-to-Conclusion */
   linkageScoreType: string

--- a/src/features/belief-analysis/types.ts
+++ b/src/features/belief-analysis/types.ts
@@ -122,6 +122,10 @@ export interface BeliefWithRelations {
   relatedBeliefs: string | null
   supportsBeliefs: string | null
 
+  /** High-stakes flag: posting goes through the speed-bump flow (steelman
+   *  acknowledgment + principle consistency). Optional so existing data flows. */
+  highStakes?: boolean
+
   valueRankings: ValueRankingItem[]
   interestEntries: InterestEntryItem[]
   sharedInterests: SharedInterestItem[]

--- a/src/features/belief-analysis/types.ts
+++ b/src/features/belief-analysis/types.ts
@@ -65,8 +65,9 @@ export interface CostBenefitItemRow {
   /** Expected Value = Magnitude × Likelihood. Sort key for the table. */
   expectedValue: number | null
   sortOrder: number
-  /** The claim's own belief page, when one exists. */
-  claimBelief?: { id: number; slug: string; statement: string } | null
+  /** The claim's own belief page, when one exists. Its positivity is the
+   *  engine-computed net that sources this row's derived likelihood. */
+  claimBelief?: { id: number; slug: string; statement: string; positivity?: number } | null
 }
 
 /** One row in the Short vs. Long-Term Impacts sub-table. */
@@ -330,6 +331,11 @@ export interface InterestEntryItem {
   pretextual: boolean
   score?: number | null
   sortOrder: number
+  /** Numeric twins (0-100) feeding the conflict-resolution pipeline. Optional
+   *  so existing Prisma data still flows. */
+  prevalenceScore?: number | null
+  linkageAccuracy?: number | null
+  validityScore?: number | null
 }
 
 /** One row in the Shared Interests table (new template). */

--- a/src/features/belief-analysis/types.ts
+++ b/src/features/belief-analysis/types.ts
@@ -58,6 +58,14 @@ export interface BeliefWithRelations {
   sharedInterests: SharedInterestItem[]
   disputeTypes: DisputeTypeItem[]
 
+  /**
+   * The contrast class — the mutually exclusive rivals this belief is priced
+   * against (the denominator made visible). Optional so existing beliefs keep
+   * flowing; populate via seed as topic option sets land. See
+   * docs/THE_DENOMINATOR.md and src/core/scoring/contrast-class.ts.
+   */
+  contrastClass?: ContrastClassData | null
+
   arguments: ArgumentWithBelief[]
   evidence: EvidenceItem[]
   objectiveCriteria: ObjectiveCriteriaItem[]
@@ -154,6 +162,36 @@ export interface ObjectiveCriteriaItem {
    * e.g., "+2pp sustained over 3 years would settle the debate".
    */
   thresholdForAgreement?: string | null
+}
+
+/**
+ * One mutually exclusive option in a belief's contrast class — a rival answer
+ * to the same topic question, competing for the same slot. The denominator for
+ * the focal belief is the rest of this set (its best rival, in particular).
+ */
+export interface ContrastClassOption {
+  /** Stable id, unique within the class. */
+  id: string
+  /** Short label for the option ("Targeted sanctions"). */
+  label: string
+  /** One-line description of the lever/option. */
+  oneLine?: string | null
+  /**
+   * S(o): the option's argument-tree score on a common scale. May be signed.
+   * Null renders blank (Rule 6) — the class is still shown, just without OCV.
+   */
+  score: number | null
+  /** Slug to the option's own belief page; plain text when null (Rule 5). */
+  slug?: string | null
+  /** True for the focal belief — the page this contrast class lives on. */
+  isFocal?: boolean
+}
+
+/** A belief's contrast class: the shared question plus the rival options. */
+export interface ContrastClassData {
+  /** The question the options compete to answer (lives on the topic). */
+  question: string
+  options: ContrastClassOption[]
 }
 
 /** One row in the Shared Values, Different Rankings table (new template). */

--- a/src/features/product-reviews/components/OwnershipSection.tsx
+++ b/src/features/product-reviews/components/OwnershipSection.tsx
@@ -69,7 +69,7 @@ export default function OwnershipSection({ costs, values }: OwnershipSectionProp
     <section className="space-y-5">
       <h2 className="text-xl font-bold mb-2">
         💰{' '}
-        <Link href="/cost-benefit%20analysis" className="text-[var(--accent)] hover:underline">
+        <Link href="/cba/about" className="text-[var(--accent)] hover:underline">
           Cost-Benefit Analysis
         </Link>
       </h2>

--- a/src/features/product-reviews/components/ProductScoreHeader.tsx
+++ b/src/features/product-reviews/components/ProductScoreHeader.tsx
@@ -54,7 +54,7 @@ export default function ProductScoreHeader({
         </span>{' '}
         <span className="text-xs text-[var(--muted-foreground)]">(computed from argument scores)</span>
         {' '}|{' '}
-        <Link href="/One%20Page%20Per%20Topic" className="text-[var(--accent)] hover:underline font-semibold">
+        <Link href="/how-it-works" className="text-[var(--accent)] hover:underline font-semibold">
           Category
         </Link>:{' '}
         <Link
@@ -82,11 +82,11 @@ export default function ProductScoreHeader({
         Method:{' '}
         <Link href="/algorithms/linkage-scores" className="text-[var(--accent)] hover:underline">Linkage Scores</Link>
         {' '}·{' '}
-        <Link href="/Argument%20scores%20from%20sub-argument%20scores" className="text-[var(--accent)] hover:underline">
+        <Link href="/algorithms/reason-rank" className="text-[var(--accent)] hover:underline">
           Argument scores from sub-argument scores
         </Link>
         {' '}·{' '}
-        <Link href="/cost-benefit%20analysis" className="text-[var(--accent)] hover:underline">Cost-Benefit Analysis</Link>
+        <Link href="/cba/about" className="text-[var(--accent)] hover:underline">Cost-Benefit Analysis</Link>
         . Unscored cells stay blank until the engine computes them.
       </p>
     </div>

--- a/src/lib/propagate-belief-scores.ts
+++ b/src/lib/propagate-belief-scores.ts
@@ -11,8 +11,12 @@
  * 2. Compute B's current truth score from its arguments and evidence.
  * 3. Find all Arguments where B is the child (i.e., B is the reason for
  *    some parent belief P). Each such argument A has a stored impactScore.
- * 4. Recompute A.impactScore = sign × B.truthScore × |A.linkageScore| × A.importanceScore × 100
- * 5. Update A.impactScore in the database.
+ * 4. Recompute A.impactScore = sign × B.truthScore × |A.linkageScore| ×
+ *    A.importanceScore × A.uniquenessScore × 100, where uniqueness discounts
+ *    restatements of earlier same-side siblings (the redundancy scan applied
+ *    at scoring time).
+ * 5. Update A.impactScore (plus the derived importance, uniqueness, and the
+ *    child's own tree score as argumentScore) in the database.
  * 6. For each parent belief P whose argument was just updated:
  *    a. Recompute P's stability score from all its arguments' impactScores.
  *    b. Persist P's new stabilityScore.
@@ -31,6 +35,10 @@ import {
   deriveImportanceFromBeliefScore,
   calculateLinkageFromArguments,
 } from '@/core/scoring/scoring-engine'
+import {
+  mechanicalSimilarity,
+  uniquenessFromSimilarities,
+} from '@/core/scoring/duplication-scoring'
 
 // Re-export so callers can import from one place
 export { computeArgumentImpactScore }
@@ -81,6 +89,50 @@ async function truthScoreFor(beliefId: number, cache: Map<number, number>): Prom
   const score = belief ? computeBeliefScores(belief).importanceWeightedScore : 0
   cache.set(beliefId, score)
   return score
+}
+
+/**
+ * Compute the uniqueness factor for every argument edge attached to a parent
+ * belief, memoized per propagation pass.
+ *
+ * Uniqueness is a property of an argument WITHIN its parent's tree: how much
+ * new signal it adds versus the same-side arguments that were there first.
+ * Oldest-first, so the original statement of a point keeps full credit and
+ * each later restatement is discounted by its similarity to what already
+ * stands (uniqueness = 1 − max similarity, per duplication-scoring). This is
+ * the "stored, not scored" redundancy scan finally applied at scoring time.
+ */
+async function siblingUniquenessFor(
+  parentBeliefId: number,
+  cache: Map<number, Map<number, number>>,
+): Promise<Map<number, number>> {
+  const cached = cache.get(parentBeliefId)
+  if (cached) return cached
+
+  const siblings = await prisma.argument.findMany({
+    where: { parentBeliefId, status: 'published' },
+    orderBy: { createdAt: 'asc' },
+    select: {
+      id: true,
+      side: true,
+      claim: true,
+      belief: { select: { statement: true } },
+    },
+  })
+
+  const uniqueness = new Map<number, number>()
+  const earlierTextsBySide = new Map<string, string[]>()
+
+  for (const sibling of siblings) {
+    const text = sibling.claim ?? sibling.belief.statement
+    const earlier = earlierTextsBySide.get(sibling.side) ?? []
+    const similarities = earlier.map((prior) => mechanicalSimilarity(text, prior))
+    uniqueness.set(sibling.id, uniquenessFromSimilarities(similarities))
+    earlierTextsBySide.set(sibling.side, [...earlier, text])
+  }
+
+  cache.set(parentBeliefId, uniqueness)
+  return uniqueness
 }
 
 /**
@@ -144,10 +196,16 @@ export async function propagateBeliefScores(
 
   // Persist the child belief's computed overallScore back to the positivity field
   // so that parent argument-tree tables always display the up-to-date score.
-  await prisma.belief.update({
-    where: { id: beliefId },
-    data: { positivity: childScores.overallScore },
-  })
+  // Only when the belief has scored content of its own (arguments or evidence):
+  // a leaf with nothing under it has no computed score, and stamping a 0 over
+  // its editorial valence would fake a verdict that was never computed (Rule 6).
+  const hasScoredContent = childBelief.arguments.length > 0 || childBelief.evidence.length > 0
+  if (hasScoredContent) {
+    await prisma.belief.update({
+      where: { id: beliefId },
+      data: { positivity: childScores.overallScore },
+    })
+  }
 
   // ── Step 2: Find every argument edge that draws on this belief ──
   // A belief can feed a parent argument through THREE distinct edges:
@@ -179,28 +237,41 @@ export async function propagateBeliefScores(
   }
 
   // ── Step 3: Recompute impactScore for each affected argument ────
-  // Each argument is recomputed from its OWN three inputs, not from the
+  // Each argument is recomputed from its OWN four inputs, not from the
   // triggering belief alone: an importance-edge argument keeps its separate
-  // truth child, and vice versa. truthScoreFor memoizes per-belief lookups.
+  // truth child, and vice versa. truthScoreFor memoizes per-belief lookups;
+  // siblingUniquenessFor memoizes the per-parent redundancy scan.
   const truthScoreCache = new Map<number, number>([[beliefId, childTruthScore]])
+  const uniquenessCache = new Map<number, Map<number, number>>()
   const parentBeliefIds = new Set<number>()
 
   for (const arg of affectedArguments.values()) {
     const truth = await truthScoreFor(arg.beliefId, truthScoreCache)
     const importance = await resolveEffectiveImportance(arg)
+    const siblingUniqueness = await siblingUniquenessFor(arg.parentBeliefId, uniquenessCache)
+    const uniqueness = siblingUniqueness.get(arg.id) ?? 1
 
     const newImpactScore = computeArgumentImpactScore(
       arg.side,
       truth,
       arg.linkageScore,
       importance,
+      uniqueness,
     )
 
     await prisma.argument.update({
       where: { id: arg.id },
-      // Persist the derived importance too, so rendered tables and later
-      // truth-edge recomputes read a value consistent with the live debate.
-      data: { impactScore: newImpactScore, importanceScore: importance },
+      // Persist the derived importance and uniqueness too, so rendered tables,
+      // the score-provenance page, and later truth-edge recomputes all read
+      // values consistent with the live debate. argumentScore is the child
+      // belief's own tree score (0–100) — the recursive "Score" column made
+      // real (Rule 6: computed, never hand-assigned).
+      data: {
+        impactScore: newImpactScore,
+        importanceScore: importance,
+        uniquenessScore: uniqueness,
+        argumentScore: Math.round(truth * 1000) / 10,
+      },
     })
 
     result.updatedArgumentIds.push(arg.id)
@@ -232,6 +303,64 @@ export async function propagateBeliefScores(
     result.updatedArgumentIds.push(...childResult.updatedArgumentIds)
     result.updatedBeliefIds.push(...childResult.updatedBeliefIds)
     result.depth = Math.max(result.depth, childResult.depth)
+  }
+
+  return result
+}
+
+export interface FullPropagationResult {
+  startedFrom: number
+  updatedArguments: number
+  updatedBeliefs: number
+  maxDepth: number
+}
+
+/**
+ * Recompute scores for every belief in the database, bottom-up.
+ *
+ * Finds every leaf belief (never used as a reason) plus isolated beliefs, and
+ * propagates each upward; the shared visited-set prevents redundant work when
+ * leaves share ancestors. Used by POST /api/scoring/propagate-all and by the
+ * seed chain, so a fresh dev database starts with engine-computed scores
+ * rather than hand-typed placeholders.
+ */
+export async function propagateAllBeliefScores(): Promise<FullPropagationResult> {
+  const allBeliefIds = await prisma.belief.findMany({ select: { id: true } })
+  const beliefIdsUsedAsChild = await prisma.argument.findMany({
+    select: { beliefId: true },
+    distinct: ['beliefId'],
+  })
+
+  const usedAsChildSet = new Set(beliefIdsUsedAsChild.map((a) => a.beliefId))
+  const startBeliefIds = allBeliefIds
+    .map((b) => b.id)
+    .filter((id) => !usedAsChildSet.has(id))
+
+  const visited = new Set<number>()
+  const result: FullPropagationResult = {
+    startedFrom: startBeliefIds.length,
+    updatedArguments: 0,
+    updatedBeliefs: 0,
+    maxDepth: 0,
+  }
+
+  for (const id of startBeliefIds) {
+    if (visited.has(id)) continue
+    const pass = await propagateBeliefScores(id, visited)
+    result.updatedArguments += pass.updatedArgumentIds.length
+    result.updatedBeliefs += pass.updatedBeliefIds.length
+    result.maxDepth = Math.max(result.maxDepth, pass.depth)
+  }
+
+  // Leaves reach their ancestors through recursion, but a mid-graph belief
+  // whose leaf children carry no arguments of their own can be missed when
+  // every leaf under it was already visited. Sweep any belief not yet visited.
+  for (const { id } of allBeliefIds) {
+    if (visited.has(id)) continue
+    const pass = await propagateBeliefScores(id, visited)
+    result.updatedArguments += pass.updatedArgumentIds.length
+    result.updatedBeliefs += pass.updatedBeliefIds.length
+    result.maxDepth = Math.max(result.maxDepth, pass.depth)
   }
 
   return result

--- a/templates/belief-analysis-template.html
+++ b/templates/belief-analysis-template.html
@@ -23,7 +23,11 @@
 
   CANONICAL SECTION ORDER:
     Header (Belief / metadata / Beliefs this supports)
-    1.  Argument Trees (scored two-sided table + Net Belief Score)
+    1.  Argument Trees (scored two-sided table + Net Belief Score, reported as
+        share/margin: the net divided by the belief's own Pro+Con total)
+    1b. Contrast Class (the denominator: mutually exclusive rivals this belief is
+        priced against, each with its tree score S and opportunity-cost value
+        OCV = S(this) - max S(rivals)). Only when the topic has a rival option set.
     2.  Evidence Ledger (two-sided: Supporting / Weakening)
     3.  Conflict Resolution Framework
         a. Shared Values, Different Rankings
@@ -73,7 +77,27 @@
 </tr>
 </tbody>
 </table>
-<p style="font-size: 13px; padding: 8px; background-color: #f0f3f6; border: 1px solid #ccc;"><strong>Net Belief Score: [NETSCORE].</strong> [NETINTERP]</p>
+<p style="font-size: 13px; padding: 8px; background-color: #f0f3f6; border: 1px solid #ccc;"><strong>Net Belief Score: [NETSCORE].</strong> The agree-case holds [SHARE]% of the argument weight, a [MARGIN]-point margin (mass [MASS]). This is the internal denominator only &mdash; how lopsided the belief is versus its own rebuttals, not whether it beats its rivals (see Contrast Class). [NETINTERP]</p>
+
+<hr />
+<br />
+<!-- CONTRAST CLASS: the denominator made visible. Include ONLY when the topic
+     has a set of mutually exclusive rival options. Each option points at its own
+     belief; its Score is that belief's own tree score, and OCV = Score - best
+     rival's Score. Exactly one option (the field winner) has OCV > 0. Omit this
+     whole block for beliefs with no rival option set. See docs/THE_DENOMINATOR.md. -->
+<h1>&#9878;&#65039; Contrast Class</h1>
+<p style="font-size: 13px;">The denominator, made visible. A score is always <em>compared to what</em> &mdash; these are the mutually exclusive rivals answering the same question. <strong>Question:</strong> [Topic question the options compete to answer].</p>
+<table style="border-collapse: collapse; border-color: #ccc;" border="1" cellspacing="0" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6; font-size: 12px;"><th width="28%">Option</th> <th width="40%">One-line</th> <th width="16%">Score</th> <th width="16%">vs. best rival</th></tr>
+</thead>
+<tbody>
+<tr style="background-color: #fffbe6;"><td>[This belief] (this belief)</td><td>[One-line]</td><td align="center">[S]</td><td align="center">[OCV]</td></tr>
+<tr><td>[Rival option]</td><td>[One-line]</td><td align="center">[S]</td><td align="center">[OCV] &#9733;</td></tr>
+</tbody>
+</table>
+<p style="font-size: 13px; padding: 8px; background-color: #f0f3f6; border: 1px solid #ccc;"><strong>Opportunity-cost value: [OCV] vs. [best rival].</strong> [Win/lose reading, stating the denominator next to the verdict.]</p>
 
 <hr />
 <br />

--- a/templates/belief-analysis-template.html
+++ b/templates/belief-analysis-template.html
@@ -28,10 +28,15 @@
   CANONICAL SECTION ORDER:
     Header (Belief / metadata / Beliefs this supports)
     0.  Scorecard (Net Belief Score / Bottom line / Strongest pro+con / What would
-        move this score most) + "How to read this page" box
+        move this score most, plus the collapsed twelve-dimension engine
+        readout, each dimension linking to its explainer) + "How to read this
+        page" box
     1.  Argument Trees (scored two-sided table: Argument/Score/Link/Imp/Impact,
         Pro+Con totals, Net Belief Score reported as share/margin: the net
-        divided by the belief's own Pro+Con total)
+        divided by the belief's own Pro+Con total). In the software every score
+        cell is a doorway: Score opens the child belief, Link the linkage
+        debate, Imp the importance sub-belief, Impact the provenance page with
+        the sign x truth x |linkage| x importance x uniqueness derivation.
     1b. Contrast Class (the denominator: mutually exclusive rivals this belief is
         priced against, each with its tree score S and opportunity-cost value
         OCV = S(this) - max S(rivals)). Only when the topic has a rival option set.
@@ -46,7 +51,10 @@
     6.  Cost-Benefit Analysis (Benefits table + Costs table: Claim / Category /
         Magnitude / Likelihood % / Expected Value, per-category subtotals), then
         Short vs. Long-Term Impacts (with Scores)
-    7.  Conflict Resolution Framework
+    7.  Conflict Resolution Framework (opens with the computed Pipeline
+        readout: shared interests, primary conflict pair, genuine value
+        conflicts, compromise candidates where a small likelihood shift flips
+        a category's net)
         a. Shared Values, Different Rankings (with Score)
         b. Likely Interests of Supporters
         c. Likely Interests of Opponents
@@ -62,7 +70,11 @@
     10. General to Specific Belief Mapping (Support+Score / Oppose+Score)
     11. Similar Beliefs (More Extreme+Score / More Moderate+Score)
     12. Definitions (Term / Definition / Score) — LAST before footer
-    13. Contribute / footer
+    13. Contribute / footer (the two moves: an add-a-reason form — no score is
+        ever submitted, the engine computes them — and "challenge a number" via
+        the clickable scores above; high-stakes beliefs walk the speed bumps:
+        acknowledge the strongest opposing argument + affirm the claimed
+        principle)
 -->
 <p style="text-align: right;"><a href="/w/page/21957696/Colorado%20Should">Home</a> &rsaquo;  <a href="/w/page/159323433/One%20Page%20Per%20Topic">Topics</a> &rsaquo;  [Category] &rsaquo;  [This Belief]</p>
 <div style="font-family: 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #333;">

--- a/tests/integration/propagate-three-way.test.ts
+++ b/tests/integration/propagate-three-way.test.ts
@@ -202,6 +202,76 @@ describe('Linkage edge: editing the linkage sub-debate', () => {
   })
 })
 
+describe('Uniqueness edge: restatements are discounted at scoring time', () => {
+  it('persists uniqueness 1.0 and the child tree score for a lone argument', async () => {
+    const arg = await prisma.argument.findUnique({ where: { id: mainArgId } })
+    // Recomputed several times above; the only same-side sibling context is itself.
+    expect(arg.uniquenessScore).toBeCloseTo(1.0, 5)
+    // argumentScore = truthChild's own tree score (1.0 → 100), computed not hand-set.
+    expect(arg.argumentScore).toBeCloseTo(100, 5)
+  })
+
+  it('discounts a near-duplicate same-side sibling and keeps the original whole', async () => {
+    // A second reason under gp whose claim restates the first one nearly verbatim.
+    const dupChild = await prisma.belief.create({
+      data: { slug: 'rcv-truth-dup', statement: 'RCV eliminates the spoiler effect entirely' },
+    })
+    await prisma.argument.create({
+      data: {
+        parentBeliefId: gpId,
+        beliefId: dupChild.id,
+        side: 'agree',
+        claim: 'RCV eliminates the spoiler effect',
+        linkageScore: 0.8,
+        importanceScore: 0.75,
+        impactScore: 0,
+      },
+    })
+
+    await propagateBeliefScores(dupChild.id)
+
+    const args = await prisma.argument.findMany({
+      where: { parentBeliefId: gpId, side: 'agree' },
+      orderBy: { createdAt: 'asc' },
+    })
+    const original = args.find((a: { id: number }) => a.id === mainArgId)
+    const duplicate = args.find((a: { id: number }) => a.id !== mainArgId)
+
+    // The restatement is heavily discounted; the first statement keeps credit.
+    expect(duplicate.uniquenessScore).toBeLessThan(0.5)
+    expect(Math.abs(duplicate.impactScore)).toBeLessThan(
+      Math.abs(duplicate.linkageScore) * duplicate.importanceScore * 100,
+    )
+    // Propagating the duplicate's child does not re-touch the original edge,
+    // and the original's stored uniqueness stays undiscounted.
+    expect(original.uniquenessScore).toBeCloseTo(1.0, 5)
+  }, 20_000)
+
+  it('a genuinely novel argument keeps ~full uniqueness', async () => {
+    const novelChild = await prisma.belief.create({
+      data: { slug: 'rcv-novel', statement: 'Ranked ballots raise turnout among independents' },
+    })
+    await prisma.argument.create({
+      data: {
+        parentBeliefId: gpId,
+        beliefId: novelChild.id,
+        side: 'agree',
+        claim: 'Ranked ballots raise turnout among independents',
+        linkageScore: 0.6,
+        importanceScore: 1.0,
+        impactScore: 0,
+      },
+    })
+
+    await propagateBeliefScores(novelChild.id)
+
+    const novel = await prisma.argument.findFirst({
+      where: { parentBeliefId: gpId, beliefId: novelChild.id },
+    })
+    expect(novel.uniquenessScore).toBeGreaterThan(0.7)
+  }, 20_000)
+})
+
 describe('Cycle safety', () => {
   it('terminates when beliefs reference each other in a cycle', async () => {
     const a = await prisma.belief.create({ data: { slug: 'cycle-a', statement: 'Belief A' } })

--- a/tests/unit/core/scoring/conflict-resolution.test.ts
+++ b/tests/unit/core/scoring/conflict-resolution.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest'
+import {
+  findSharedInterests,
+  derivePrimaryConflictPair,
+  findValueConflicts,
+  categoryNets,
+  findCompromiseCandidates,
+  analyzeConflict,
+  type InterestInput,
+  type CbaItemInput,
+} from '../../../../src/core/scoring/conflict-resolution'
+
+const interest = (
+  id: number,
+  side: 'supporter' | 'opponent',
+  text: string,
+  validity: number | null,
+  linkage: number | null = null,
+  prevalence: number | null = null,
+): InterestInput => ({
+  id,
+  side,
+  interest: text,
+  validityScore: validity,
+  linkageAccuracy: linkage,
+  prevalenceScore: prevalence,
+})
+
+describe('findSharedInterests', () => {
+  it('pairs similar cross-side interests when both clear the floor', () => {
+    const shared = findSharedInterests([
+      interest(1, 'supporter', 'Economic security for families', 90),
+      interest(2, 'opponent', 'Economic security for working families', 85),
+    ])
+    expect(shared).toHaveLength(1)
+    expect(shared[0].supporterId).toBe(1)
+    expect(shared[0].opponentId).toBe(2)
+    expect(shared[0].similarity).toBeGreaterThanOrEqual(0.5)
+  })
+
+  it('excludes pairs where either side is below the Resolution Floor', () => {
+    const shared = findSharedInterests([
+      interest(1, 'supporter', 'Economic security for families', 90),
+      interest(2, 'opponent', 'Economic security for families', 40),
+    ])
+    expect(shared).toHaveLength(0)
+  })
+
+  it('excludes unscored interests (null validity is not floor-clearing)', () => {
+    const shared = findSharedInterests([
+      interest(1, 'supporter', 'Economic security for families', null),
+      interest(2, 'opponent', 'Economic security for families', 90),
+    ])
+    expect(shared).toHaveLength(0)
+  })
+
+  it('excludes dissimilar interests even at high validity', () => {
+    const shared = findSharedInterests([
+      interest(1, 'supporter', 'Reducing childhood poverty nationwide', 95),
+      interest(2, 'opponent', 'Protecting constitutional gun rights', 95),
+    ])
+    expect(shared).toHaveLength(0)
+  })
+
+  it('scores pairs by harmonic validity so lopsided pairs sink', () => {
+    const shared = findSharedInterests([
+      interest(1, 'supporter', 'Fiscal responsibility in budgets', 95),
+      interest(2, 'opponent', 'Fiscal responsibility in budgets', 95),
+      interest(3, 'supporter', 'Dignity of honest work', 100),
+      interest(4, 'opponent', 'Dignity of honest work', 71),
+    ])
+    expect(shared.length).toBe(2)
+    expect(shared[0].pairedValidity).toBeGreaterThan(shared[1].pairedValidity)
+    expect(shared[0].supporterInterest).toContain('Fiscal')
+  })
+})
+
+describe('derivePrimaryConflictPair', () => {
+  const pool = [
+    interest(1, 'supporter', 'End extreme poverty', 90, 80, 60),
+    interest(2, 'supporter', 'Look generous to donors', 20, 95, 20),
+    interest(3, 'opponent', 'Keep taxes low', 85, 90, 70),
+    interest(4, 'opponent', 'Punish outgroup', 10, 40, 10),
+  ]
+
+  it('picks the highest validity-weighted-linkage interest per side', () => {
+    const pair = derivePrimaryConflictPair(pool)
+    expect(pair).not.toBeNull()
+    // supporter: end-poverty drive 80×0.9=72 beats pretext 95×0.2=19
+    expect(pair!.supporter.id).toBe(1)
+    // opponent: low-taxes drive 90×0.85=76.5 beats 40×0.1=4
+    expect(pair!.opponent.id).toBe(3)
+    expect(pair!.supporterDrive).toBeCloseTo(72, 5)
+    expect(pair!.opponentDrive).toBeCloseTo(76.5, 5)
+  })
+
+  it('excludes interests already identified as shared', () => {
+    const pair = derivePrimaryConflictPair(pool, [
+      {
+        supporterId: 1,
+        opponentId: 3,
+        supporterInterest: '',
+        opponentInterest: '',
+        similarity: 1,
+        pairedValidity: 87,
+      },
+    ])
+    expect(pair).not.toBeNull()
+    expect(pair!.supporter.id).toBe(2)
+    expect(pair!.opponent.id).toBe(4)
+  })
+
+  it('returns null when a side has no linkage-scored interests', () => {
+    const pair = derivePrimaryConflictPair([
+      interest(1, 'supporter', 'End extreme poverty', 90, 80),
+      interest(2, 'opponent', 'Keep taxes low', 85, null),
+    ])
+    expect(pair).toBeNull()
+  })
+})
+
+describe('findValueConflicts', () => {
+  it('returns values ranked far apart, biggest gap first', () => {
+    const conflicts = findValueConflicts([
+      { id: 1, value: 'Freedom', supporterRank: 5, opponentRank: 1 },
+      { id: 2, value: 'Safety', supporterRank: 1, opponentRank: 4 },
+      { id: 3, value: 'Honesty', supporterRank: 2, opponentRank: 2 },
+    ])
+    expect(conflicts.map((c) => c.value)).toEqual(['Freedom', 'Safety'])
+    expect(conflicts[0].gap).toBe(4)
+  })
+
+  it('ignores rows missing a rank on either side', () => {
+    const conflicts = findValueConflicts([
+      { id: 1, value: 'Freedom', supporterRank: 5, opponentRank: null },
+    ])
+    expect(conflicts).toHaveLength(0)
+  })
+
+  it('respects the minimum gap', () => {
+    const conflicts = findValueConflicts(
+      [{ id: 1, value: 'Freedom', supporterRank: 2, opponentRank: 1 }],
+      { minGap: 2 },
+    )
+    expect(conflicts).toHaveLength(0)
+  })
+})
+
+const cbaItem = (
+  id: number,
+  side: 'benefit' | 'cost',
+  category: string,
+  magnitude: number,
+  likelihood: number,
+): CbaItemInput => ({ id, side, claim: `claim ${id}`, category, magnitude, likelihood })
+
+describe('categoryNets', () => {
+  it('subtotals expected value within a category only', () => {
+    const nets = categoryNets([
+      cbaItem(1, 'benefit', 'dollars', 100, 0.8), // +80
+      cbaItem(2, 'cost', 'dollars', 50, 0.6), // -30
+      cbaItem(3, 'benefit', 'hours', 10, 0.5), // +5
+    ])
+    const dollars = nets.find((n) => n.category === 'dollars')!
+    expect(dollars.net).toBeCloseTo(50, 5)
+    const hours = nets.find((n) => n.category === 'hours')!
+    expect(hours.net).toBeCloseTo(5, 5)
+  })
+
+  it('skips rows with missing category, magnitude, or likelihood', () => {
+    const nets = categoryNets([
+      { id: 1, side: 'benefit', claim: 'x', category: null, magnitude: 100, likelihood: 0.5 },
+      { id: 2, side: 'cost', claim: 'y', category: 'dollars', magnitude: null, likelihood: 0.5 },
+      { id: 3, side: 'cost', claim: 'z', category: 'dollars', magnitude: 10, likelihood: null },
+    ])
+    expect(nets).toHaveLength(0)
+  })
+})
+
+describe('findCompromiseCandidates', () => {
+  it('finds the item whose small likelihood shift flips its category net', () => {
+    // dollars: +80 benefit, -70 cost → net +10. The cost item (magnitude 100)
+    // flips the net with a shift of 0.10 ≤ 0.15.
+    const candidates = findCompromiseCandidates([
+      cbaItem(1, 'benefit', 'dollars', 100, 0.8),
+      cbaItem(2, 'cost', 'dollars', 100, 0.7),
+    ])
+    expect(candidates.length).toBeGreaterThan(0)
+    const byId = new Map(candidates.map((c) => [c.itemId, c]))
+    expect(byId.get(2)!.direction).toBe('raise')
+    expect(byId.get(2)!.requiredShift).toBeCloseTo(0.1, 5)
+    expect(byId.get(1)!.direction).toBe('lower')
+  })
+
+  it('rejects shifts larger than the achievable threshold', () => {
+    // net +50 with magnitudes 100 → required shift 0.5 > 0.15.
+    const candidates = findCompromiseCandidates([
+      cbaItem(1, 'benefit', 'dollars', 100, 0.8),
+      cbaItem(2, 'cost', 'dollars', 100, 0.3),
+    ])
+    expect(candidates).toHaveLength(0)
+  })
+
+  it('rejects shifts that would push likelihood outside [0, 1]', () => {
+    // net +1 in dollars; the benefit at likelihood 0.005 cannot be lowered by 0.01.
+    const candidates = findCompromiseCandidates([
+      cbaItem(1, 'benefit', 'dollars', 100, 0.005),
+      { id: 2, side: 'benefit', claim: 'b', category: 'dollars', magnitude: 1000, likelihood: 0.0495 },
+      cbaItem(3, 'cost', 'dollars', 100, 0.49),
+    ])
+    expect(candidates.find((c) => c.itemId === 1)).toBeUndefined()
+  })
+
+  it('orders candidates by the smallest required shift', () => {
+    const candidates = findCompromiseCandidates([
+      cbaItem(1, 'benefit', 'dollars', 100, 0.6), // shift 0.10
+      cbaItem(2, 'cost', 'dollars', 200, 0.25), // shift 0.05
+    ])
+    expect(candidates[0].itemId).toBe(2)
+    expect(candidates[0].requiredShift).toBeCloseTo(0.05, 5)
+  })
+})
+
+describe('analyzeConflict', () => {
+  it('assembles all four outputs from scored rows', () => {
+    const readout = analyzeConflict(
+      [
+        interest(1, 'supporter', 'Economic security for families', 90, 80),
+        interest(2, 'opponent', 'Economic security for families', 85, 60),
+        interest(3, 'supporter', 'End extreme poverty', 88, 85),
+        interest(4, 'opponent', 'Keep taxes low', 82, 90),
+      ],
+      [{ id: 1, value: 'Freedom', supporterRank: 5, opponentRank: 1 }],
+      [cbaItem(1, 'benefit', 'dollars', 100, 0.8), cbaItem(2, 'cost', 'dollars', 100, 0.7)],
+    )
+    expect(readout.sharedInterests.length).toBeGreaterThan(0)
+    expect(readout.primaryConflictPair).not.toBeNull()
+    expect(readout.primaryConflictPair!.supporter.id).toBe(3)
+    expect(readout.primaryConflictPair!.opponent.id).toBe(4)
+    expect(readout.valueConflicts).toHaveLength(1)
+    expect(readout.compromiseCandidates.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/core/scoring/contrast-class.test.ts
+++ b/tests/unit/core/scoring/contrast-class.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for the denominator / contrast-class engine.
+ *
+ * Two layers: Layer 1 (justification, internal denominator — a belief vs its
+ * own rebuttals) and Layer 2 (opportunity cost, external denominator — a belief
+ * vs its best rival). The worked example throughout is the sanctions page from
+ * the spec (docs/THE_DENOMINATOR.md): Pro 35.08, Con 25.87.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  justificationScore,
+  truthShare,
+  argumentMass,
+  pairwiseMargin,
+  opportunityCostValue,
+  comparativeScores,
+  normalizeCriterion,
+  weightedCriteriaScores,
+  fieldShares,
+  sortArguments,
+  analyzeContrastClass,
+  type ContrastOption,
+  type Criterion,
+} from '../../../../src/core/scoring/contrast-class'
+
+describe('justificationScore (Layer 1)', () => {
+  it('turns the sanctions +9.2 numerator into a +15.1% margin', () => {
+    const j = justificationScore(35.08, 25.87)
+    expect(j).toBeCloseTo(0.151, 3)
+  })
+
+  it('is the affine twin of the truth share: J = 2p − 1', () => {
+    const pro = 35.08
+    const con = 25.87
+    const p = truthShare(pro, con)!
+    expect(justificationScore(pro, con)).toBeCloseTo(2 * p - 1, 10)
+  })
+
+  it('washes out volume: [9,1] and [90,10] both score +0.8', () => {
+    expect(justificationScore(9, 1)).toBeCloseTo(0.8, 10)
+    expect(justificationScore(90, 10)).toBeCloseTo(0.8, 10)
+  })
+
+  it('goes negative when cons outweigh pros (the Rule 9 trigger)', () => {
+    expect(justificationScore(10, 30)).toBeLessThan(0)
+  })
+
+  it('returns 0 (undefined, not refuted) with no argument weight', () => {
+    expect(justificationScore(0, 0)).toBe(0)
+  })
+})
+
+describe('truthShare', () => {
+  it('reports the sanctions harm-case at ~57.6%', () => {
+    expect(truthShare(35.08, 25.87)).toBeCloseTo(0.576, 3)
+  })
+
+  it('returns null (not 0.5) when there is no weight', () => {
+    expect(truthShare(0, 0)).toBeNull()
+  })
+})
+
+describe('argumentMass', () => {
+  it('reports total mass to pair beside the ratio', () => {
+    expect(argumentMass(35.08, 25.87)).toBeCloseTo(60.95, 2)
+  })
+})
+
+describe('pairwiseMargin', () => {
+  it('is a simple difference S(oi) − S(oj)', () => {
+    expect(pairwiseMargin(0.7, 0.5)).toBeCloseTo(0.2, 10)
+    expect(pairwiseMargin(0.5, 0.7)).toBeCloseTo(-0.2, 10)
+  })
+})
+
+describe('opportunityCostValue (Layer 2)', () => {
+  it('subtracts the best rival, not nothing', () => {
+    expect(opportunityCostValue(0.6, [0.8, 0.4, 0.2])).toBeCloseTo(-0.2, 10)
+  })
+
+  it('is positive only for the field winner', () => {
+    expect(opportunityCostValue(0.9, [0.8, 0.4])).toBeCloseTo(0.1, 10)
+  })
+
+  it('is undefined (null) with no rivals — no denominator', () => {
+    expect(opportunityCostValue(0.9, [])).toBeNull()
+  })
+})
+
+describe('comparativeScores — the sanctions contrast class', () => {
+  // Stylized scores standing in for the argument-tree S(o) of each lever.
+  const options: ContrastOption[] = [
+    { id: 'military', label: 'Military force', score: 0.30 },
+    { id: 'broad', label: 'Broad sanctions', score: 0.50 },
+    { id: 'targeted', label: 'Targeted sanctions', score: 0.62 },
+    { id: 'engagement', label: 'Conditional engagement', score: 0.45 },
+    { id: 'integration', label: 'Full integration', score: 0.25 },
+  ]
+
+  it('finds exactly one winner (targeted) with positive OCV', () => {
+    const results = comparativeScores(options)
+    const winners = results.filter((r) => r.isWinner)
+    expect(winners).toHaveLength(1)
+    expect(winners[0].id).toBe('targeted')
+    expect(winners[0].ocv!).toBeGreaterThan(0)
+  })
+
+  it('shows broad sanctions LOSING to their best rival (targeted)', () => {
+    const broad = comparativeScores(options).find((r) => r.id === 'broad')!
+    expect(broad.bestRivalId).toBe('targeted')
+    expect(broad.ocv!).toBeCloseTo(0.5 - 0.62, 10)
+    expect(broad.ocv!).toBeLessThan(0)
+  })
+
+  it('produces no strict winner on a tie', () => {
+    const tied: ContrastOption[] = [
+      { id: 'a', label: 'A', score: 0.5 },
+      { id: 'b', label: 'B', score: 0.5 },
+    ]
+    expect(comparativeScores(tied).some((r) => r.isWinner)).toBe(false)
+  })
+})
+
+describe('normalizeCriterion', () => {
+  it('min-max normalizes against the spread of rivals', () => {
+    const [lo, mid, hi] = normalizeCriterion([0.1, 0.4, 0.7])
+    expect(lo).toBeCloseTo(0, 10)
+    expect(mid).toBeCloseTo(0.5, 10)
+    expect(hi).toBeCloseTo(1, 10)
+  })
+
+  it('returns neutral 0.5 when the field is flat (no division by zero)', () => {
+    expect(normalizeCriterion([0.6, 0.6, 0.6])).toEqual([0.5, 0.5, 0.5])
+  })
+})
+
+describe('weightedCriteriaScores', () => {
+  const options: ContrastOption[] = [
+    { id: 'broad', label: 'Broad sanctions', score: 0.5 },
+    { id: 'integration', label: 'Full integration', score: 0.25 },
+  ]
+  // Mike's argument: integration scores worst on C1 (coercive capacity). That
+  // low C1 is precisely why broad sanctions look good against integration.
+  const criteria: Criterion[] = [
+    { key: 'C1-capacity', importance: 1.0, raw: { broad: 0.8, integration: 0.1 } },
+    { key: 'C2-welfare', importance: 0.6, raw: { broad: 0.3, integration: 0.9 } },
+  ]
+
+  it('weights normalized criteria by topic-level importance', () => {
+    const results = weightedCriteriaScores(options, criteria)
+    const broad = results.find((r) => r.optionId === 'broad')!
+    // C1 normalized: broad=1, integration=0 → broad contributes 1.0×1.0.
+    // C2 normalized: broad=0, integration=1 → broad contributes 0.6×0.
+    expect(broad.weighted).toBeCloseTo(1.0, 10)
+  })
+
+  it('decomposes the score per criterion to explain the win', () => {
+    const broad = weightedCriteriaScores(options, criteria)
+      .find((r) => r.optionId === 'broad')!
+    const c1 = broad.perCriterion.find((p) => p.key === 'C1-capacity')!
+    expect(c1.normalized).toBe(1)
+    expect(c1.contribution).toBeCloseTo(1.0, 10)
+  })
+})
+
+describe('fieldShares (signed-score edge case)', () => {
+  it('returns real shares when all scores are non-negative', () => {
+    const result = fieldShares([
+      { id: 'a', label: 'A', score: 0.6 },
+      { id: 'b', label: 'B', score: 0.4 },
+    ])
+    expect(result.status).toBe('ok')
+    expect(result.shares!.a).toBeCloseTo(0.6, 10)
+    expect(result.shares!.b).toBeCloseTo(0.4, 10)
+  })
+
+  it('refuses to fake a probability for signed scores by default', () => {
+    const result = fieldShares([
+      { id: 'a', label: 'A', score: 0.6 },
+      { id: 'b', label: 'B', score: -0.2 },
+    ])
+    expect(result.status).toBe('signed')
+    expect(result.shares).toBeNull()
+  })
+
+  it('rank-shifts and flags it when explicitly allowed', () => {
+    const result = fieldShares(
+      [
+        { id: 'a', label: 'A', score: 0.6 },
+        { id: 'b', label: 'B', score: -0.2 },
+      ],
+      { allowShift: true },
+    )
+    expect(result.status).toBe('shifted')
+    expect(result.shifted).toBe(true)
+    const sum = result.shares!.a + result.shares!.b
+    expect(sum).toBeCloseTo(1, 10)
+    expect(result.shares!.a).toBeGreaterThan(result.shares!.b)
+  })
+})
+
+describe('sortArguments — intrinsic vs comparative dedup', () => {
+  it('pulls "rival beats X" out of the con tally, cleaning Layer 1', () => {
+    // "only non-military lever" is comparative, not a strike against the belief.
+    const result = sortArguments([
+      { kind: 'intrinsic', side: 'pro', weight: 20 },
+      { kind: 'intrinsic', side: 'con', weight: 10 },
+      { kind: 'comparative', side: 'con', weight: 15 },
+    ])
+    expect(result.intrinsicPro).toBe(20)
+    expect(result.intrinsicCon).toBe(10)
+    expect(result.comparativeWeight).toBe(15)
+    // Cleaned justification is 20 vs 10, not 20 vs 25.
+    expect(result.justification).toBeCloseTo(justificationScore(20, 10), 10)
+    expect(result.justification).toBeGreaterThan(justificationScore(20, 25))
+  })
+})
+
+describe('analyzeContrastClass — combined readout', () => {
+  const options: ContrastOption[] = [
+    { id: 'military', label: 'Military force', score: 0.30 },
+    { id: 'broad', label: 'Broad sanctions', score: 0.50 },
+    { id: 'targeted', label: 'Targeted sanctions', score: 0.62 },
+  ]
+
+  it('states the denominator next to the verdict for the focal option', () => {
+    const readout = analyzeContrastClass('broad', options)
+    expect(readout.focalBestRivalId).toBe('targeted')
+    expect(readout.focalOcv!).toBeCloseTo(-0.12, 10)
+    // Pairwise margins against every rival, both signs present.
+    const vsMilitary = readout.focalMargins.find((m) => m.rivalId === 'military')!
+    const vsTargeted = readout.focalMargins.find((m) => m.rivalId === 'targeted')!
+    expect(vsMilitary.margin).toBeCloseTo(0.20, 10) // wins vs military
+    expect(vsTargeted.margin).toBeCloseTo(-0.12, 10) // loses vs targeted
+  })
+
+  it('omits criteria when none are supplied', () => {
+    expect(analyzeContrastClass('broad', options).criteria).toBeNull()
+  })
+})

--- a/tests/unit/lib/propagate-belief-scores.test.ts
+++ b/tests/unit/lib/propagate-belief-scores.test.ts
@@ -139,6 +139,40 @@ describe('computeArgumentImpactScore', () => {
     })
   })
 
+  // ── Uniqueness discount ─────────────────────────────────────────
+
+  describe('uniqueness multiplies into the conclusion-score term', () => {
+    it('defaults to 1 (no discount) when omitted', () => {
+      const withoutUniqueness = computeArgumentImpactScore('agree', 0.8, 0.7, 1.0)
+      const explicitFull = computeArgumentImpactScore('agree', 0.8, 0.7, 1.0, 1.0)
+      expect(withoutUniqueness).toBe(explicitFull)
+    })
+
+    it('scales the impact proportionally: a 90% restatement contributes ~10%', () => {
+      const original = computeArgumentImpactScore('agree', 0.8, 0.7, 1.0, 1.0)
+      const restatement = computeArgumentImpactScore('agree', 0.8, 0.7, 1.0, 0.1)
+      expect(restatement).toBeCloseTo(original * 0.1, 1)
+    })
+
+    it('a fully duplicated argument contributes nothing', () => {
+      const score = computeArgumentImpactScore('agree', 0.8, 0.7, 1.0, 0)
+      expect(score).toBe(0)
+    })
+
+    it('discounts disagree arguments symmetrically', () => {
+      const full = computeArgumentImpactScore('disagree', 0.8, 0.7, 1.0, 1.0)
+      const half = computeArgumentImpactScore('disagree', 0.8, 0.7, 1.0, 0.5)
+      expect(half).toBeCloseTo(full / 2, 1)
+      expect(half).toBeLessThan(0)
+    })
+
+    it('computes the full five-factor formula', () => {
+      // 1.0 × 0.8 × 0.5 × 0.9 × 0.75 × 100 = 27.0
+      const score = computeArgumentImpactScore('agree', 0.8, 0.5, 0.9, 0.75)
+      expect(score).toBe(27.0)
+    })
+  })
+
   // ── Propagation semantics ───────────────────────────────────────
 
   describe('propagation semantics', () => {


### PR DESCRIPTION
## Summary

This PR documents the Idea Stock Exchange's scoring engine and makes it discoverable through new algorithm explainer pages. It adds the core scoring pipeline documentation, implements the denominator (contrast-class) layer, conflict resolution analysis, and creates a comprehensive algorithm index with live examples.

## Key Changes

**Documentation & Specs**
- Rewrote `docs/HOW_IT_WORKS.md` as a developer map linking claims to implementation code
- Added `docs/THE_DENOMINATOR.md` — canonical spec for scoring beliefs against counterclaims (contrast-class / opportunity-cost layer)
- Updated `docs/BELIEF_PAGE_RULES.md` to reflect new algorithm pages and scoring outputs

**Core Scoring Engine**
- `src/core/scoring/contrast-class.ts` — Layer 1 (justification score: internal denominator) and Layer 2 (opportunity cost: external denominator). Computes how decisively a belief's own arguments favor it, and how it ranks against rival claims
- `src/core/scoring/conflict-resolution.ts` — Reads scored trees sideways to extract shared interests, primary conflict pairs, value conflicts, and compromise candidates (Fisher & Ury framework)
- Updated `src/core/scoring/scoring-engine.ts` to include uniqueness discount in impact calculation
- Updated `src/lib/propagate-belief-scores.ts` to persist uniqueness and argumentScore alongside impactScore

**Algorithm Index & Explainer Pages**
- `src/app/algorithms/page.tsx` — Master index of all scoring algorithms with descriptions and links
- `src/app/algorithms/importance-score/page.tsx` — How importance is weighted and sourced from dedicated sub-beliefs
- `src/app/algorithms/truth-scores/page.tsx` — How beliefs earn truth scores from argument trees
- `src/app/algorithms/linkage-scores/page.tsx` — Linkage accuracy and hidden assumptions
- `src/app/algorithms/unique-scores/page.tsx` — Uniqueness discount for restatements
- `src/app/algorithms/evidence-scores/page.tsx` — Evidence Verification Score (EVS)
- `src/app/algorithms/topic-overlap/page.tsx` — Belief-level uniqueness readout
- `src/app/algorithms/assumptions/page.tsx` — How unstated premises are surfaced and scored
- `src/app/arguments/[id]/score/page.tsx` — Score provenance: derivation of one argument's impact, factor by factor

**Live How-It-Works Page**
- `src/app/how-it-works/page.tsx` — Reader-facing version with live engine readout (fetches real belief scores from database)
- `src/app/contact/page.tsx` — Contact page

**Belief Page Integration**
- `src/features/belief-analysis/components/ContrastClassSection.tsx` — Renders the denominator (rival options and opportunity cost values)
- `src/features/belief-analysis/components/ConflictResolutionSection.tsx` — Renders shared interests, primary conflict pair, value conflicts, compromise candidates
- `src/features/belief-analysis/data/contrast-classes.ts` — Static contrast-class definitions (mutually exclusive rivals per belief)
- `src/features/belief-analysis/lib/conflict-pipeline.ts` — Adapter between Prisma rows and conflict-resolution pipeline
- Updated `src/features/belief-analysis/components/ArgumentTreesSection.tsx` to show justification score and truth share
- Updated `src/features/belief-analysis/components/ContributeSection.tsx` to render live add-a-reason form with speed bumps
- `src/features/belief-analysis/components/AddArgumentForm.tsx` — Form for posting new arguments with steelman acknowledgment and moral-principle consistency checks

**API & Database**
- `src/app/api/beliefs/[id]/arguments/route.ts` — POST endpoint for adding arguments with speed-bump enforcement (high-stakes beliefs only)
- Added `highStakes` boolean field to Belief model (Prisma schema)
- Added `uniquenessScore` to Argument model
- Migration: `prisma/migrations/20260706000000_add_uniqueness_and_high_stakes

https://claude.ai/code/session_01LWxDkHwiPACGqKRdVvTtyW