### PR TITLE
Redesign topic pages to "Page Design" revision (July 2026)

### DIFF
--- a/prisma/migrations/20260711161656_add_topic_evidence_ledger_fields/migration.sql
+++ b/prisma/migrations/20260711161656_add_topic_evidence_ledger_fields/migration.sql
@@ -1,0 +1,42 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_DebateEvidence" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "topicId" INTEGER NOT NULL,
+    "side" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "finding" TEXT NOT NULL,
+    "qualityScore" INTEGER NOT NULL DEFAULT 75,
+    "qualityLabel" TEXT NOT NULL DEFAULT 'Peer Reviewed',
+    "url" TEXT,
+    "tier" TEXT NOT NULL DEFAULT 'T2',
+    "argument" TEXT NOT NULL DEFAULT '',
+    "linkage" REAL,
+    "standing" TEXT NOT NULL DEFAULT 'VERIFIED',
+    CONSTRAINT "DebateEvidence_topicId_fkey" FOREIGN KEY ("topicId") REFERENCES "DebateTopic" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_DebateEvidence" ("finding", "id", "qualityLabel", "qualityScore", "side", "source", "title", "topicId", "url") SELECT "finding", "id", "qualityLabel", "qualityScore", "side", "source", "title", "topicId", "url" FROM "DebateEvidence";
+DROP TABLE "DebateEvidence";
+ALTER TABLE "new_DebateEvidence" RENAME TO "DebateEvidence";
+CREATE INDEX "DebateEvidence_topicId_idx" ON "DebateEvidence"("topicId");
+CREATE TABLE "new_DebatePosition" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "topicId" INTEGER NOT NULL,
+    "positionScore" INTEGER NOT NULL,
+    "positionLabel" TEXT NOT NULL,
+    "coreBelief" TEXT NOT NULL,
+    "topArgument" TEXT NOT NULL,
+    "beliefScore" TEXT NOT NULL DEFAULT '[0]',
+    "mediaUrl" TEXT,
+    "evidenceId" INTEGER,
+    CONSTRAINT "DebatePosition_topicId_fkey" FOREIGN KEY ("topicId") REFERENCES "DebateTopic" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "DebatePosition_evidenceId_fkey" FOREIGN KEY ("evidenceId") REFERENCES "DebateEvidence" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_DebatePosition" ("beliefScore", "coreBelief", "id", "mediaUrl", "positionLabel", "positionScore", "topArgument", "topicId") SELECT "beliefScore", "coreBelief", "id", "mediaUrl", "positionLabel", "positionScore", "topArgument", "topicId" FROM "DebatePosition";
+DROP TABLE "DebatePosition";
+ALTER TABLE "new_DebatePosition" RENAME TO "DebatePosition";
+CREATE INDEX "DebatePosition_topicId_idx" ON "DebatePosition"("topicId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1636,11 +1636,16 @@ model DebatePosition {
   topic   DebateTopic @relation(fields: [topicId], references: [id], onDelete: Cascade)
 
   positionScore Int    /// -100, -50, 0, 50, 100
-  positionLabel String /// "Strongly Oppose", "Skeptical", "Neutral", "Supportive", "Strongly Support"
+  positionLabel String /// "Strongly Oppose", "Skeptical", "Mixed / Conditional", "Supportive", "Strongly Support"
   coreBelief    String
   topArgument   String
   beliefScore   String @default("[0]")
   mediaUrl      String?
+
+  /// Evidence Ledger row backing the top sub-argument (renders as the
+  /// Evidence column link in the Position Spectrum table)
+  evidenceId Int?
+  evidence   DebateEvidence? @relation(fields: [evidenceId], references: [id])
 
   @@index([topicId])
 }
@@ -1750,6 +1755,20 @@ model DebateEvidence {
   qualityScore Int    @default(75)
   qualityLabel String @default("Peer Reviewed")
   url          String?
+
+  /// Evidence tier: "T1" peer-reviewed, "T2" reputable institution,
+  /// "T3" secondary, "T4" anecdotal
+  tier         String @default("T2")
+  /// The specific argument this evidence bears on, as a standalone claim.
+  /// Empty rows fall back to `finding` at render time.
+  argument     String @default("")
+  /// How directly the evidence bears on its argument, 0.0–1.0
+  linkage      Float?
+  /// Verification lifecycle: "VERIFIED" counts at full weight, "DISPUTED" at
+  /// half while the challenge is open, "FALSIFIED" at zero
+  standing     String @default("VERIFIED")
+
+  positions DebatePosition[]
 
   @@index([topicId])
 }

--- a/prisma/seed-debate-topics.ts
+++ b/prisma/seed-debate-topics.ts
@@ -13,6 +13,14 @@ async function main() {
     debateTopic: {
       deleteMany: (args: unknown) => Promise<unknown>;
       create: (args: unknown) => Promise<{ id: number; slug: string }>;
+      findUnique: (args: unknown) => Promise<{
+        id: number;
+        positions: Array<{ id: number; positionScore: number }>;
+        evidenceItems: Array<{ id: number }>;
+      } | null>;
+    };
+    debatePosition: {
+      update: (args: unknown) => Promise<unknown>;
     };
   };
 
@@ -55,7 +63,7 @@ async function main() {
           },
           {
             positionScore: 0,
-            positionLabel: 'Neutral/Nuanced',
+            positionLabel: 'Mixed / Conditional',
             coreBelief:
               'Marriage is valuable for some but not universally superior to other relationship structures.',
             topArgument:
@@ -200,8 +208,7 @@ async function main() {
         create: [
           {
             sortOrder: 0,
-            rungType: 'general',
-            rungLabel: 'Most General (Worldview)',
+            rungLabel: 'Worldview',
             proChain:
               'Human beings are social and sexual creatures who flourish best within stable, committed, complementary partnerships.',
             conChain:
@@ -209,9 +216,7 @@ async function main() {
           },
           {
             sortOrder: 1,
-            rungType: 'subcategory',
-            branchName: 'Role of the State',
-            rungLabel: 'political/ethical philosophy',
+            rungLabel: 'Political principle',
             proChain:
               'Society has a legitimate interest in structuring family formation to protect children and reduce dependence on the state.',
             conChain:
@@ -219,19 +224,15 @@ async function main() {
           },
           {
             sortOrder: 2,
-            rungType: 'subcategory',
-            branchName: 'Marriage and Child-Rearing',
-            rungLabel: 'this topic',
+            rungLabel: 'Position on this topic',
             proChain:
-              'Marriage between committed partners is the best available structure for raising children and should be culturally promoted and legally supported.',
+              'Marriage between committed partners is the best available structure for raising children and should be culturally promoted and legally supported. (+50% to +100%)',
             conChain:
-              'Marriage should be available to all who want it, but policy should not privilege it over other stable family structures.',
+              'Marriage should be available to all who want it, but policy should not privilege it over other stable family structures. (−20% to −50%)',
           },
           {
             sortOrder: 3,
-            rungType: 'specific',
-            branchName: 'Marriage and Child-Rearing',
-            rungLabel: '',
+            rungLabel: 'Specific policy',
             proChain:
               'Eliminate the marriage penalty in the tax code; fund relationship skills programs; restore marriage rates in low-income communities as a poverty-reduction strategy.',
             conChain:
@@ -292,6 +293,11 @@ async function main() {
               'Married individuals report better health, wealth, and life satisfaction across longitudinal data.',
             qualityScore: 80,
             qualityLabel: 'Peer Reviewed',
+            tier: 'T2',
+            argument:
+              'Married individuals do better on health, wealth, and life satisfaction than unmarried peers.',
+            linkage: 0.85,
+            standing: 'VERIFIED',
           },
           {
             side: 'supporting',
@@ -301,6 +307,11 @@ async function main() {
               'Children raised by single parents face significantly worse outcomes on education, income, and family stability.',
             qualityScore: 85,
             qualityLabel: 'Longitudinal',
+            tier: 'T1',
+            argument:
+              'Children raised outside two-parent homes face worse outcomes on education, income, and family stability.',
+            linkage: 0.8,
+            standing: 'VERIFIED',
           },
           {
             side: 'weakening',
@@ -310,6 +321,11 @@ async function main() {
               'Much of the marriage benefit disappears when controlling for pre-existing wellbeing and selection effects.',
             qualityScore: 85,
             qualityLabel: 'Peer Reviewed',
+            tier: 'T1',
+            argument:
+              'The observed marriage benefit is largely a selection effect, not a causal effect of marriage.',
+            linkage: 0.85,
+            standing: 'VERIFIED',
           },
           {
             side: 'weakening',
@@ -319,80 +335,25 @@ async function main() {
               'Legal marriage adds little independent benefit over stable cohabitation in countries with strong cohabitation norms.',
             qualityScore: 75,
             qualityLabel: 'Cross-national',
-          },
-        ],
-      },
-      objectiveCriteria: {
-        create: [
-          {
-            name: 'Long-term life satisfaction at 50, 65, and 80',
-            description:
-              'Longitudinal survey data across relationship structures — not snapshot happiness measures',
-            criteriaScore: 90,
-            validity: 'High',
-            reliability: 'High',
-            linkage: 'High',
-            importance: 'High',
+            tier: 'T1',
+            argument:
+              'Legal marriage adds little independent benefit over stable cohabitation where cohabitation norms are strong.',
+            linkage: 0.7,
+            standing: 'VERIFIED',
           },
           {
-            name: 'Child outcomes by family structure',
-            description:
-              'Educational attainment, income at 30, incarceration rates, and family formation patterns of adult children',
-            criteriaScore: 88,
-            validity: 'High',
-            reliability: 'High',
-            linkage: 'High',
-            importance: 'High',
-          },
-          {
-            name: 'Health outcomes controlling for socioeconomic status',
-            description:
-              'Mortality rates, cardiovascular health, and mental health outcomes across relationship structures, adjusted for income and selection',
-            criteriaScore: 82,
-            validity: 'High',
-            reliability: 'High',
-            linkage: 'Med',
-            importance: 'High',
-          },
-          {
-            name: '30-year wealth accumulation and bankruptcy rates',
-            description:
-              'Comparative financial outcomes across marriage, cohabitation, and single-person households',
-            criteriaScore: 78,
-            validity: 'High',
-            reliability: 'High',
-            linkage: 'Med',
-            importance: 'Med',
-          },
-          {
-            name: 'Divorce and dissolution rates',
-            description:
-              'Measures stability of the institution itself — but not quality of intact marriages',
-            criteriaScore: 55,
-            validity: 'High',
-            reliability: 'High',
-            linkage: 'Low',
-            importance: 'Med',
-          },
-          {
-            name: 'Marriage rates and trends over time',
-            description:
-              'Measures popularity, not quality — high marriage rates in a society do not indicate good outcomes',
-            criteriaScore: 40,
-            validity: 'Low',
-            reliability: 'High',
-            linkage: 'Low',
-            importance: 'Low',
-          },
-          {
-            name: 'Alignment with religious teaching',
-            description:
-              'Not independently verifiable or universally applicable; functions as a values claim, not an empirical criterion',
-            criteriaScore: 20,
-            validity: 'Low',
-            reliability: 'Low',
-            linkage: 'Low',
-            importance: 'Low',
+            side: 'supporting',
+            title: 'Advocacy white paper on marriage decline (2012)',
+            source: 'Advocacy organization report',
+            finding:
+              'Attributes a wide range of social ills primarily to declining marriage rates.',
+            qualityScore: 45,
+            qualityLabel: 'Secondary',
+            tier: 'T3',
+            argument:
+              'Declining marriage rates are the primary driver of poverty and social dysfunction.',
+            linkage: 0.55,
+            standing: 'DISPUTED',
           },
         ],
       },
@@ -491,6 +452,31 @@ async function main() {
       },
     } as unknown as never,
   });
+
+  // Wire Position Spectrum rows to the Evidence Ledger rows that back their
+  // top sub-argument (indexes into the evidenceItems create array above).
+  const full = await db.debateTopic.findUnique({
+    where: { slug: 'marriage' },
+    include: { positions: true, evidenceItems: { orderBy: { id: 'asc' } } },
+  } as unknown as never);
+
+  if (full) {
+    const links: Array<[positionScore: number, evidenceIndex: number]> = [
+      [-50, 2], // Skeptical → Musick & Bumpass (selection effects)
+      [50, 0],  // Supportive → Waite & Gallagher
+      [100, 1], // Strongly Support → McLanahan & Sandefur
+    ];
+    for (const [score, evidenceIndex] of links) {
+      const position = full.positions.find((p) => p.positionScore === score);
+      const evidence = full.evidenceItems[evidenceIndex];
+      if (position && evidence) {
+        await db.debatePosition.update({
+          where: { id: position.id },
+          data: { evidenceId: evidence.id },
+        } as unknown as never);
+      }
+    }
+  }
 
   console.log(`✅ Created debate topic: Marriage (id=${topic.id}, slug=${topic.slug})`);
 }

--- a/src/app/debate-topics/[slug]/page.tsx
+++ b/src/app/debate-topics/[slug]/page.tsx
@@ -4,14 +4,13 @@ import { getDebateTopic } from '@/features/debate-topics/db';
 import ExternalReferences from '@/components/debate-topic/ExternalReferences';
 import TopicMetrics from '@/components/debate-topic/TopicMetrics';
 import Spectrum1Positions from '@/components/debate-topic/Spectrum1Positions';
+import EvidenceLedger from '@/components/debate-topic/EvidenceLedger';
 import Spectrum2Magnitude from '@/components/debate-topic/Spectrum2Magnitude';
 import Spectrum3Escalation from '@/components/debate-topic/Spectrum3Escalation';
 import FoundationalAssumptions from '@/components/debate-topic/FoundationalAssumptions';
 import Spectrum4AbstractionLadder from '@/components/debate-topic/Spectrum4AbstractionLadder';
 import CoreValuesConflict from '@/components/debate-topic/CoreValuesConflict';
 import CommonGround from '@/components/debate-topic/CommonGround';
-import EvidenceLedger from '@/components/debate-topic/EvidenceLedger';
-import ObjectiveCriteriaTable from '@/components/debate-topic/ObjectiveCriteriaTable';
 import MediaResources from '@/components/debate-topic/MediaResources';
 import RelatedTopics from '@/components/debate-topic/RelatedTopics';
 
@@ -37,15 +36,15 @@ export default async function DebateTopicPage({ params }: Props) {
         <ExternalReferences external={topic.external} />
 
         {/* Breadcrumb + Title */}
-        <div className="text-right text-sm mb-4 text-gray-600">
+        <div className="text-right text-sm mb-4 text-gray-600 italic">
           <Link href="/debate-topics" className="text-blue-600 hover:underline">Topics</Link>
           {categoryPath.map((cat, i) => (
             <span key={i}>
-              <span className="mx-1">›</span>
+              <span className="mx-1">&gt;</span>
               <span className="text-gray-700">{cat}</span>
             </span>
           ))}
-          <span className="mx-1">›</span>
+          <span className="mx-1">&gt;</span>
           <strong>{topic.title}</strong>
         </div>
 
@@ -67,27 +66,29 @@ export default async function DebateTopicPage({ params }: Props) {
           controversyRating={topic.controversyRating}
         />
 
-        {/*
-          The three-part address. Every belief about this topic gets one fixed address:
-          Direction, Magnitude, and a node on the general-to-specific tree. Engagement and
-          the assumption stack are deliberately NOT matching coordinates.
-        */}
-        <div className="bg-[#f4f9ff] border-l-4 border-[#0055a4] p-3 my-4 text-sm">
-          <strong>What this page does.</strong> It gives every belief about this topic one fixed address, so
-          the thousand ways of saying the same thing collapse into a single entry and the real reasons to
-          agree or disagree can be counted and weighed by evidence instead of by how often they get repeated.
-          The address has three parts, one per table below:{' '}
-          <a href="#direction" className="text-blue-600 hover:underline">Direction</a> (which way it runs),{' '}
-          <a href="#magnitude" className="text-blue-600 hover:underline">Magnitude</a> (how absolute), and{' '}
-          <a href="#specificity" className="text-blue-600 hover:underline">Specificity</a> (where it sits on
-          the general-to-specific tree). Same address means the same claim, so it merges; nearly the same
-          address gets the redundancy discount. Full logic lives on{' '}
-          <a href="/one-page-per-topic" className="text-blue-600 hover:underline">One Page Per Topic</a>.
+        {/* Audit lock */}
+        <div className="bg-[#fffbe6] border-l-4 border-[#b58900] px-3 py-2 my-3 text-xs">
+          <strong>Audit lock.</strong> Every numeric score on this page is computed from linked argument
+          and evidence nodes. Nothing here is hand-entered. If a score looks wrong, fix the underlying
+          node, not the display. See{' '}
+          <Link href="/algorithms/truth-scores" className="text-blue-600 hover:underline">Truth</Link>{' '}
+          and{' '}
+          <Link href="/algorithms/reason-rank" className="text-blue-600 hover:underline">ReasonRank</Link>.
         </div>
+
+        {/* What This Page Is For */}
+        <h2 className="text-xl font-bold mt-6 mb-2">What This Page Is For</h2>
+        <p className="text-sm mb-4">
+          One canonical home for everything anyone has argued about this topic. Arguments are scored by
+          evidence quality, linked to the claims they support or undermine, and updated automatically when
+          new data arrives. The rebuttal to any bad argument on this page is always one click away. See{' '}
+          <Link href="/beliefs" className="text-blue-600 hover:underline">One Page Per Belief</Link> for
+          the single-claim version of this design.
+        </p>
 
         <hr className="my-6" />
 
-        {/* Continuum 1: Direction */}
+        {/* 1. The Position Spectrum */}
         {topic.positions.length > 0 && (
           <>
             <Spectrum1Positions positions={topic.positions} />
@@ -95,22 +96,30 @@ export default async function DebateTopicPage({ params }: Props) {
           </>
         )}
 
-        {/* Continuum 2: Claim Magnitude */}
+        {/* 2. The Evidence Ledger */}
+        {topic.evidenceItems.length > 0 && (
+          <>
+            <EvidenceLedger evidenceItems={topic.evidenceItems} />
+            <hr className="my-6" />
+          </>
+        )}
+
+        {/* 3. Claim Magnitude */}
         <Spectrum2Magnitude
           topicTitle={topic.title}
           claimMagnitudeLevels={topic.claimMagnitudeLevels}
         />
         <hr className="my-6" />
 
-        {/* Continuum 3: General to Specific, with Branching Subcategories */}
-        {topic.abstractionRungs.length > 0 && (
+        {/* 4. The Engagement Landscape: Civic Escalation */}
+        {topic.escalationLevels.length > 0 && (
           <>
-            <Spectrum4AbstractionLadder rungs={topic.abstractionRungs} topicTitle={topic.title} />
+            <Spectrum3Escalation escalationLevels={topic.escalationLevels} />
             <hr className="my-6" />
           </>
         )}
 
-        {/* Assumption Stack Behind Each Position (a dependency map, not a continuum) */}
+        {/* 5. Foundational Assumptions at Each Position */}
         {topic.assumptions.length > 0 && (
           <>
             <FoundationalAssumptions
@@ -121,7 +130,15 @@ export default async function DebateTopicPage({ params }: Props) {
           </>
         )}
 
-        {/* Core Values Conflict */}
+        {/* 6. The Abstraction Ladder */}
+        {topic.abstractionRungs.length > 0 && (
+          <>
+            <Spectrum4AbstractionLadder rungs={topic.abstractionRungs} topicTitle={topic.title} />
+            <hr className="my-6" />
+          </>
+        )}
+
+        {/* 7. Core Values Conflict */}
         {topic.coreValues && (
           <>
             <CoreValuesConflict coreValues={topic.coreValues} topicTitle={topic.title} />
@@ -129,15 +146,7 @@ export default async function DebateTopicPage({ params }: Props) {
           </>
         )}
 
-        {/* The Engagement Landscape (a stakeholder map, not a matching continuum) */}
-        {topic.escalationLevels.length > 0 && (
-          <>
-            <Spectrum3Escalation escalationLevels={topic.escalationLevels} topicTitle={topic.title} />
-            <hr className="my-6" />
-          </>
-        )}
-
-        {/* Common Ground and Compromise */}
+        {/* 8. Common Ground and Compromise */}
         {topic.commonGround && (
           <>
             <CommonGround commonGround={topic.commonGround} />
@@ -145,23 +154,7 @@ export default async function DebateTopicPage({ params }: Props) {
           </>
         )}
 
-        {/* Evidence Ledger */}
-        {topic.evidenceItems.length > 0 && (
-          <>
-            <EvidenceLedger evidenceItems={topic.evidenceItems} />
-            <hr className="my-6" />
-          </>
-        )}
-
-        {/* Objective Criteria */}
-        {topic.objectiveCriteria.length > 0 && (
-          <>
-            <ObjectiveCriteriaTable criteria={topic.objectiveCriteria} />
-            <hr className="my-6" />
-          </>
-        )}
-
-        {/* Media Resources */}
+        {/* 9. Best Media and Resources */}
         {topic.mediaResources.length > 0 && (
           <>
             <MediaResources mediaResources={topic.mediaResources} />
@@ -169,7 +162,7 @@ export default async function DebateTopicPage({ params }: Props) {
           </>
         )}
 
-        {/* Related Topics */}
+        {/* 10. Related Topics */}
         {topic.relatedTopics.length > 0 && (
           <>
             <RelatedTopics relatedTopics={topic.relatedTopics} />
@@ -179,11 +172,10 @@ export default async function DebateTopicPage({ params }: Props) {
 
         {/* Contribute */}
         <div>
-          <h2 className="text-xl font-bold mb-2">📬 Contribute</h2>
-          <p>
+          <h2 className="text-xl font-bold mb-2">Contribute</h2>
+          <p className="mb-3">
             <Link href="/contact" className="text-blue-600 hover:underline">Contact us</Link>{' '}
-            to add beliefs, strengthen arguments, link evidence, or propose criteria.
-            <br />
+            to add beliefs, strengthen arguments, or link new evidence.{' '}
             <a
               href="https://github.com/myklob/ideastockexchange"
               className="text-blue-600 hover:underline"
@@ -192,7 +184,14 @@ export default async function DebateTopicPage({ params }: Props) {
             >
               GitHub
             </a>{' '}
-            for the code and scoring algorithms.
+            for technical implementation and scoring algorithms.
+          </p>
+          <p className="text-xs text-gray-600">
+            <strong>Related design pages:</strong>{' '}
+            <Link href="/beliefs" className="text-blue-600 hover:underline">One Page Per Belief</Link>,{' '}
+            <Link href="/algorithms/unique-scores" className="text-blue-600 hover:underline">Duplication Scores</Link>,{' '}
+            <Link href="/algorithms/combine-similar-beliefs" className="text-blue-600 hover:underline">Grouping Similar Phrasings</Link>,{' '}
+            <Link href="/algorithms/topic-overlap" className="text-blue-600 hover:underline">Grouping by Sub-Topic</Link>.
           </p>
         </div>
 

--- a/src/app/debate-topics/new/page.tsx
+++ b/src/app/debate-topics/new/page.tsx
@@ -149,7 +149,7 @@ function NewDebateTopicForm() {
             </form>
 
             <div className="mt-6 p-4 bg-gray-50 rounded text-xs text-gray-600">
-              <strong>What gets generated:</strong> Definition & scope, 5-point position spectrum, escalation levels (1–6), foundational assumptions by position range, abstraction ladder, core values conflict, common ground & compromise, evidence ledger, objective criteria table, media resources, and related topics.
+              <strong>What gets generated:</strong> Definition & scope, 5-point position spectrum with evidence links, evidence ledger (tier, quality, linkage, standing), claim magnitude examples, civic escalation levels (1–6), foundational assumptions by position range, abstraction ladder, core values conflict, common ground & compromise, media resources, and related topics.
             </div>
           </div>
         )}
@@ -179,7 +179,6 @@ function NewDebateTopicForm() {
               <div className="ml-4">&quot;coreValues&quot;: &#123;...&#125;,</div>
               <div className="ml-4">&quot;commonGround&quot;: &#123;...&#125;,</div>
               <div className="ml-4">&quot;evidenceItems&quot;: [...],</div>
-              <div className="ml-4">&quot;objectiveCriteria&quot;: [...],</div>
               <div className="ml-4">&quot;mediaResources&quot;: [...],</div>
               <div className="ml-4">&quot;relatedTopics&quot;: [...]</div>
               <div className="ml-2">&#125;&apos;</div>

--- a/src/components/debate-topic/CommonGround.tsx
+++ b/src/components/debate-topic/CommonGround.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import type { DebateCommonGround } from '@/core/types/debate-topic';
 
 interface Props {
@@ -6,42 +5,19 @@ interface Props {
 }
 
 export default function CommonGround({ commonGround }: Props) {
-  const valueConflicts = commonGround.valueConflicts ?? [];
-
   return (
     <div className="mb-8">
-      <h2 className="text-xl font-bold mb-1">
-        🤝 Common Ground and Compromise
-      </h2>
+      <h2 className="text-xl font-bold mb-1">8. Common Ground and Compromise</h2>
       <p className="text-sm text-gray-600 mb-3">
-        The scored <Link href="/cba/about" className="text-blue-600 hover:underline">cost-benefit</Link>{' '}
-        trees read sideways. Compromise Candidates are the winnable disagreements, the ones a small
-        likelihood shift can flip, as opposed to the symbolic value conflicts no negotiation resolves. That
-        is the payoff of scoring both sides with equal rigor.
+        Solutions that address both sides&apos; core concerns are more durable than victories. Compromise
+        positions belong here.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100 align-top">
-              <th className="border border-gray-300 px-3 py-2 w-1/3">
-                Shared Interests
-                <br />
-                <span className="text-xs font-normal text-gray-500">Impacts both sides want</span>
-              </th>
-              <th className="border border-gray-300 px-3 py-2 w-1/3">
-                Real Value Conflicts
-                <br />
-                <span className="text-xs font-normal text-gray-500">
-                  One side prices freedom, the other safety
-                </span>
-              </th>
-              <th className="border border-gray-300 px-3 py-2 w-1/3">
-                Compromise Candidates
-                <br />
-                <span className="text-xs font-normal text-gray-500">
-                  A small likelihood shift flips a category&apos;s net
-                </span>
-              </th>
+            <tr className="bg-[#f0f3f6]">
+              <th className="border border-gray-300 px-3 py-2 w-1/2">What Both Sides Might Agree On</th>
+              <th className="border border-gray-300 px-3 py-2 w-1/2">Possible Compromise Positions</th>
             </tr>
           </thead>
           <tbody>
@@ -52,17 +28,6 @@ export default function CommonGround({ commonGround }: Props) {
                     <li key={i}>{a}</li>
                   ))}
                 </ol>
-              </td>
-              <td className="border border-gray-300 px-3 py-3 align-top">
-                {valueConflicts.length > 0 ? (
-                  <ol className="list-decimal list-inside space-y-1">
-                    {valueConflicts.map((v, i) => (
-                      <li key={i}>{v}</li>
-                    ))}
-                  </ol>
-                ) : (
-                  <span className="text-gray-400 text-xs">None listed</span>
-                )}
               </td>
               <td className="border border-gray-300 px-3 py-3 align-top">
                 <ol className="list-decimal list-inside space-y-1">

--- a/src/components/debate-topic/CoreValuesConflict.tsx
+++ b/src/components/debate-topic/CoreValuesConflict.tsx
@@ -8,19 +8,16 @@ interface Props {
 export default function CoreValuesConflict({ coreValues }: Props) {
   return (
     <div className="mb-8">
-      <h2 className="text-xl font-bold mb-1">
-        ⚖️ Core Values Conflict
-      </h2>
+      <h2 className="text-xl font-bold mb-1">7. Core Values Conflict</h2>
       <p className="text-sm text-gray-600 mb-3">
-        Advertised values each side claims, and the motivation critics attribute.{' '}
-        <span className="text-gray-500">
-          See: <a href="/how-it-works" className="text-blue-600 hover:underline">American Values</a>.
-        </span>
+        Most policy disagreements are not disagreements about facts. They are disagreements about which
+        values take priority when values conflict. This table makes the priorities on both sides explicit,
+        including the gap between advertised values and motivations critics attribute.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
+            <tr className="bg-[#f0f3f6]">
               <th className="border border-gray-300 px-3 py-2 w-1/2">
                 Values Supporting This Topic
               </th>
@@ -41,7 +38,7 @@ export default function CoreValuesConflict({ coreValues }: Props) {
                 {coreValues.supportingActual.length > 0 && (
                   <>
                     <br />
-                    <strong>Critics say the actual motivation is:</strong>
+                    <strong>Actual (per critics):</strong>
                     <ol className="list-decimal list-inside mt-1 space-y-1">
                       {coreValues.supportingActual.map((v, i) => (
                         <li key={i}>{v}</li>
@@ -60,7 +57,7 @@ export default function CoreValuesConflict({ coreValues }: Props) {
                 {coreValues.opposingActual.length > 0 && (
                   <>
                     <br />
-                    <strong>Critics say the actual motivation is:</strong>
+                    <strong>Actual (per critics):</strong>
                     <ol className="list-decimal list-inside mt-1 space-y-1">
                       {coreValues.opposingActual.map((v, i) => (
                         <li key={i}>{v}</li>

--- a/src/components/debate-topic/EvidenceLedger.tsx
+++ b/src/components/debate-topic/EvidenceLedger.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { DebateEvidence } from '@/core/types/debate-topic';
 
 interface Props {
@@ -10,96 +11,97 @@ function qualityColor(score: number): string {
   return 'text-red-600';
 }
 
+function standingBadge(standing: string) {
+  if (standing === 'FALSIFIED') {
+    return <span className="font-semibold text-red-600">FALSIFIED</span>;
+  }
+  if (standing === 'DISPUTED') {
+    return <span className="font-semibold text-[#b58900]">DISPUTED</span>;
+  }
+  return <span className="font-semibold text-gray-700">VERIFIED</span>;
+}
+
+function tierRank(tier: string | undefined): number {
+  const n = Number((tier ?? 'T2').replace(/^T/i, ''));
+  return Number.isFinite(n) ? n : 2;
+}
+
 export default function EvidenceLedger({ evidenceItems }: Props) {
-  // A highlight reel: highest-quality evidence first on each side.
-  const byQuality = (a: DebateEvidence, b: DebateEvidence) => b.qualityScore - a.qualityScore;
-  const supporting = evidenceItems.filter((e) => e.side === 'supporting').sort(byQuality);
-  const weakening = evidenceItems.filter((e) => e.side === 'weakening').sort(byQuality);
-  const maxRows = Math.max(supporting.length, weakening.length);
+  const rows = [...evidenceItems].sort(
+    (a, b) => tierRank(a.tier) - tierRank(b.tier) || b.qualityScore - a.qualityScore
+  );
 
   return (
-    <div className="mb-8">
-      <h2 className="text-xl font-bold mb-1">⚖️ The Evidence Ledger</h2>
-      <p className="text-xs text-gray-600 mb-3">
-        A highlight reel of the highest-impact evidence appearing anywhere under this topic. Evidence
-        formally attaches to specific beliefs and is scored on its own study page; this is the cross-topic
-        view.{' '}
-        <span className="text-gray-500">
-          See: <a href="/evidence-scoring" className="text-blue-600 hover:underline">Evidence Scoring Methodology</a>.
-        </span>
+    <div id="evidence-ledger" className="mb-8">
+      <h2 className="text-xl font-bold mb-1">2. The Evidence Ledger</h2>
+      <p className="text-sm text-gray-600 mb-3">
+        The raw inputs every Belief Score on this page traces back to. Quality scores reflect
+        methodology, sample size, and reproducibility. Ten independent sources confirming one finding
+        raise that finding&apos;s{' '}
+        <Link href="/algorithms/truth-scores" className="text-blue-600 hover:underline">Truth Score</Link>;
+        they do not create ten arguments. Corroboration is rewarded. Repetition is not. See{' '}
+        <Link href="/algorithms/unique-scores" className="text-blue-600 hover:underline">Duplication Scores</Link>.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 w-[40%]">Supporting Evidence (Pro)</th>
-              <th className="border border-gray-300 px-3 py-2 w-[10%] text-center">Quality</th>
-              <th className="border border-gray-300 px-3 py-2 w-[40%]">Weakening Evidence (Con)</th>
-              <th className="border border-gray-300 px-3 py-2 w-[10%] text-center">Quality</th>
+            <tr className="bg-[#f0f3f6]">
+              <th className="border border-gray-300 px-2 py-2 w-[6%] text-center">T</th>
+              <th className="border border-gray-300 px-3 py-2 w-[20%]">Source</th>
+              <th className="border border-gray-300 px-2 py-2 w-[5%] text-center">↑↓</th>
+              <th className="border border-gray-300 px-3 py-2 w-[37%]">Argument It Bears On</th>
+              <th className="border border-gray-300 px-2 py-2 w-[10%] text-center">Quality</th>
+              <th className="border border-gray-300 px-2 py-2 w-[10%] text-center">
+                <Link href="/algorithms/linkage-scores" className="text-blue-600 hover:underline">Linkage</Link>
+              </th>
+              <th className="border border-gray-300 px-2 py-2 w-[12%] text-center">Standing</th>
             </tr>
           </thead>
           <tbody>
-            {Array.from({ length: maxRows }).map((_, i) => {
-              const s = supporting[i];
-              const w = weakening[i];
-              return (
-                <tr key={i} className="align-top">
-                  <td className="border border-gray-300 px-3 py-2">
-                    {s ? (
-                      <>
-                        {s.url ? (
-                          <a href={s.url} className="font-semibold text-blue-600 hover:underline">{s.title}</a>
-                        ) : (
-                          <strong>{s.title}</strong>
-                        )}
-                        <br />
-                        <span className="text-xs text-gray-500">{s.source}</span>
-                        <br />
-                        <span className="text-xs">{s.finding}</span>
-                      </>
-                    ) : null}
-                  </td>
-                  <td className="border border-gray-300 px-3 py-2 text-center align-middle">
-                    {s ? (
-                      <>
-                        <span className={`font-bold ${qualityColor(s.qualityScore)}`}>[{s.qualityScore}%]</span>
-                        <br />
-                        <span className="text-xs text-gray-500">({s.qualityLabel})</span>
-                      </>
-                    ) : null}
-                  </td>
-                  <td className="border border-gray-300 px-3 py-2">
-                    {w ? (
-                      <>
-                        {w.url ? (
-                          <a href={w.url} className="font-semibold text-blue-600 hover:underline">{w.title}</a>
-                        ) : (
-                          <strong>{w.title}</strong>
-                        )}
-                        <br />
-                        <span className="text-xs text-gray-500">{w.source}</span>
-                        <br />
-                        <span className="text-xs">{w.finding}</span>
-                      </>
-                    ) : null}
-                  </td>
-                  <td className="border border-gray-300 px-3 py-2 text-center align-middle">
-                    {w ? (
-                      <>
-                        <span className={`font-bold ${qualityColor(w.qualityScore)}`}>[{w.qualityScore}%]</span>
-                        <br />
-                        <span className="text-xs text-gray-500">({w.qualityLabel})</span>
-                      </>
-                    ) : null}
-                  </td>
-                </tr>
-              );
-            })}
+            {rows.map((e, i) => (
+              <tr key={e.id ?? i} id={e.id !== undefined ? `evidence-${e.id}` : undefined} className="align-top scroll-mt-4">
+                <td className="border border-gray-300 px-2 py-2 text-center">{e.tier ?? 'T2'}</td>
+                <td className="border border-gray-300 px-3 py-2">
+                  {e.url ? (
+                    <a href={e.url} className="text-blue-600 hover:underline">{e.title}</a>
+                  ) : (
+                    e.title
+                  )}
+                  {e.source && <span className="block text-xs text-gray-500">{e.source}</span>}
+                </td>
+                <td className="border border-gray-300 px-2 py-2 text-center font-bold">
+                  {e.side === 'weakening' ? (
+                    <span className="text-red-600">−</span>
+                  ) : (
+                    <span className="text-green-700">+</span>
+                  )}
+                </td>
+                <td className="border border-gray-300 px-3 py-2">{e.argument || e.finding}</td>
+                <td className={`border border-gray-300 px-2 py-2 text-center font-bold ${qualityColor(e.qualityScore)}`}>
+                  {e.qualityScore}%
+                </td>
+                <td className="border border-gray-300 px-2 py-2 text-center font-mono">
+                  {e.linkage !== undefined ? `+${e.linkage.toFixed(2)}` : '—'}
+                </td>
+                <td className="border border-gray-300 px-2 py-2 text-center">
+                  {standingBadge(e.standing ?? 'VERIFIED')}
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>
-      <p className="text-right text-xs mt-2 text-gray-500">
-        See: <a href="/evidence-scoring" className="text-blue-600 hover:underline">Evidence Scoring Methodology</a>
+      <p className="text-xs text-gray-600 mt-2">
+        <strong>Legend.</strong> <strong>T</strong> = evidence tier (T1 peer-reviewed, T2 reputable
+        institution, T3 secondary, T4 anecdotal). <strong>↑↓</strong> = supports (+) or weakens (−) the
+        linked argument. <strong>Quality</strong> = methodological strength of the evidence itself.{' '}
+        <strong>Linkage</strong> = how directly this evidence bears on the specific argument it&apos;s
+        attached to (see{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-600 hover:underline">Linkage Scores</Link>).{' '}
+        <strong>Standing</strong> = where the evidence sits in the verification lifecycle: VERIFIED counts
+        at full weight, DISPUTED at half weight while the challenge is open, FALSIFIED at zero, with the
+        retraction propagating to every score built on it. See{' '}
+        <Link href="/algorithms/evidence-scores" className="text-blue-600 hover:underline">Evidence Scores</Link>.
       </p>
     </div>
   );

--- a/src/components/debate-topic/FoundationalAssumptions.tsx
+++ b/src/components/debate-topic/FoundationalAssumptions.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { DebateAssumption } from '@/core/types/debate-topic';
 
 interface Props {
@@ -17,27 +18,27 @@ export default function FoundationalAssumptions({ assumptions, keyInsight }: Pro
   return (
     <div className="mb-8">
       <h2 className="text-xl font-bold mb-1">
-        📜 Assumption Stack Behind Each Position
+        5.{' '}
+        <Link href="/algorithms/assumptions" className="text-blue-600 hover:underline">
+          Foundational Assumptions
+        </Link>{' '}
+        at Each Position
       </h2>
-      <p className="text-sm text-gray-600 mb-3">
-        Not a fourth axis. Continuum 3 sorts beliefs by altitude; this takes each stance and lists the
-        assumptions a person must accept to hold it, which is how a fight at the bottom gets traced to its
-        real root higher up.
-        {keyInsight && (
-          <>
-            {' '}<strong className="text-gray-800">Core split:</strong> {keyInsight}
-          </>
-        )}
-        {' '}<span className="text-gray-500">
-          See: <a href="/Assumptions" className="text-blue-600 hover:underline">Assumptions</a>.
-        </span>
+      <p className="text-sm text-gray-600 mb-2">
+        Your position on the spectrum in section 1 depends on deeper assumptions about reality, values,
+        and causation. This table maps those dependencies from worldview down to topic-specific claim.
       </p>
+      {keyInsight && (
+        <p className="text-sm mb-3">
+          <strong>Key Insight:</strong> {keyInsight}
+        </p>
+      )}
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
+            <tr className="bg-[#f0f3f6]">
               <th className="border border-gray-300 px-3 py-2 w-[15%]">To Hold Position</th>
-              <th className="border border-gray-300 px-3 py-2">You Must Accept These Assumptions (General to Specific)</th>
+              <th className="border border-gray-300 px-3 py-2">You Must Believe These Assumptions (General → Specific)</th>
             </tr>
           </thead>
           <tbody>
@@ -48,7 +49,7 @@ export default function FoundationalAssumptions({ assumptions, keyInsight }: Pro
                   <br />
                   <span className="text-xs font-normal">({a.positionLabel})</span>
                 </td>
-                <td className={`border border-gray-300 px-3 py-2 ${RANGE_BG[a.positionRange] ?? ''}`}>
+                <td className="border border-gray-300 px-3 py-2">
                   {a.assumptions.map((text, i) => (
                     <div key={i} className={i > 0 ? 'mt-1' : ''}>
                       {text}

--- a/src/components/debate-topic/MediaResources.tsx
+++ b/src/components/debate-topic/MediaResources.tsx
@@ -1,12 +1,14 @@
+import Link from 'next/link';
 import type { DebateMediaResource } from '@/core/types/debate-topic';
 
 interface Props {
   mediaResources: DebateMediaResource[];
 }
 
-function positivityLabel(p: number): string {
+function directionLabel(p: number): string {
   if (p > 0) return `+${p}%`;
-  return `${p}%`;
+  if (p < 0) return `−${Math.abs(p)}%`;
+  return '0%';
 }
 
 export default function MediaResources({ mediaResources }: Props) {
@@ -14,24 +16,25 @@ export default function MediaResources({ mediaResources }: Props) {
 
   return (
     <div className="mb-8">
-      <h2 className="text-xl font-bold mb-1">📚 Best Media and Resources</h2>
-      <p className="text-xs text-gray-600 mb-3">
-        Sorted by positivity and informational value.{' '}
-        <span className="text-gray-500">
-          See: <a href="/media-framework" className="text-blue-600 hover:underline">Media Framework</a>.
-        </span>
+      <h2 className="text-xl font-bold mb-1">9. Best Media and Resources</h2>
+      <p className="text-sm text-gray-600 mb-3">
+        Curated sources sorted by direction and informational value. Direction and Magnitude are the same
+        belief coordinates from sections 1 and 3, applied to what the source argues. The Escalation column
+        applies section 4&apos;s ladder to the content itself: what level of action does this source
+        advocate? A book can call for civil disobedience regardless of what any reader does. See{' '}
+        <Link href="/media" className="text-blue-600 hover:underline">Media Framework</Link>.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
+            <tr className="bg-[#f0f3f6]">
               <th className="border border-gray-300 px-3 py-2 w-[28%]">Title</th>
-              <th className="border border-gray-300 px-3 py-2 w-[10%]">Medium</th>
-              <th className="border border-gray-300 px-3 py-2 w-[14%]">Bias/Tone</th>
-              <th className="border border-gray-300 px-3 py-2 w-[10%] text-center">Positivity</th>
+              <th className="border border-gray-300 px-3 py-2 w-[12%]">Medium</th>
+              <th className="border border-gray-300 px-3 py-2 w-[12%]">Bias / Tone</th>
+              <th className="border border-gray-300 px-3 py-2 w-[10%] text-center">Direction</th>
               <th className="border border-gray-300 px-3 py-2 w-[10%] text-center">Magnitude</th>
-              <th className="border border-gray-300 px-3 py-2 w-[8%] text-center">Escalation</th>
-              <th className="border border-gray-300 px-3 py-2 w-[20%]">Key Insight</th>
+              <th className="border border-gray-300 px-3 py-2 w-[10%] text-center">Escalation</th>
+              <th className="border border-gray-300 px-3 py-2 w-[18%]">Key Insight</th>
             </tr>
           </thead>
           <tbody>
@@ -47,7 +50,7 @@ export default function MediaResources({ mediaResources }: Props) {
                 <td className="border border-gray-300 px-3 py-2 text-gray-600">{m.medium}</td>
                 <td className="border border-gray-300 px-3 py-2 text-gray-600">{m.biasOrTone}</td>
                 <td className="border border-gray-300 px-3 py-2 text-center font-mono font-semibold">
-                  {positivityLabel(m.positivity)}
+                  {directionLabel(m.positivity)}
                 </td>
                 <td className="border border-gray-300 px-3 py-2 text-center">{m.magnitude}%</td>
                 <td className="border border-gray-300 px-3 py-2 text-center">{m.escalation}</td>

--- a/src/components/debate-topic/RelatedTopics.tsx
+++ b/src/components/debate-topic/RelatedTopics.tsx
@@ -35,24 +35,22 @@ function TopicList({ topics }: { topics: DebateRelatedTopic[] }) {
 export default function RelatedTopics({ relatedTopics }: Props) {
   const parents = relatedTopics.filter((t) => t.relationType === 'parent');
   const children = relatedTopics.filter((t) => t.relationType === 'child');
-  const siblings = relatedTopics.filter((t) => t.relationType === 'sibling');
-  const opposing = relatedTopics.filter((t) => t.relationType === 'opposingView');
+  // Legacy "opposingView" rows render under Adjacent — the template has no
+  // separate opposing column.
+  const siblings = relatedTopics.filter(
+    (t) => t.relationType === 'sibling' || t.relationType === 'opposingView'
+  );
 
   return (
     <div id="related" className="mb-8">
-      <h2 className="text-xl font-bold mb-1">🔗 Related Topics</h2>
-      <p className="text-sm text-gray-600 mb-3">
-        The <strong>Children</strong> column is where full subcategories from Continuum 3 go once they
-        outgrow a row and earn their own page.
-      </p>
+      <h2 className="text-xl font-bold mb-3">10. Related Topics</h2>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 w-1/4">Broader (Parents)</th>
-              <th className="border border-gray-300 px-3 py-2 w-1/4">Sub-Issues (Children)</th>
-              <th className="border border-gray-300 px-3 py-2 w-1/4">Related (Siblings)</th>
-              <th className="border border-gray-300 px-3 py-2 w-1/4">Opposing / Critical Views</th>
+            <tr className="bg-[#f0f3f6]">
+              <th className="border border-gray-300 px-3 py-2 w-1/3">Broader (Parents)</th>
+              <th className="border border-gray-300 px-3 py-2 w-1/3">Narrower (Children)</th>
+              <th className="border border-gray-300 px-3 py-2 w-1/3">Adjacent (Siblings)</th>
             </tr>
           </thead>
           <tbody>
@@ -65,9 +63,6 @@ export default function RelatedTopics({ relatedTopics }: Props) {
               </td>
               <td className="border border-gray-300 px-3 py-3 align-top">
                 <TopicList topics={siblings} />
-              </td>
-              <td className="border border-gray-300 px-3 py-3 align-top">
-                <TopicList topics={opposing} />
               </td>
             </tr>
           </tbody>

--- a/src/components/debate-topic/Spectrum1Positions.tsx
+++ b/src/components/debate-topic/Spectrum1Positions.tsx
@@ -19,25 +19,21 @@ function scoreColor(score: number): string {
 export default function Spectrum1Positions({ positions }: Props) {
   return (
     <div id="direction" className="mb-8">
-      <h2 className="text-xl font-bold mb-1">
-        📊 Continuum 1: Direction{' '}
-        <a href="/positive-to-negative" className="text-base font-normal text-blue-600 hover:underline">
-          (Oppose ↔ Support)
-        </a>
-      </h2>
+      <h2 className="text-xl font-bold mb-1">1. The Position Spectrum (Negative ↔ Positive)</h2>
       <p className="text-sm text-gray-600 mb-4">
-        Which way the belief runs, from total opposition (−100%) to total support (+100%). The{' '}
-        <strong>Belief Score</strong> column is a separate thing: how well the belief holds up once its
-        arguments are scored, not which way it points. A claim can sit at +100% and still score badly.
+        Where do beliefs about this topic sit on the direction of support? This dimension captures
+        direction <em>only</em>. How extreme the phrasing is, and how far someone is willing to go to act
+        on the belief, are tracked in sections 3 and 4.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 w-[12%]">Position</th>
-              <th className="border border-gray-300 px-3 py-2 w-[55%]">Core Belief / Claim</th>
-              <th className="border border-gray-300 px-3 py-2 w-[25%]">Top Underlying Argument</th>
-              <th className="border border-gray-300 px-3 py-2 w-[8%] text-center">Belief Score</th>
+            <tr className="bg-[#f0f3f6]">
+              <th className="border border-gray-300 px-3 py-2 w-[10%]">Position</th>
+              <th className="border border-gray-300 px-3 py-2 w-[38%]">Belief Held at This Position</th>
+              <th className="border border-gray-300 px-3 py-2 w-[28%]">Top Sub-Argument Driving the Score</th>
+              <th className="border border-gray-300 px-3 py-2 w-[12%] text-center">Belief Score</th>
+              <th className="border border-gray-300 px-3 py-2 w-[12%] text-center">Evidence</th>
             </tr>
           </thead>
           <tbody>
@@ -46,7 +42,7 @@ export default function Spectrum1Positions({ positions }: Props) {
                 <td className="border border-gray-300 px-3 py-2 text-center font-semibold">
                   <strong>{pos.positionScore > 0 ? '+' : ''}{pos.positionScore}%</strong>
                   <br />
-                  <span className="text-xs font-normal">({pos.positionLabel})</span>
+                  <span className="text-xs font-normal">{pos.positionLabel}</span>
                 </td>
                 <td className="border border-gray-300 px-3 py-2">
                   {pos.mediaUrl ? (
@@ -59,15 +55,25 @@ export default function Spectrum1Positions({ positions }: Props) {
                 <td className={`border border-gray-300 px-3 py-2 text-center font-mono font-bold ${scoreColor(pos.positionScore)}`}>
                   {pos.beliefScore}
                 </td>
+                <td className="border border-gray-300 px-3 py-2 text-center">
+                  {pos.evidenceId !== undefined ? (
+                    <a href={`#evidence-${pos.evidenceId}`} className="text-blue-600 hover:underline">
+                      ledger
+                    </a>
+                  ) : (
+                    <span className="text-gray-400">—</span>
+                  )}
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-      <p className="text-right text-xs mt-2 text-gray-500">
-        See: <a href="/positive-to-negative" className="text-blue-600 hover:underline">Full Positivity Framework</a>
-        {' | '}
-        <a href="/positive-to-negative" className="text-blue-600 hover:underline">Why We Need This Continuum</a>
+      <p className="text-xs text-gray-600 mt-2">
+        <strong>Reading the table.</strong> The Position column is a coordinate, not a verdict. The Belief
+        Score is the verdict, computed from linked sub-arguments. A position can be widely held (lots of
+        people sit at +50%) and still have a low Belief Score, because what people believe and what
+        survives evidence are different questions.
       </p>
     </div>
   );

--- a/src/components/debate-topic/Spectrum2Magnitude.tsx
+++ b/src/components/debate-topic/Spectrum2Magnitude.tsx
@@ -1,18 +1,20 @@
+import Link from 'next/link';
 import type { DebateClaimMagnitude } from '@/core/types/debate-topic';
 
-// Canonical band names per the topic template: Modest / Moderate / Strong / Total.
-// Older rows were stored as "Weak (20%)" … "Extreme (100%)" with "X Assertion"
+// Canonical band names per the topic template: Weak / Moderate / Strong / Extreme.
+// Older rows were stored as "Modest (20%)" … "Total (100%)" with "X Assertion"
 // sublabels; normalize at render so every topic shows the current canon.
 const LEVEL_RENAMES: Record<string, string> = {
-  'Weak (20%)': 'Modest (20%)',
-  'Extreme (100%)': 'Total (100%)',
+  'Modest (20%)': 'Weak (20%)',
+  'Total (100%)': 'Extreme (100%)',
 };
 
 const SUBLABEL_RENAMES: Record<string, string> = {
   'Modest Assertion': 'Hedged',
   Modest: 'Hedged',
   'Standard Assertion': 'Standard',
-  'Broad Assertion': 'Broad',
+  'Broad Assertion': 'Categorical',
+  Broad: 'Categorical',
   'Maximal Assertion': 'Maximal',
 };
 
@@ -25,52 +27,35 @@ function canonicalSublabel(sublabel: string): string {
 }
 
 // Generic fallback rows used when no DB-backed data is available for a topic.
-// Each row describes what a belief *sounds like* at that strength, on either side,
-// plus the telltale words that place it there.
+// Each row describes what a belief *sounds like* at that strength, on either side.
 const GENERIC_MAGNITUDE_ROWS = [
   {
-    sortOrder: 0,
-    magnitudeLevel: 'Modest (20%)',
-    magnitudePercent: 20,
+    magnitudeLevel: 'Weak (20%)',
     sublabel: 'Hedged',
-    proExample: (topic: string) =>
-      `${topic} is somewhat good, openly admitting real flaws and exceptions.`,
-    antiExample: (topic: string) =>
-      `${topic} is somewhat bad, while conceding it works acceptably much of the time.`,
-    scopeDescription: 'Narrow. Hedged with “some,” “tends to,” “in certain cases.”',
+    proExample: (topic: string) => `${topic} can be a useful tool in some cases.`,
+    antiExample: (topic: string) => `${topic} may not be the best tool here.`,
+    scopeDescription: 'Narrow. Acknowledges exceptions.',
   },
   {
-    sortOrder: 1,
     magnitudeLevel: 'Moderate (50%)',
-    magnitudePercent: 50,
     sublabel: 'Standard',
-    proExample: (topic: string) =>
-      `${topic} is clearly better than the alternatives in most cases.`,
-    antiExample: (topic: string) =>
-      `${topic} is clearly worse than the alternatives in most cases.`,
-    scopeDescription: 'Definite but bounded. “Clearly,” “generally.” Where most serious arguments live.',
+    proExample: (topic: string) => `${topic} is clearly better than the alternatives in most cases.`,
+    antiExample: (topic: string) => `${topic} fails to deliver what its supporters claim.`,
+    scopeDescription: 'Definite but bounded. Most defensible level.',
   },
   {
-    sortOrder: 2,
     magnitudeLevel: 'Strong (80%)',
-    magnitudePercent: 80,
-    sublabel: 'Broad',
-    proExample: (topic: string) =>
-      `${topic} is right across the board and the alternatives reliably fail.`,
-    antiExample: (topic: string) =>
-      `${topic} is wrong across the board and fails wherever it is tried.`,
-    scopeDescription: 'Near-universal. “Across the board,” “fundamentally.” Little room for exceptions.',
+    sublabel: 'Categorical',
+    proExample: (topic: string) => `${topic} is fundamentally the right approach.`,
+    antiExample: (topic: string) => `${topic} is fundamentally the wrong approach.`,
+    scopeDescription: 'Wide. Little room for exceptions.',
   },
   {
-    sortOrder: 3,
-    magnitudeLevel: 'Total (100%)',
-    magnitudePercent: 100,
+    magnitudeLevel: 'Extreme (100%)',
     sublabel: 'Maximal',
-    proExample: (topic: string) =>
-      `${topic} is always right, everywhere, with no legitimate exception.`,
-    antiExample: (topic: string) =>
-      `${topic} is always wrong, has never once worked and never will.`,
-    scopeDescription: 'Total, zero limits. “Always,” “never.” One counterexample sinks it.',
+    proExample: (topic: string) => `${topic} is the only acceptable option, everywhere, always.`,
+    antiExample: (topic: string) => `${topic} has never once worked and never will.`,
+    scopeDescription: 'Catastrophic framing, no limits. Easy to dismiss.',
   },
 ];
 
@@ -87,25 +72,24 @@ export default function Spectrum2Magnitude({ topicTitle, claimMagnitudeLevels }:
 
   return (
     <div id="magnitude" className="mb-8">
-      <h2 className="text-xl font-bold mb-1">
-        💪 Continuum 2: Claim Magnitude, How Absolute the Claim Is{' '}
-        <a href="/strong-to-weak" className="text-base font-normal text-blue-600 hover:underline">
-          (Modest ↔ Total)
-        </a>
-      </h2>
+      <h2 className="text-xl font-bold mb-1">3. Claim Magnitude (Weak ↔ Strong)</h2>
       <p className="text-sm text-gray-600 mb-4">
-        How absolute the claim is, from a hedged &ldquo;sometimes&rdquo; to a flat &ldquo;always,&rdquo;
-        independent of which way it runs and of whether it is true. Two beliefs match on this axis when
-        they are equally bold.
+        How extreme is the phrasing of a claim, independent of which direction it runs and independent of
+        whether it&apos;s true? A weak pro claim and a weak anti claim are both modest assertions. The
+        Belief Score, computed elsewhere, tells you how well-supported a claim is. This dimension just
+        identifies its structural reach so equivalent claims can be matched and grouped. See{' '}
+        <Link href="/algorithms/strong-to-weak" className="text-blue-600 hover:underline">
+          Magnitude Spectrum
+        </Link>.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 w-[16%]">Claim Magnitude</th>
-              <th className="border border-gray-300 px-3 py-2 w-[32%]">Pro Belief at This Strength</th>
-              <th className="border border-gray-300 px-3 py-2 w-[32%]">Anti Belief at This Strength</th>
-              <th className="border border-gray-300 px-3 py-2 w-[20%]">Scope &amp; Telltale Words</th>
+            <tr className="bg-[#f0f3f6]">
+              <th className="border border-gray-300 px-3 py-2 w-[18%]">Magnitude</th>
+              <th className="border border-gray-300 px-3 py-2 w-[33%]">Pro-Topic Example</th>
+              <th className="border border-gray-300 px-3 py-2 w-[33%]">Anti-Topic Example</th>
+              <th className="border border-gray-300 px-3 py-2 w-[16%]">Scope</th>
             </tr>
           </thead>
           <tbody>
@@ -149,14 +133,11 @@ export default function Spectrum2Magnitude({ topicTitle, claimMagnitudeLevels }:
           </tbody>
         </table>
       </div>
-      <div className="bg-blue-50 p-3 border-l-4 border-blue-700 mt-3 text-xs">
-        <strong>Key insight:</strong> The strongest arguments on either side usually live at Moderate (50%),
-        not Total (100%). Attacking only the Total versions is a straw man. Engage the best version of the
-        opposing argument, not the loudest.
+      <div className="bg-[#eef5ff] p-3 border-l-4 border-[#36c] mt-3 text-sm">
+        <strong>Why this matters.</strong> The strongest real arguments on either side typically operate
+        at Moderate magnitude. Engaging only with the Extreme version of an opposing claim is a straw man.
+        The platform requires engaging the best version of the opposing argument, not the loudest.
       </div>
-      <p className="text-right text-xs mt-2 text-gray-500">
-        See: <a href="/strong-to-weak" className="text-blue-600 hover:underline">Why We Need This Continuum</a>
-      </p>
     </div>
   );
 }

--- a/src/components/debate-topic/Spectrum3Escalation.tsx
+++ b/src/components/debate-topic/Spectrum3Escalation.tsx
@@ -2,115 +2,85 @@ import type { DebateEscalation } from '@/core/types/debate-topic';
 
 interface Props {
   escalationLevels: DebateEscalation[];
-  topicTitle: string;
 }
 
 const ROW_COLORS = [
-  'bg-green-50',
-  'bg-green-100',
-  'bg-yellow-100',
-  'bg-yellow-200',
-  'bg-orange-200',
-  'bg-red-200',
+  'bg-[#e8f5e9]',
+  'bg-[#c8e6c9]',
+  'bg-[#fff9c4]',
+  'bg-[#ffe082]',
+  'bg-[#ffb74d]',
+  'bg-[#ef9a9a]',
 ];
 
-export default function Spectrum3Escalation({ escalationLevels, topicTitle }: Props) {
-  // Determine whether we have per-side data (pro/antiDescription populated)
-  const hasPerSideData = escalationLevels.some(
-    (e) => e.proDescription && e.proDescription.trim().length > 0
-  );
+const LEVEL_SUBLABELS: Record<number, string> = {
+  1: 'Slight lean',
+  2: 'Engaged supporter',
+  3: 'Conscientious objector',
+  4: 'Principled lawbreaking',
+  5: 'Active disruption',
+  6: 'No limiting principles',
+};
 
+export default function Spectrum3Escalation({ escalationLevels }: Props) {
   return (
     <div id="engagement" className="mb-8">
       <h2 className="text-xl font-bold mb-1">
-        ⚡ The Engagement Landscape{' '}
-        <a href="/escalation-spectrum" className="text-base font-normal text-blue-600 hover:underline">
-          (Passive ↔ Active)
-        </a>
+        4. The Engagement Landscape: Civic Escalation (Preference ↔ Any Means)
       </h2>
       <p className="text-sm text-gray-600 mb-4">
-        <strong>A stakeholder map, not a matching axis.</strong> It measures how far a person will go to act
-        on a belief, which is a fact about the person, not the belief, so it never feeds the three-part
-        address above. A casual supporter and someone willing to go to prison hold the <em>same belief</em>.{' '}
-        <span className="text-gray-500">
-          See: <a href="/escalation-spectrum" className="text-blue-600 hover:underline">Escalation Spectrum</a>.
-        </span>
+        How many other principles is someone willing to violate to advance this belief? This is the other
+        meaning of &ldquo;strength of conviction&rdquo;: not <em>how extreme is the claim</em> (section 3),
+        but <em>what limits does the believer accept on acting</em>. Thomas More held the most absolute
+        possible conviction Henry VIII was wrong and chose silent execution rather than act outside legal
+        process. Martin Luther King held an equally total conviction and chose to openly violate unjust
+        laws while accepting the consequences. Both are coherent positions. Unlike sections 1, 3, and 6,
+        this ladder describes believers rather than beliefs, so it never enters belief matching; see the
+        note below the table.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 w-[18%]">Engagement Level</th>
-              {hasPerSideData ? (
-                <>
-                  <th className="border border-gray-300 px-3 py-2 w-[27%]">
-                    Pro-{topicTitle}: What It Looks Like
-                  </th>
-                  <th className="border border-gray-300 px-3 py-2 w-[27%]">
-                    Anti-{topicTitle}: What It Looks Like
-                  </th>
-                  <th className="border border-gray-300 px-3 py-2 w-[14%]">
-                    Pro Example
-                  </th>
-                  <th className="border border-gray-300 px-3 py-2 w-[14%]">
-                    Anti Example
-                  </th>
-                </>
-              ) : (
-                <>
-                  <th className="border border-gray-300 px-3 py-2 w-[33%]">
-                    What It Looks Like on This Topic
-                  </th>
-                  <th className="border border-gray-300 px-3 py-2 w-[27%]">Example</th>
-                  <th className="border border-gray-300 px-3 py-2 w-[22%]">Which Principles Are Still Honored</th>
-                </>
-              )}
+            <tr className="bg-[#f0f3f6]">
+              <th className="border border-gray-300 px-3 py-2 w-[22%]">Level</th>
+              <th className="border border-gray-300 px-3 py-2 w-[28%]">What It Looks Like</th>
+              <th className="border border-gray-300 px-3 py-2 w-[30%]">Historical Example</th>
+              <th className="border border-gray-300 px-3 py-2 w-[20%]">Principles Still Honored</th>
             </tr>
           </thead>
           <tbody>
             {escalationLevels.map((row, i) => (
-              <tr key={row.level} className={ROW_COLORS[i] ?? ''}>
-                <td className="border border-gray-300 px-3 py-2 text-center font-semibold">
+              <tr key={row.level}>
+                <td className={`border border-gray-300 px-3 py-2 text-center font-semibold ${ROW_COLORS[i] ?? ''}`}>
                   <strong>{row.level}. {row.levelLabel}</strong>
-                  <br />
-                  <span className="text-xs font-normal text-gray-600">{row.description}</span>
+                  {LEVEL_SUBLABELS[row.level] && (
+                    <>
+                      <br />
+                      <span className="text-xs font-normal text-gray-600">{LEVEL_SUBLABELS[row.level]}</span>
+                    </>
+                  )}
                 </td>
-                {hasPerSideData ? (
-                  <>
-                    <td className="border border-gray-300 px-3 py-2 text-gray-700 text-xs">
-                      {row.proDescription || row.description}
-                    </td>
-                    <td className="border border-gray-300 px-3 py-2 text-gray-700 text-xs">
-                      {row.antiDescription || row.description}
-                    </td>
-                    <td className="border border-gray-300 px-3 py-2 text-gray-600 text-xs italic">
-                      {row.proExample || row.example}
-                    </td>
-                    <td className="border border-gray-300 px-3 py-2 text-gray-600 text-xs italic">
-                      {row.antiExample || row.example}
-                    </td>
-                  </>
-                ) : (
-                  <>
-                    <td className="border border-gray-300 px-3 py-2">{row.description}</td>
-                    <td className="border border-gray-300 px-3 py-2 text-gray-700">{row.example}</td>
-                    <td className="border border-gray-300 px-3 py-2 text-gray-600 text-xs">{row.principles}</td>
-                  </>
-                )}
+                <td className="border border-gray-300 px-3 py-2 text-gray-700">{row.description}</td>
+                <td className="border border-gray-300 px-3 py-2 text-gray-700">{row.example}</td>
+                <td className="border border-gray-300 px-3 py-2 text-gray-600 text-xs">{row.principles}</td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-      <p className="text-sm text-gray-600 mt-3">
-        <strong>Key insight:</strong> Engagement is independent of the three matching axes. Someone can hold
-        a moderate claim (50%) about a cause they feel lukewarm toward (+40%) and still go to prison for it
-        (Level 4). For engagement beyond Level 4, see:{' '}
-        <a href="/escalation-spectrum" className="text-blue-600 hover:underline">Escalation Spectrum</a>.
-      </p>
-      <p className="text-right text-xs mt-2 text-gray-500">
-        <a href="/how-it-works" className="text-blue-600 hover:underline">Core Values Framework</a>
-      </p>
+      <div className="bg-[#fff0f0] p-3 border-l-4 border-[#c00] mt-3 text-sm">
+        <strong>Escalation is an overlay, not a matching coordinate.</strong> The system matches and
+        groups beliefs on properties of the claim itself: direction (section 1), magnitude (section 3),
+        and level of abstraction (section 6). Escalation describes the believer. Two people can assert the
+        identical claim, same direction, same magnitude, same rung on the abstraction ladder, and sit four
+        levels apart on this ladder: one holds a moderate claim (section 3 = 50%) he barely leans into
+        (section 1 = +40%) and goes to prison for it (Level 4); another holds an extreme claim (100%) she
+        cares about totally (+100%) and never steps outside the law (Level 2). If escalation entered
+        matching, the system would file one claim on two pages because its holders differ. The ladder
+        earns its place on the page anyway, because a debate&apos;s temperature is a property of the
+        conflict worth tracking: when a topic&apos;s believers start climbing it, the conflict resolution
+        pipeline wants to know.
+      </div>
     </div>
   );
 }

--- a/src/components/debate-topic/Spectrum4AbstractionLadder.tsx
+++ b/src/components/debate-topic/Spectrum4AbstractionLadder.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import type { DebateAbstractionRung } from '@/core/types/debate-topic';
 
 interface Props {
@@ -5,130 +6,54 @@ interface Props {
   topicTitle: string;
 }
 
-/**
- * Continuum 3: the general-to-specific tree. A general (worldview) belief
- * branches into subcategories, and each subcategory holds the specific beliefs
- * beneath it. A belief only merges with another that shares its branch AND its
- * rung. Rows seeded before branching existed carry rungType "rung" and render
- * as the old flat ladder.
- */
-function TreeRows({ rungs }: { rungs: DebateAbstractionRung[] }) {
-  const generals = rungs.filter((r) => r.rungType === 'general');
-  const rest = rungs.filter((r) => r.rungType !== 'general');
-
-  // Subcategory rows use ├─ except the last branch, which uses └─.
-  const lastSubcategoryIndex = rest.reduce(
-    (last, r, i) => (r.rungType === 'subcategory' ? i : last),
-    -1,
-  );
-
-  return (
-    <>
-      {generals.map((rung) => (
-        <tr key={rung.sortOrder} className="hover:bg-gray-50">
-          <td className="border border-gray-300 px-3 py-2 bg-[#eef3f8]">
-            <strong>Most General</strong>
-            <br />
-            <span className="text-xs font-normal text-gray-600">(Worldview)</span>
-          </td>
-          <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">&ldquo;{rung.proChain}&rdquo;</td>
-          <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">&ldquo;{rung.conChain}&rdquo;</td>
-        </tr>
-      ))}
-      {generals.length > 0 && rest.length > 0 && (
-        <tr>
-          <td className="border border-gray-300 px-3 py-1.5 text-center text-xs text-gray-500" colSpan={3}>
-            the general belief branches into subcategories ↓
-          </td>
-        </tr>
-      )}
-      {rest.map((rung, i) => {
-        if (rung.rungType === 'subcategory') {
-          const connector = i === lastSubcategoryIndex ? '└─' : '├─';
-          return (
-            <tr key={rung.sortOrder} className="hover:bg-gray-50">
-              <td className="border border-gray-300 px-3 py-2 bg-[#f4f9ff]">
-                <strong>{connector} {rung.branchName ?? 'Subcategory'}</strong>
-                {rung.rungLabel && (
-                  <>
-                    <br />
-                    <span className="text-xs font-normal text-gray-600">{rung.rungLabel}</span>
-                  </>
-                )}
-              </td>
-              <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">&ldquo;{rung.proChain}&rdquo;</td>
-              <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">&ldquo;{rung.conChain}&rdquo;</td>
-            </tr>
-          );
-        }
-        return (
-          <tr key={rung.sortOrder} className="hover:bg-gray-50">
-            <td className="border border-gray-300 px-3 py-2 pl-8 text-gray-600">
-              └─ <em>Specific</em>
-            </td>
-            <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">&ldquo;{rung.proChain}&rdquo;</td>
-            <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">&ldquo;{rung.conChain}&rdquo;</td>
-          </tr>
-        );
-      })}
-    </>
-  );
-}
-
-function LadderRows({ rungs }: { rungs: DebateAbstractionRung[] }) {
-  return (
-    <>
-      {rungs.map((rung, i) => (
-        <tr key={rung.sortOrder} className="hover:bg-gray-50">
-          <td className="border border-gray-300 px-3 py-2 text-center font-semibold">
-            {i === 0 ? <strong>Most General</strong> : i === rungs.length - 1 ? <strong>Most Specific</strong> : ''}
-            <br />
-            <span className="text-xs font-normal text-gray-600">{rung.rungLabel}</span>
-          </td>
-          <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">&ldquo;{rung.proChain}&rdquo;</td>
-          <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">&ldquo;{rung.conChain}&rdquo;</td>
-        </tr>
-      ))}
-    </>
-  );
+// Section 6: the abstraction ladder. The same upstream worldview generates many
+// downstream policy positions; each rung renders as a row with a ↓ connector to
+// the next. Rows keep whatever rungLabel they were authored with (canonical
+// chain: Worldview → Political principle → Position on this topic → Specific
+// policy); rows from the retired branching-tree era fall back to branchName.
+function rungDisplayLabel(rung: DebateAbstractionRung): string {
+  return rung.rungLabel || rung.branchName || 'Specific policy';
 }
 
 export default function Spectrum4AbstractionLadder({ rungs, topicTitle }: Props) {
-  const hasTree = rungs.some((r) => r.rungType && r.rungType !== 'rung');
-
   return (
     <div id="specificity" className="mb-8">
-      <h2 className="text-xl font-bold mb-1">
-        🌳 Continuum 3: General to Specific, with Branching Subcategories{' '}
-        <a href="/general-to-specific" className="text-base font-normal text-blue-600 hover:underline">
-          (General ↔ Specific)
-        </a>
-      </h2>
+      <h2 className="text-xl font-bold mb-1">6. The Abstraction Ladder (General ↔ Specific)</h2>
       <p className="text-sm text-gray-600 mb-4">
-        The same topic holds claims at every altitude, from a sweeping worldview down to one line-item
-        policy. A general belief <strong>branches</strong> into subcategories, and each subcategory holds
-        the specific beliefs beneath it. A belief only merges with another that shares its branch{' '}
-        <em>and</em> its rung, so a worldview never gets double-counted with the policy it implies. A
-        subcategory that outgrows a row graduates to its own child page (see{' '}
-        <a href="#related" className="text-blue-600 hover:underline">Related Topics</a>).
+        The same upstream worldview can generate dozens of downstream policy positions. Tracing the chain
+        makes explicit what is actually being argued about.
       </p>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300 text-sm">
           <thead>
-            <tr className="bg-gray-100">
-              <th className="border border-gray-300 px-3 py-2 w-[24%]">Rung / Branch</th>
-              <th className="border border-gray-300 px-3 py-2 w-[38%]">Pro-{topicTitle} Belief</th>
-              <th className="border border-gray-300 px-3 py-2 w-[38%]">Anti-{topicTitle} Belief</th>
+            <tr className="bg-[#f0f3f6]">
+              <th className="border border-gray-300 px-3 py-2 w-[15%]">Level</th>
+              <th className="border border-gray-300 px-3 py-2 w-[42%]">Pro-{topicTitle} Chain</th>
+              <th className="border border-gray-300 px-3 py-2 w-[43%]">Anti-{topicTitle} Chain</th>
             </tr>
           </thead>
           <tbody>
-            {hasTree ? <TreeRows rungs={rungs} /> : <LadderRows rungs={rungs} />}
+            {rungs.map((rung, i) => (
+              <Fragment key={rung.sortOrder}>
+                {i > 0 && (
+                  <tr>
+                    <td className="border border-gray-300 px-3 py-1 text-center text-gray-500">↓</td>
+                    <td className="border border-gray-300 px-3 py-1 text-center text-gray-500">↓</td>
+                    <td className="border border-gray-300 px-3 py-1 text-center text-gray-500">↓</td>
+                  </tr>
+                )}
+                <tr className="hover:bg-gray-50">
+                  <td className="border border-gray-300 px-3 py-2 text-center">
+                    <strong>{rungDisplayLabel(rung)}</strong>
+                  </td>
+                  <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">&ldquo;{rung.proChain}&rdquo;</td>
+                  <td className="border border-gray-300 px-3 py-2 text-gray-700 italic">&ldquo;{rung.conChain}&rdquo;</td>
+                </tr>
+              </Fragment>
+            ))}
           </tbody>
         </table>
       </div>
-      <p className="text-right text-xs mt-2 text-gray-500">
-        See: <a href="/general-to-specific" className="text-blue-600 hover:underline">General to Specific Framework</a>
-      </p>
     </div>
   );
 }

--- a/src/components/debate-topic/TopicMetrics.tsx
+++ b/src/components/debate-topic/TopicMetrics.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 interface Props {
   importanceScore: number;   // 0–100
   evidenceDepth: string;     // "Low" | "Med" | "High"
@@ -18,31 +20,26 @@ function depthColor(depth: string): string {
 
 export default function TopicMetrics({ importanceScore, evidenceDepth, controversyRating }: Props) {
   return (
-    <div className="border border-gray-300 p-3 bg-gray-50 mb-6 text-center text-sm">
+    <div className="border border-gray-300 p-3 bg-[#f0f3f6] mb-3 text-center text-sm">
       <strong>Topic Metrics</strong>
-      <br />
-      <a href="/algorithms/importance-score" className="text-blue-600 hover:underline">
+      {' | '}
+      <Link href="/algorithms/importance-score" className="text-blue-600 hover:underline">
         Importance
-      </a>
+      </Link>
       :{' '}
       <strong className={scoreColor(importanceScore)}>{importanceScore}</strong>
       {' | '}
-      <a href="/algorithms/evidence-scores" className="text-blue-600 hover:underline">
+      <Link href="/algorithms/evidence-scores" className="text-blue-600 hover:underline">
         Evidence Depth
-      </a>
+      </Link>
       :{' '}
       <strong className={depthColor(evidenceDepth)}>{evidenceDepth}</strong>
       {' | '}
-      <a href="/w/page/159300543/ReasonRank" className="text-blue-600 hover:underline">
+      <Link href="/algorithms/reason-rank" className="text-blue-600 hover:underline">
         Controversy
-      </a>
+      </Link>
       :{' '}
       <strong className={scoreColor(controversyRating)}>{controversyRating}</strong>
-      <p className="mt-1.5 mb-0 text-[11px] text-gray-500">
-        Every bracketed number on this page is a placeholder until the{' '}
-        <a href="/w/page/159300543/ReasonRank" className="text-blue-600 hover:underline">ReasonRank</a>{' '}
-        engine computes live scores.
-      </p>
     </div>
   );
 }

--- a/src/core/types/debate-topic.ts
+++ b/src/core/types/debate-topic.ts
@@ -11,20 +11,25 @@ export interface DebateTopicExternal {
 export interface DebatePosition {
   id?: number;
   positionScore: number; // -100, -50, 0, 50, 100
-  positionLabel: string; // "Strongly Oppose", "Skeptical", "Neutral/Nuanced", "Supportive", "Strongly Support"
+  positionLabel: string; // "Strongly Oppose", "Skeptical", "Mixed / Conditional", "Supportive", "Strongly Support"
   coreBelief: string;
   topArgument: string;
   beliefScore: string; // e.g. "[+XX]", "[-XX]", "[0]"
   mediaUrl?: string;
+  /// Evidence Ledger row backing the top sub-argument (Evidence column link)
+  evidenceId?: number;
+  /// Authoring-time pointer into the evidenceItems array, resolved to
+  /// evidenceId when rows are persisted (used by seeds and the AI generator)
+  evidenceIndex?: number;
 }
 
-/// One row in Continuum 2 (Claim Magnitude) — topic-specific pro and anti examples.
+/// One row in section 3 (Claim Magnitude) — topic-specific pro and anti examples.
 export interface DebateClaimMagnitude {
   id?: number;
   sortOrder: number;
-  magnitudeLevel: string;  // "Modest (20%)", "Moderate (50%)", "Strong (80%)", "Total (100%)"
+  magnitudeLevel: string;  // "Weak (20%)", "Moderate (50%)", "Strong (80%)", "Extreme (100%)"
   magnitudePercent: number; // 20, 50, 80, 100
-  sublabel: string;         // "Hedged", "Standard", "Broad", "Maximal"
+  sublabel: string;         // "Hedged", "Standard", "Categorical", "Maximal"
   proExample: string;       // topic-specific pro-topic claim at this magnitude
   antiExample: string;      // topic-specific anti-topic claim at this magnitude
   scopeDescription: string; // scope and telltale words at this strength
@@ -34,14 +39,15 @@ export interface DebateEscalation {
   id?: number;
   level: number; // 1–6
   levelLabel: string;
-  description: string;
-  example: string;
-  principles: string;
-  // Per-side fields (Spectrum 3 civic engagement model)
-  proDescription: string;
-  antiDescription: string;
-  proExample: string;
-  antiExample: string;
+  description: string; // what acting at this level looks like
+  example: string;     // historical example
+  principles: string;  // which principles are still honored
+  /// Per-side fields from the retired pro/anti split — kept so older rows
+  /// still round-trip; the current template renders the single-column form.
+  proDescription?: string;
+  antiDescription?: string;
+  proExample?: string;
+  antiExample?: string;
 }
 
 export interface DebateAssumption {
@@ -91,6 +97,16 @@ export interface DebateEvidence {
   qualityScore: number; // 0–100
   qualityLabel: string; // "Peer Reviewed", "Longitudinal", "Cross-national", etc.
   url?: string;
+  /// Evidence tier: "T1" peer-reviewed, "T2" reputable institution,
+  /// "T3" secondary, "T4" anecdotal
+  tier?: string;
+  /// The specific argument this evidence bears on, as a standalone claim.
+  /// Falls back to `finding` at render time.
+  argument?: string;
+  /// How directly the evidence bears on its argument, 0.0–1.0
+  linkage?: number;
+  /// "VERIFIED" (full weight) | "DISPUTED" (half weight) | "FALSIFIED" (zero)
+  standing?: string;
 }
 
 export interface DebateObjectiveCriteria {

--- a/src/features/debate-topics/ai-generator.ts
+++ b/src/features/debate-topics/ai-generator.ts
@@ -80,47 +80,52 @@ Return a single valid JSON object matching this exact structure (all fields requ
       "positionScore": -100,
       "positionLabel": "Strongly Oppose",
       "coreBelief": "The most extreme negative belief about ${topicName}.",
-      "topArgument": "The strongest argument for this extreme position.",
-      "beliefScore": "[-XX]"
+      "topArgument": "Atomic argument label driving the score (a standalone claim).",
+      "beliefScore": "[-XX]",
+      "evidenceIndex": 0
     },
     {
       "positionScore": -50,
       "positionLabel": "Skeptical",
       "coreBelief": "A moderately negative belief.",
-      "topArgument": "Key argument.",
-      "beliefScore": "[-XX]"
+      "topArgument": "Atomic argument label.",
+      "beliefScore": "[-XX]",
+      "evidenceIndex": 1
     },
     {
       "positionScore": 0,
-      "positionLabel": "Neutral/Nuanced",
-      "coreBelief": "A balanced, nuanced position.",
-      "topArgument": "Key nuancing argument.",
-      "beliefScore": "[0]"
+      "positionLabel": "Mixed / Conditional",
+      "coreBelief": "A balanced, conditional position.",
+      "topArgument": "Atomic argument label.",
+      "beliefScore": "[0]",
+      "evidenceIndex": 2
     },
     {
       "positionScore": 50,
       "positionLabel": "Supportive",
       "coreBelief": "A moderately positive belief.",
-      "topArgument": "Key supporting argument.",
-      "beliefScore": "[+XX]"
+      "topArgument": "Atomic argument label.",
+      "beliefScore": "[+XX]",
+      "evidenceIndex": 3
     },
     {
       "positionScore": 100,
       "positionLabel": "Strongly Support",
       "coreBelief": "The most strongly positive belief.",
-      "topArgument": "The strongest pro argument.",
-      "beliefScore": "[+XX]"
+      "topArgument": "Atomic argument label.",
+      "beliefScore": "[+XX]",
+      "evidenceIndex": 0
     }
   ],
   "claimMagnitudeLevels": [
     {
       "sortOrder": 0,
-      "magnitudeLevel": "Modest (20%)",
+      "magnitudeLevel": "Weak (20%)",
       "magnitudePercent": 20,
       "sublabel": "Hedged",
-      "proExample": "A modest pro-${topicName} claim that acknowledges real flaws and leaves room for exceptions.",
-      "antiExample": "A modest anti-${topicName} claim that acknowledges some advantages while noting specific inefficiencies.",
-      "scopeDescription": "Narrow scope. Leaves room for exceptions and context-dependence."
+      "proExample": "A hedged pro-${topicName} claim that acknowledges real flaws and leaves room for exceptions.",
+      "antiExample": "A hedged anti-${topicName} claim that acknowledges some advantages while noting specific inefficiencies.",
+      "scopeDescription": "Narrow. Acknowledges exceptions."
     },
     {
       "sortOrder": 1,
@@ -129,71 +134,69 @@ Return a single valid JSON object matching this exact structure (all fields requ
       "sublabel": "Standard",
       "proExample": "${topicName}, when functioning well, produces significantly better outcomes than the available alternatives.",
       "antiExample": "${topicName} is significantly compromised by [specific flaw], producing reliably suboptimal outcomes.",
-      "scopeDescription": "Clear claim without overstating. The level at which most serious academic arguments operate."
+      "scopeDescription": "Definite but bounded. Most defensible level."
     },
     {
       "sortOrder": 2,
       "magnitudeLevel": "Strong (80%)",
       "magnitudePercent": 80,
-      "sublabel": "Broad",
-      "proExample": "${topicName} is the only approach that provides [key benefit], and any alternative is fundamentally unjust or ineffective.",
-      "antiExample": "${topicName} is fundamentally broken and cannot produce good outcomes without changes so drastic it would cease to be recognizable.",
-      "scopeDescription": "Wide scope, absolute framing. Leaves little room for alternatives or incremental improvement."
+      "sublabel": "Categorical",
+      "proExample": "${topicName} is fundamentally the right approach, and the alternatives reliably fail.",
+      "antiExample": "${topicName} is fundamentally the wrong approach and fails wherever it is tried.",
+      "scopeDescription": "Wide. Little room for exceptions."
     },
     {
       "sortOrder": 3,
-      "magnitudeLevel": "Total (100%)",
+      "magnitudeLevel": "Extreme (100%)",
       "magnitudePercent": 100,
       "sublabel": "Maximal",
-      "proExample": "${topicName} is the pinnacle of human achievement in this domain and any deviation from it, however small, must be resisted by any means necessary.",
+      "proExample": "${topicName} is the only acceptable option, everywhere, always, and any deviation must be resisted.",
       "antiExample": "${topicName} is a total fraud that has never served its intended beneficiaries and never will.",
-      "scopeDescription": "Catastrophic framing with no limiting conditions. The hardest to defend and the easiest to dismiss without engaging the moderate arguments."
+      "scopeDescription": "Catastrophic framing, no limits. Easy to dismiss."
     }
   ],
   "escalationLevels": [
     {
       "level": 1,
       "levelLabel": "Preference",
-      "description": "Passive lean — would support or oppose if convenient but won't prioritize over other concerns.",
-      "example": "A typical casual participant in the ${topicName} debate.",
-      "principles": "All other principles intact.",
-      "proDescription": "Would support ${topicName} if convenient. Would not prioritize it over other concerns.",
-      "antiDescription": "Mildly skeptical of ${topicName}. Would prefer alternatives in certain contexts. Would not act on this preference.",
-      "proExample": "A typical casual supporter of ${topicName} — votes accordingly when it aligns with other priorities.",
-      "antiExample": "A typical casual skeptic — expresses reservations in conversation but takes no active steps."
+      "description": "Would vote for it if convenient. Won't reorder priorities to advance it.",
+      "example": "Most voters on most issues most of the time.",
+      "principles": "All other principles intact."
     },
     {
       "level": 2,
       "levelLabel": "Active Advocacy",
-      "description": "Engaged participant — votes, donates, signs petitions, argues publicly.",
+      "description": "Votes, donates, signs petitions, argues publicly.",
       "example": "Standard civic participation for or against ${topicName}.",
-      "principles": "Works fully within legal and social norms.",
-      "proDescription": "Votes, donates, signs petitions, argues publicly in favor of ${topicName}.",
-      "antiDescription": "Votes, donates, lobbies, and argues publicly against ${topicName} or for alternatives.",
-      "proExample": "Canvasses for candidates who support ${topicName}; writes op-eds; donates to advocacy organizations.",
-      "antiExample": "Lobbies legislators; organizes community opposition; funds legal challenges."
+      "principles": "Operates fully within legal and social norms."
     },
     {
       "level": 3,
       "levelLabel": "Principled Non-Compliance",
-      "description": "Conscientious objector — refuses personal participation even at personal cost. Does not obstruct others.",
-      "example": "Accepts personal cost rather than act against conscience on ${topicName}.",
-      "principles": "Willing to sacrifice self. Will not obstruct others.",
-      "proDescription": "Refuses personal participation in what they consider unjust opposition to ${topicName}, even at personal cost. Does not obstruct others.",
-      "antiDescription": "Refuses to implement or participate in ${topicName} even when required. Does not obstruct others.",
-      "proExample": "Resigns from a position rather than implement policies hostile to ${topicName}; accepts professional consequences.",
-      "antiExample": "An official who resigns rather than implement ${topicName}-related policy they consider unjust."
+      "description": "Refuses personal participation in what they see as unjust, at cost to themselves. Does not obstruct others.",
+      "example": "A Thomas More pattern applied to the ${topicName} debate — resignation or refusal at personal cost.",
+      "principles": "Sacrifices self. Will not act against others."
     },
     {
       "level": 4,
       "levelLabel": "Civil Disobedience",
-      "description": "Principled lawbreaking — openly breaks specific unjust laws. Accepts legal consequences.",
-      "example": "MLK/Gandhi equivalent applied to the ${topicName} debate.",
-      "principles": "Violates specific laws. Accepts the legal system's authority to respond.",
-      "proDescription": "Openly breaks specific unjust laws considered obstacles to ${topicName}. Accepts legal consequences and uses prosecution as moral leverage.",
-      "antiDescription": "Openly defies specific laws or mandates related to ${topicName}. Accepts legal consequences and uses prosecution as moral leverage.",
-      "proExample": "Participates in civil disobedience to advance ${topicName} — sit-ins, blockades — while accepting arrest.",
-      "antiExample": "Conscientious objectors who accepted imprisonment rather than comply with ${topicName}-related mandates."
+      "description": "Openly breaks specific laws judged unjust. Accepts legal consequences. Uses trial as moral leverage.",
+      "example": "An MLK/Gandhi equivalent applied to the ${topicName} debate.",
+      "principles": "Violates specific laws. Accepts the legal system's authority to punish."
+    },
+    {
+      "level": 5,
+      "levelLabel": "Resistance",
+      "description": "Breaks laws and rejects the legitimacy of the resulting punishment. Distinguishes legality from justice.",
+      "example": "A historical resistance parallel relevant to ${topicName}.",
+      "principles": "Rejects specific laws as illegitimate. Avoids harm to uninvolved parties."
+    },
+    {
+      "level": 6,
+      "levelLabel": "Any Means Necessary",
+      "description": "Willing to harm others, violate any norm, or destroy any institution to advance the cause.",
+      "example": "Documented extremism connected to the ${topicName} debate, if any exists; otherwise a generic description.",
+      "principles": "No other principle outranks this belief."
     }
   ],
   "assumptions": [
@@ -224,11 +227,10 @@ Return a single valid JSON object matching this exact structure (all fields requ
     }
   ],
   "abstractionRungs": [
-    {"sortOrder": 0, "rungType": "general", "rungLabel": "Most General (Worldview)", "proChain": "Broad belief about human nature or society that supports this topic", "conChain": "Broad belief about human nature or society that opposes this topic"},
-    {"sortOrder": 1, "rungType": "subcategory", "branchName": "Subcategory A", "rungLabel": "name of sub-issue", "proChain": "Mid-level pro claim inside A", "conChain": "Mid-level anti claim inside A"},
-    {"sortOrder": 2, "rungType": "specific", "branchName": "Subcategory A", "rungLabel": "", "proChain": "Specific pro policy or action under A", "conChain": "Specific anti policy or action under A"},
-    {"sortOrder": 3, "rungType": "subcategory", "branchName": "Subcategory B", "rungLabel": "name of sub-issue", "proChain": "Mid-level pro claim inside B", "conChain": "Mid-level anti claim inside B"},
-    {"sortOrder": 4, "rungType": "specific", "branchName": "Subcategory B", "rungLabel": "", "proChain": "Specific pro claim under B", "conChain": "Specific anti claim under B"}
+    {"sortOrder": 0, "rungLabel": "Worldview", "proChain": "Broad belief about human nature or society that supports this topic", "conChain": "Broad belief about human nature or society that opposes this topic"},
+    {"sortOrder": 1, "rungLabel": "Political principle", "proChain": "Mid-level principle that supports this topic", "conChain": "Mid-level principle that opposes this topic"},
+    {"sortOrder": 2, "rungLabel": "Position on this topic", "proChain": "The pro position on ${topicName}, with its direction range, e.g. (+50% to +100%)", "conChain": "The anti position on ${topicName}, with its direction range, e.g. (-50% to -100%)"},
+    {"sortOrder": 3, "rungLabel": "Specific policy", "proChain": "A concrete pro policy or action", "conChain": "A concrete anti policy or action"}
   ],
   "coreValues": {
     "supportingAdvertised": ["1. Value name — brief description", "2. ...", "3. ..."],
@@ -247,39 +249,49 @@ Return a single valid JSON object matching this exact structure (all fields requ
       "title": "Author, 'Title' (Year)",
       "source": "Journal/Publisher",
       "finding": "Key finding in one sentence.",
-      "qualityScore": 80,
-      "qualityLabel": "Peer Reviewed"
+      "qualityScore": 95,
+      "qualityLabel": "Peer Reviewed",
+      "tier": "T1",
+      "argument": "The standalone argument this evidence supports.",
+      "linkage": 0.9,
+      "standing": "VERIFIED"
     },
     {
       "side": "supporting",
-      "title": "Author, 'Title' (Year)",
-      "source": "Source",
+      "title": "Institution report (Year)",
+      "source": "Institution",
       "finding": "Key finding.",
       "qualityScore": 85,
-      "qualityLabel": "Longitudinal"
+      "qualityLabel": "Institutional",
+      "tier": "T2",
+      "argument": "The standalone argument this evidence supports.",
+      "linkage": 0.7,
+      "standing": "VERIFIED"
     },
     {
       "side": "weakening",
       "title": "Author, 'Title' (Year)",
       "source": "Journal",
       "finding": "Key finding.",
-      "qualityScore": 85,
-      "qualityLabel": "Peer Reviewed"
+      "qualityScore": 80,
+      "qualityLabel": "Peer Reviewed",
+      "tier": "T1",
+      "argument": "The standalone argument this evidence weakens.",
+      "linkage": 0.85,
+      "standing": "VERIFIED"
     },
     {
       "side": "weakening",
-      "title": "Author, 'Title' (Year)",
+      "title": "Secondary source (Year)",
       "source": "Source",
       "finding": "Key finding.",
-      "qualityScore": 75,
-      "qualityLabel": "Cross-national"
+      "qualityScore": 45,
+      "qualityLabel": "Secondary",
+      "tier": "T3",
+      "argument": "The standalone argument this evidence weakens.",
+      "linkage": 0.55,
+      "standing": "DISPUTED"
     }
-  ],
-  "objectiveCriteria": [
-    {"name": "Best criterion", "description": "Why it's the best measure.", "criteriaScore": 90, "validity": "High", "reliability": "High", "linkage": "High", "importance": "High"},
-    {"name": "Second criterion", "description": "...", "criteriaScore": 85, "validity": "High", "reliability": "High", "linkage": "High", "importance": "High"},
-    {"name": "Third criterion", "description": "...", "criteriaScore": 75, "validity": "High", "reliability": "High", "linkage": "Med", "importance": "High"},
-    {"name": "Weaker criterion", "description": "Why it's less reliable.", "criteriaScore": 45, "validity": "Low", "reliability": "High", "linkage": "Low", "importance": "Low"}
   ],
   "mediaResources": [
     {"title": "Book/Article Title — Author", "medium": "Book", "biasOrTone": "Academic/Advocacy", "positivity": 70, "magnitude": 60, "escalation": 2, "keyInsight": "..."},
@@ -291,11 +303,11 @@ Return a single valid JSON object matching this exact structure (all fields requ
     {"relationType": "child", "relatedTitle": "Sub-issue 1", "relatedSlug": "sub-issue-1"},
     {"relationType": "child", "relatedTitle": "Sub-issue 2", "relatedSlug": "sub-issue-2"},
     {"relationType": "sibling", "relatedTitle": "Related concept", "relatedSlug": "related-concept"},
-    {"relationType": "opposingView", "relatedTitle": "Critical perspective on ${topicName}", "relatedSlug": "critical-perspective"}
+    {"relationType": "sibling", "relatedTitle": "Another adjacent topic", "relatedSlug": "adjacent-topic"}
   ]
 }
 
-Fill in all "..." placeholders with substantive, accurate content for "${topicName}". Use real research, real book/study titles where possible. Return ONLY the JSON object, no other text.`;
+Fill in all "..." placeholders with substantive, accurate content for "${topicName}". Use real research, real book/study titles where possible. Each position's "evidenceIndex" is a 0-based index into "evidenceItems" pointing at the ledger row that best backs that position's top sub-argument; omit it where no row fits. Evidence "tier" is T1 peer-reviewed, T2 reputable institution, T3 secondary, T4 anecdotal; "linkage" (0.0-1.0) is how directly the evidence bears on its argument; "standing" is VERIFIED, DISPUTED, or FALSIFIED. Keep every beliefScore bracketed ("[+XX]", "[-XX]", "[0]") — scores are computed by the engine, never hand-entered. Return ONLY the JSON object, no other text.`;
 
   const raw = await callAI(prompt, 7000);
   const parsed = safeParseJson<Partial<DebateTopic>>(raw, {});

--- a/src/features/debate-topics/db.ts
+++ b/src/features/debate-topics/db.ts
@@ -48,6 +48,7 @@ function mapTopicFromDb(row: any): DebateTopic {
     topArgument: p.topArgument,
     beliefScore: p.beliefScore,
     mediaUrl: p.mediaUrl ?? undefined,
+    evidenceId: p.evidenceId ?? undefined,
   }));
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -126,6 +127,10 @@ function mapTopicFromDb(row: any): DebateTopic {
     qualityScore: e.qualityScore,
     qualityLabel: e.qualityLabel,
     url: e.url ?? undefined,
+    tier: e.tier ?? undefined,
+    argument: e.argument || undefined,
+    linkage: e.linkage ?? undefined,
+    standing: e.standing ?? undefined,
   }));
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -199,7 +204,8 @@ const FULL_INCLUDE = {
   abstractionRungs: true,
   coreValues: true,
   commonGround: true,
-  evidenceItems: true,
+  // id order keeps evidenceIndex → row mapping stable after nested creates
+  evidenceItems: { orderBy: { id: 'asc' } },
   objectiveCriteria: true,
   mediaResources: true,
   relatedTopics: true,
@@ -331,6 +337,10 @@ export async function createDebateTopic(data: DebateTopic): Promise<DebateTopic>
           qualityScore: e.qualityScore,
           qualityLabel: e.qualityLabel,
           url: e.url ?? null,
+          tier: e.tier ?? 'T2',
+          argument: e.argument ?? '',
+          linkage: e.linkage ?? null,
+          standing: e.standing ?? 'VERIFIED',
         })),
       },
       objectiveCriteria: {
@@ -368,10 +378,31 @@ export async function createDebateTopic(data: DebateTopic): Promise<DebateTopic>
     },
   });
 
-  const full = await db.debateTopic.findUnique({
+  let full = await db.debateTopic.findUnique({
     where: { slug: created.slug },
     include: FULL_INCLUDE,
   });
+
+  // Resolve authoring-time evidenceIndex pointers now that ledger rows have ids.
+  const links = data.positions.flatMap((p) => {
+    if (p.evidenceIndex === undefined) return [];
+    const target = full.evidenceItems[p.evidenceIndex];
+    return target ? [{ positionScore: p.positionScore, evidenceId: target.id }] : [];
+  });
+  if (links.length > 0) {
+    await Promise.all(
+      links.map((link) =>
+        db.debatePosition.updateMany({
+          where: { topicId: full.id, positionScore: link.positionScore },
+          data: { evidenceId: link.evidenceId },
+        })
+      )
+    );
+    full = await db.debateTopic.findUnique({
+      where: { slug: created.slug },
+      include: FULL_INCLUDE,
+    });
+  }
 
   return mapTopicFromDb(full);
 }

--- a/templates/topic-template.html
+++ b/templates/topic-template.html
@@ -1,212 +1,325 @@
 <!-- page=Template -->
 <!-- content-type=text/html -->
 <!--
-  ===== ISE TOPIC PAGE MASTER TEMPLATE (July 2026 revision) =====
-  The wiki template for topic pages ("One Page Per Topic"). Mirrored by the
-  React implementation in src/app/debate-topics/[slug]/page.tsx and the section
-  components in src/components/debate-topic/*. If you change this template,
-  update the React implementation. The two must stay in sync.
+  ===== ISE TOPIC PAGE MASTER TEMPLATE (July 2026 "Page Design" revision) =====
+  The wiki template for topic pages. Mirrored by the React implementation in
+  src/app/debate-topics/[slug]/page.tsx and the section components in
+  src/components/debate-topic/*. If you change this template, update the React
+  implementation. The two must stay in sync.
 
-  CORE IDEA — the three-part address:
-  Every belief about the topic gets one fixed address: a Direction (-100% to
-  +100%), a Magnitude band (Modest / Moderate / Strong / Total), and a node on
-  the general-to-specific tree (which branch, which rung). Two beliefs at the
-  same address are duplicates and merge; nearly the same address gets the
-  redundancy discount. The Engagement Landscape and the Assumption Stack are
-  deliberately NOT matching coordinates — they describe people and
-  dependencies, not the belief's address.
+  CORE IDEA — one canonical home per topic:
+  Every argument anyone has made about the topic lives here, scored by evidence
+  quality, linked to the claims it supports or undermines, and updated
+  automatically when new data arrives. Beliefs are matched and grouped on three
+  properties of the claim itself: Direction (section 1), Magnitude (section 3),
+  and level of abstraction (section 6). Civic Escalation (section 4) describes
+  believers, not beliefs — it is an overlay for the conflict-resolution
+  pipeline, never a matching coordinate.
+
+  AUDIT LOCK: every numeric score on the page is computed from linked argument
+  and evidence nodes. Nothing is hand-entered. Scores stay [bracketed] until
+  the engine computes them; a wrong-looking score is fixed at the underlying
+  node, not the display.
 
   SECTION ORDER:
-    Header (breadcrumb / Topic name / Definition + Scope / Topic Metrics box)
-    "What this page does" box (the three-part address, with anchors)
-    1. Continuum 1: Direction (Oppose <-> Support) — Position / Core Belief /
-       Top Underlying Argument / Belief Score
-    2. Continuum 2: Claim Magnitude (Modest <-> Total) — band / pro belief /
-       anti belief / scope & telltale words + key insight (engage the best
-       version, not the loudest)
-    3. Continuum 3: General to Specific, with Branching Subcategories —
-       worldview row branches into subcategories, each holding specific rows;
-       a subcategory that outgrows its row graduates to a child page
-    4. Assumption Stack Behind Each Position (not a fourth axis; Core split)
-    5. Core Values Conflict (advertised vs. attributed, both sides)
-    6. The Engagement Landscape (Passive <-> Active) — a stakeholder map, not
-       a matching axis
-    7. Common Ground and Compromise (Shared Interests / Real Value Conflicts /
-       Compromise Candidates)
-    8. The Evidence Ledger (cross-topic highlight reel, quality-ranked)
-    9. Best Objective Criteria (Criteria Score / Validity / Reliability /
-       Linkage / Importance)
-    10. Best Media and Resources (sorted by positivity)
-    11. Related Topics (Parents / Children / Siblings / Opposing)
-    12. Contribute
+    Header (breadcrumb / Topic name / Definition + Scope / Topic Metrics /
+      Audit lock notice)
+    What This Page Is For
+    1.  The Position Spectrum (Negative <-> Positive) — Position / Belief /
+        Top Sub-Argument / Belief Score / Evidence link
+    2.  The Evidence Ledger — Tier / Source / supports-weakens / Argument It
+        Bears On / Quality / Linkage / Standing (VERIFIED, DISPUTED, FALSIFIED)
+    3.  Claim Magnitude (Weak <-> Strong) — Weak / Moderate / Strong / Extreme
+        + "engage the best version, not the loudest"
+    4.  The Engagement Landscape: Civic Escalation (Preference <-> Any Means) —
+        six levels, believers not beliefs, never enters matching
+    5.  Foundational Assumptions at Each Position — five bands, Key Insight
+    6.  The Abstraction Ladder (General <-> Specific) — Worldview -> Political
+        principle -> Position on this topic -> Specific policy
+    7.  Core Values Conflict (advertised vs. actual per critics, both sides)
+    8.  Common Ground and Compromise (agreements / compromise positions)
+    9.  Best Media and Resources (Direction / Magnitude / Escalation applied
+        to what the source argues)
+    10. Related Topics (Parents / Children / Siblings)
+    Contribute + related design pages
 -->
-<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold; text-align: right;"><a style="font-size: 13px;" href="/w/page/21957696/Colorado%20Should">Home</a><span style="font-size: 13px;"> &rsaquo; </span><a style="font-size: 13px;" href="/w/page/159323433/One%20Page%20Per%20Topic">Topics</a><span style="font-size: 13px;"> &rsaquo; </span><strong style="font-family: inherit; font-style: inherit;">[Category] &gt; [Topic Name]</strong></h2>
-<div style="font-family: 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #333;">
-<p style="display: none;">AUTHORING RULES (hidden; readers never see this). Place every belief about this topic at one address: a Direction (-100% to +100%), a Magnitude band, and a node on the general-to-specific tree (which branch, which rung). Two beliefs at the same address are duplicates: merge them. Nearly the same address gets the redundancy discount. Every argument cell must be a complete proposition whose pro/con direction is evident from the cell alone, with no insider knowledge needed (standalone-claim rule); name cells by their opening words. All scores stay [bracketed] until the ReasonRank engine computes them; never fill a score cell for an empty row. The three continuums describe the belief, never the believer: how far a person will fight (engagement) is a separate section and never a matching coordinate. Keep on-page prose to one caption line per section and link the canonical page for the full logic; do not restate a definition that already has a home.</p>
+<p style="text-align: right;"><em><a href="/w/page/21957696/Colorado%20Should">Home</a> &gt; <a href="/w/page/159323361/Page%20Design">Page Design</a> &gt; <strong>Topic Template</strong></em></p>
 <h1>Topic: [Topic Name]</h1>
-<p style="font-size: 13px;"><strong>Definition:</strong> [Neutral, objective definition of the topic].<br /><strong>Scope:</strong> [What is included here vs. what belongs in related topics].</p>
-<div style="border: 1px solid #ccc; padding: 10px; background-color: #f9f9f9;">
-<p style="text-align: center; margin: 0;"><strong>Topic Metrics</strong><br /><a href="/w/page/162731388/Importance%20Score">Importance</a>: <strong>[0-100]</strong> | <a href="/w/page/159353568/Evidence%20Scores">Evidence Depth</a>: <strong>[Low/Med/High]</strong> | <a href="/w/page/159300543/ReasonRank">Controversy</a>: <strong>[0-100]</strong></p>
-<p style="text-align: center; margin: 6px 0 0 0; font-size: 11px; color: #777;">Every bracketed number on this page is a placeholder until the <a href="/w/page/159300543/ReasonRank">ReasonRank</a> engine computes live scores.</p>
+<p style="font-size: 13px;"><strong>Definition:</strong> [One neutral sentence. No advocacy. Example: "A carbon tax is a fee imposed on the burning of carbon-based fuels."]<br /><strong>Scope:</strong> [What lives here vs. neighboring topics. Example: "Covers economy-wide carbon pricing. Sector-specific schemes (EV mandates, methane fees) live on their own pages."]</p>
+<div style="border: 1px solid #ccc; padding: 10px; background-color: #f0f3f6;">
+<p style="text-align: center; margin: 0;"><strong>Topic Metrics</strong> &nbsp;|&nbsp; <a href="/w/page/162731388/Importance%20Score">Importance</a>: <strong>[0&ndash;100]</strong> &nbsp;|&nbsp; <a href="/w/page/159353568/Evidence%20Scores">Evidence Depth</a>: <strong>[Low / Med / High]</strong> &nbsp;|&nbsp; <a href="/w/page/159300543/ReasonRank">Controversy</a>: <strong>[0&ndash;100]</strong></p>
 </div>
-<div style="border-left: 5px solid #0055a4; padding: 10px 14px; background-color: #f4f9ff; margin: 15px 0; font-size: 13px;"><strong>What this page does.</strong> It gives every belief about this topic one fixed address, so the thousand ways of saying the same thing collapse into a single entry and the real reasons to agree or disagree can be counted and weighed by evidence instead of by how often they get repeated. The address has three parts, one per table below: <a href="#direction">Direction</a> (which way it runs), <a href="#magnitude">Magnitude</a> (how absolute), and <a href="#specificity">Specificity</a> (where it sits on the general-to-specific tree). Same address means the same claim, so it merges; nearly the same address gets the <a href="/w/page/159300543/ReasonRank">redundancy discount</a>. Full logic lives on <a href="/w/page/159323433/One%20Page%20Per%20Topic">One Page Per Topic</a>.</div>
-<h2 id="direction" style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📊 Continuum 1: Direction (<a href="/positive%20to%20negative">Oppose &harr; Support</a>)</h2>
-<p style="font-size: 13px;">Which way the belief runs, from total opposition (-100%) to total support (+100%). The <strong>Belief Score</strong> column is a separate thing: how well the belief holds up once its arguments are scored, not which way it points. A claim can sit at +100% and still score badly. <span style="color: #666;">See: <a href="/w/page/162417909/beliefs%20grouped">Full Positivity Framework</a> | <a href="/positive%20to%20negative">Why We Need This Continuum</a>.</span></p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<div style="background-color: #fffbe6; padding: 8px 12px; border-left: 3px solid #b58900; margin: 12px 0; font-size: 12px;"><strong>Audit lock.</strong> Every numeric score on this page is computed from linked argument and evidence nodes. Nothing here is hand-entered. If a score looks wrong, fix the underlying node, not the display. See <a href="/w/page/21960078/truth">Truth</a> and <a href="/w/page/159300543/ReasonRank">ReasonRank</a>.</div>
+<h2>&nbsp;</h2>
+<h2>What This Page Is For</h2>
+<p>One canonical home for everything anyone has argued about this topic. Arguments are scored by evidence quality, linked to the claims they support or undermine, and updated automatically when new data arrives. The rebuttal to any bad argument on this page is always one click away. See <a href="/w/page/159323925/One%20Page%20Per%20Belief">One Page Per Belief</a> for the single-claim version of this design.</p>
+<hr />
+<h1>1. The Position Spectrum (Negative &harr; Positive)</h1>
+<p style="font-size: 13px;">Where do beliefs about this topic sit on the direction of support? This dimension captures direction <em>only</em>. How extreme the phrasing is, and how far someone is willing to go to act on the belief, are tracked in sections 3 and 4. See <a href="/w/page/163411251/positive%20to%20negative">Positivity Spectrum</a>.</p>
+<table style="border-collapse: collapse;" border="1" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #f0f3f6;">
-<th width="12%">Position</th> <th width="55%">Core Belief / Claim</th> <th width="25%">Top Underlying Argument</th> <th width="8%">Belief Score</th>
+<th width="10%">Position</th> <th width="38%">Belief Held at This Position</th> <th width="28%">Top Sub-Argument Driving the Score</th> <th width="12%"><a href="/w/page/21956921/Beliefs">Belief Score</a></th> <th width="12%">Evidence</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="background-color: #ffcccc; text-align: center;"><strong>-100%</strong><br />(Strongly Oppose)</td>
-<td>[Belief that the topic is fundamentally harmful or false]</td>
-<td>[Primary reason, e.g., "Violates human rights"]</td>
-<td align="center"><span style="color: #d32f2f; font-weight: bold;">[-XX]</span></td>
+<td style="background-color: #ffcccc;" align="center"><strong>&minus;100%</strong><br />Strongly Oppose</td>
+<td>[Belief at this position. Example: "A carbon tax is regressive and crushes working families."]</td>
+<td>[Atomic argument label. Example: "disproportionate burden on low-income households"]</td>
+<td align="center"><span style="color: #c00;">[&minus;XX]</span></td>
+<td align="center">[link to Evidence Ledger row]</td>
 </tr>
 <tr>
-<td style="background-color: #ffe6e6; text-align: center;"><strong>-50%</strong><br />(Skeptical)</td>
-<td>[Belief that the topic has significant flaws or costs]</td>
-<td>[Primary reason, e.g., "Too expensive"]</td>
-<td align="center"><span style="color: #d32f2f; font-weight: bold;">[-XX]</span></td>
+<td style="background-color: #ffe6e6;" align="center"><strong>&minus;50%</strong><br />Skeptical</td>
+<td>[Belief at this position. Example: "A carbon tax might work in theory but won't survive political capture."]</td>
+<td>[Atomic argument label. Example: "exemption-riddled in practice"]</td>
+<td align="center"><span style="color: #c00;">[&minus;XX]</span></td>
+<td align="center">[link]</td>
 </tr>
 <tr>
-<td style="background-color: #ffffcc; text-align: center;"><strong>0%</strong><br />(Neutral/Nuanced)</td>
-<td>[Belief that the topic is complex or context-dependent]</td>
-<td>[Primary reason, e.g., "Depends on implementation"]</td>
-<td align="center"><strong>[0]</strong></td>
+<td style="background-color: #ffffcc;" align="center"><strong>0%</strong><br />Mixed / Conditional</td>
+<td>[Belief at this position. Example: "A carbon tax works only if revenue is rebated and borders are adjusted."]</td>
+<td>[Atomic argument label. Example: "depends on revenue recycling design"]</td>
+<td align="center">[0]</td>
+<td align="center">[link]</td>
 </tr>
 <tr>
-<td style="background-color: #e6ffe6; text-align: center;"><strong>+50%</strong><br />(Supportive)</td>
-<td>[Belief that the topic is generally beneficial]</td>
-<td>[Primary reason, e.g., "Solves specific problem"]</td>
-<td align="center"><span style="color: #2e7d32; font-weight: bold;">[+XX]</span></td>
+<td style="background-color: #e6ffe6;" align="center"><strong>+50%</strong><br />Supportive</td>
+<td>[Belief at this position. Example: "A carbon tax is the cheapest way to cut emissions at scale."]</td>
+<td>[Atomic argument label. Example: "lower abatement cost than mandates"]</td>
+<td align="center"><span style="color: #060;">[+XX]</span></td>
+<td align="center">[link]</td>
 </tr>
 <tr>
-<td style="background-color: #ccffcc; text-align: center;"><strong>+100%</strong><br />(Strongly Support)</td>
-<td>[Belief that the topic is essential or a moral imperative]</td>
-<td>[Primary reason, e.g., "Saves lives"]</td>
-<td align="center"><span style="color: #2e7d32; font-weight: bold;">[+XX]</span></td>
+<td style="background-color: #ccffcc;" align="center"><strong>+100%</strong><br />Strongly Support</td>
+<td>[Belief at this position. Example: "A carbon tax is a moral necessity given the cost of inaction."]</td>
+<td>[Atomic argument label. Example: "intergenerational duty to limit warming"]</td>
+<td align="center"><span style="color: #060;">[+XX]</span></td>
+<td align="center">[link]</td>
 </tr>
 </tbody>
 </table>
-<h2 id="magnitude" style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">💪 Continuum 2: Claim Magnitude, How Absolute the Claim Is (<a href="/strong%20to%20weak">Modest &harr; Total</a>)</h2>
-<p style="font-size: 13px;">How absolute the claim is, from a hedged "sometimes" to a flat "always," independent of which way it runs and of whether it is true. Two beliefs match on this axis when they are equally bold. <span style="color: #666;">See: <a href="/strong%20to%20weak">Why We Need This Continuum</a>.</span></p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<p style="font-size: 12px; color: #555;"><strong>Reading the table.</strong> The Position column is a coordinate, not a verdict. The Belief Score is the verdict, computed from linked sub-arguments. A position can be widely held (lots of people sit at +50%) and still have a low Belief Score, because what people believe and what survives evidence are different questions.</p>
+<hr />
+<h1>2. The Evidence Ledger</h1>
+<p style="font-size: 13px;">The raw inputs every Belief Score on this page traces back to. Quality scores reflect methodology, sample size, and reproducibility. Ten independent sources confirming one finding raise that finding's <a href="/w/page/21960078/truth">Truth Score</a>; they do not create ten arguments. Corroboration is rewarded. Repetition is not. See <a href="/w/page/163478577/Duplication%20Scores">Duplication Scores</a>.</p>
+<table style="border-collapse: collapse;" border="1" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #f0f3f6;">
-<th width="16%">Claim Magnitude</th> <th width="32%">Pro Belief at This Strength</th> <th width="32%">Anti Belief at This Strength</th> <th width="20%">Scope &amp; Telltale Words</th>
+<th width="6%">T</th> <th width="20%">Source</th> <th width="5%">&uarr;&darr;</th> <th width="37%">Argument It Bears On</th> <th width="10%">Quality</th> <th width="10%"><a href="/w/page/159338766/Linkage%20Scores">Linkage</a></th> <th width="12%">Standing</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td align="center"><strong>Modest (20%)</strong><br />Hedged</td>
-<td>[Somewhat good, openly admits real flaws and exceptions]</td>
-<td>[Somewhat bad, concedes it works acceptably much of the time]</td>
-<td>Narrow. <em>"Some," "tends to," "in certain cases."</em></td>
+<td align="center">T1</td>
+<td>[Source. Example: "Metcalf &amp; Stock (2020), <em>AER</em>"]</td>
+<td align="center"><span style="color: #060;">+</span></td>
+<td>[Argument supported. Example: "carbon taxes reduce emissions in countries that implement them"]</td>
+<td align="center"><strong>95%</strong></td>
+<td align="center">+0.90</td>
+<td align="center">VERIFIED</td>
+</tr>
+<tr>
+<td align="center">T2</td>
+<td>[Source. Example: "World Bank Carbon Pricing Dashboard (2024)"]</td>
+<td align="center"><span style="color: #060;">+</span></td>
+<td>[Argument supported. Example: "carbon pricing is now in force across 25% of global emissions"]</td>
+<td align="center"><strong>85%</strong></td>
+<td align="center">+0.70</td>
+<td align="center">VERIFIED</td>
+</tr>
+<tr>
+<td align="center">T2</td>
+<td>[Source. Example: "CBO distributional analysis (2023)"]</td>
+<td align="center"><span style="color: #c00;">&minus;</span></td>
+<td>[Argument weakened. Example: "carbon tax is regressive without rebate"]</td>
+<td align="center"><strong>80%</strong></td>
+<td align="center">+0.85</td>
+<td align="center">VERIFIED</td>
+</tr>
+<tr>
+<td align="center">T3</td>
+<td>[Source. Example: "Industry trade group white paper"]</td>
+<td align="center"><span style="color: #c00;">&minus;</span></td>
+<td>[Argument weakened. Example: "carbon tax causes leakage to non-pricing jurisdictions"]</td>
+<td align="center"><strong>45%</strong></td>
+<td align="center">+0.55</td>
+<td align="center"><span style="color: #b58900;">DISPUTED</span></td>
+</tr>
+</tbody>
+</table>
+<p style="font-size: 12px; color: #555;"><strong>Legend.</strong> <strong>T</strong> = evidence tier (T1 peer-reviewed, T2 reputable institution, T3 secondary, T4 anecdotal). <strong>&uarr;&darr;</strong> = supports (+) or weakens (&minus;) the linked argument. <strong>Quality</strong> = methodological strength of the evidence itself. <strong>Linkage</strong> = how directly this evidence bears on the specific argument it's attached to (see <a href="/w/page/159338766/Linkage%20Scores">Linkage Scores</a>). <strong>Standing</strong> = where the evidence sits in the verification lifecycle: VERIFIED counts at full weight, DISPUTED at half weight while the challenge is open, FALSIFIED at zero, with the retraction propagating to every score built on it. See <a href="/w/page/159353568/Evidence%20Scores">Evidence Scores</a>.</p>
+<hr />
+<h1>3. Claim Magnitude (Weak &harr; Strong)</h1>
+<p style="font-size: 13px;">How extreme is the phrasing of a claim, independent of which direction it runs and independent of whether it's true? A weak pro claim and a weak anti claim are both modest assertions. The Belief Score, computed elsewhere, tells you how well-supported a claim is. This dimension just identifies its structural reach so equivalent claims can be matched and grouped. See <a href="/w/page/163411296/strong%20to%20weak">Magnitude Spectrum</a>.</p>
+<table style="border-collapse: collapse;" border="1" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="18%">Magnitude</th> <th width="33%">Pro-Topic Example</th> <th width="33%">Anti-Topic Example</th> <th width="16%">Scope</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center"><strong>Weak (20%)</strong><br />Hedged</td>
+<td>"A carbon tax can be a useful tool in some cases."</td>
+<td>"A carbon tax may not be the best tool here."</td>
+<td>Narrow. Acknowledges exceptions.</td>
 </tr>
 <tr>
 <td align="center"><strong>Moderate (50%)</strong><br />Standard</td>
-<td>[Clearly better than the alternatives in most cases]</td>
-<td>[Clearly worse than the alternatives in most cases]</td>
-<td>Definite but bounded. <em>"Clearly," "generally."</em> Where most serious arguments live.</td>
+<td>"A carbon tax is the most cost-effective way to cut emissions."</td>
+<td>"A carbon tax fails to deliver the cuts its supporters claim."</td>
+<td>Definite but bounded. Most defensible level.</td>
 </tr>
 <tr>
-<td align="center"><strong>Strong (80%)</strong><br />Broad</td>
-<td>[Right across the board; the alternatives reliably fail]</td>
-<td>[Wrong across the board; fails wherever it is tried]</td>
-<td>Near-universal. <em>"Across the board," "fundamentally."</em></td>
+<td align="center"><strong>Strong (80%)</strong><br />Categorical</td>
+<td>"A carbon tax is fundamentally the right approach to climate policy."</td>
+<td>"A carbon tax is fundamentally the wrong approach to climate policy."</td>
+<td>Wide. Little room for exceptions.</td>
 </tr>
 <tr>
-<td align="center"><strong>Total (100%)</strong><br />Maximal</td>
-<td>[Always right, everywhere, no legitimate exception]</td>
-<td>[Always wrong, has never once worked and never will]</td>
-<td>Total, zero limits. <em>"Always," "never."</em> One counterexample sinks it.</td>
+<td align="center"><strong>Extreme (100%)</strong><br />Maximal</td>
+<td>"A carbon tax is the only way to save the planet."</td>
+<td>"A carbon tax is a totalitarian power grab dressed up as climate policy."</td>
+<td>Catastrophic framing, no limits. Easy to dismiss.</td>
 </tr>
 </tbody>
 </table>
-<p style="font-size: 13px; background-color: #f4f9ff; padding: 10px; border-left: 4px solid #0055a4;"><strong>Key insight:</strong> The strongest arguments on either side usually live at Moderate (50%), not Total (100%). Attacking only the Total versions is a straw man. Engage the best version of the opposing argument, not the loudest.</p>
-<h2 id="specificity" style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🌳 Continuum 3: General to Specific, with Branching Subcategories (<a href="/w/page/21957696/General%20to%20Specific">General &harr; Specific</a>)</h2>
-<p style="font-size: 13px;">The same topic holds claims at every altitude, from a sweeping worldview down to one line-item policy. A general belief <strong>branches</strong> into subcategories, and each subcategory holds the specific beliefs beneath it. A belief only merges with another that shares its branch <em>and</em> its rung, so a worldview never gets double-counted with the policy it implies. A subcategory that outgrows a row graduates to its own child page (see <a href="#related">Related Topics</a>). <span style="color: #666;">See: <a href="/w/page/21957696/General%20to%20Specific">General to Specific Framework</a>.</span></p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<div style="background-color: #eef5ff; padding: 10px; border-left: 4px solid #36c; margin: 10px 0; font-size: 13px;"><strong>Why this matters.</strong> The strongest real arguments on either side typically operate at Moderate magnitude. Engaging only with the Extreme version of an opposing claim is a straw man. The platform requires engaging the best version of the opposing argument, not the loudest.</div>
+<hr />
+<h1>4. The Engagement Landscape: Civic Escalation (Preference &harr; Any Means)</h1>
+<p style="font-size: 13px;">How many other principles is someone willing to violate to advance this belief? This is the other meaning of "strength of conviction": not <em>how extreme is the claim</em> (section 3), but <em>what limits does the believer accept on acting</em>. Thomas More held the most absolute possible conviction Henry VIII was wrong and chose silent execution rather than act outside legal process. Martin Luther King held an equally total conviction and chose to openly violate unjust laws while accepting the consequences. Both are coherent positions. Unlike sections 1, 3, and 6, this ladder describes believers rather than beliefs, so it never enters belief matching; see the note below the table.</p>
+<table style="border-collapse: collapse;" border="1" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #f0f3f6;">
-<th width="24%">Rung / Branch</th> <th width="38%">Pro-Topic Belief</th> <th width="38%">Anti-Topic Belief</th>
+<th width="22%">Level</th> <th width="28%">What It Looks Like</th> <th width="30%">Historical Example</th> <th width="20%">Principles Still Honored</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="background-color: #eef3f8;"><strong>Most General</strong><br />(Worldview)</td>
-<td>"[Broad belief about human nature or society that supports this topic]"</td>
-<td>"[Broad belief about human nature or society that opposes this topic]"</td>
+<td style="background-color: #e8f5e9;" align="center"><strong>1. Preference</strong><br />Slight lean</td>
+<td>Would vote for it if convenient. Won't reorder priorities to advance it.</td>
+<td>Most voters on most issues most of the time.</td>
+<td>All other principles intact.</td>
 </tr>
 <tr>
-<td style="font-size: 12px; color: #666;" colspan="3" align="center">the general belief branches into subcategories &darr;</td>
+<td style="background-color: #c8e6c9;" align="center"><strong>2. Active Advocacy</strong><br />Engaged supporter</td>
+<td>Votes, donates, signs petitions, argues publicly.</td>
+<td>Standard civic participation.</td>
+<td>Operates fully within legal and social norms.</td>
 </tr>
 <tr>
-<td style="background-color: #f4f9ff;"><strong>&#9500;&#9472; Subcategory A</strong><br />[name of sub-issue]</td>
-<td>"[Mid-level pro claim inside A]"</td>
-<td>"[Mid-level anti claim inside A]"</td>
+<td style="background-color: #fff9c4;" align="center"><strong>3. Principled Non-Compliance</strong><br />Conscientious objector</td>
+<td>Refuses personal participation in what they see as unjust, at cost to themselves. Does not obstruct others.</td>
+<td>Thomas More refused to endorse Henry VIII's break with Rome and accepted execution rather than act outside legal process.</td>
+<td>Sacrifices self. Will not act against others.</td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&nbsp;&#9492;&#9472; <em>Specific</em></td>
-<td>"[Specific pro policy or action under A]"</td>
-<td>"[Specific anti policy or action under A]"</td>
+<td style="background-color: #ffe082;" align="center"><strong>4. Civil Disobedience</strong><br />Principled lawbreaking</td>
+<td>Openly breaks specific laws judged unjust. Accepts legal consequences. Uses trial as moral leverage.</td>
+<td>Martin Luther King and the Civil Rights Movement; Gandhi's Salt March; Thoreau's tax refusal.</td>
+<td>Violates specific laws. Accepts the legal system's authority to punish.</td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&nbsp;&#9492;&#9472; <em>Specific</em></td>
-<td>"[Another specific pro claim under A]"</td>
-<td>"[Another specific anti claim under A]"</td>
+<td style="background-color: #ffb74d;" align="center"><strong>5. Resistance</strong><br />Active disruption</td>
+<td>Breaks laws and rejects the legitimacy of the resulting punishment. Distinguishes legality from justice.</td>
+<td>Underground Railroad operators; resistance movements in occupied Europe.</td>
+<td>Rejects specific laws as illegitimate. Avoids harm to uninvolved parties.</td>
 </tr>
 <tr>
-<td style="background-color: #f4f9ff;"><strong>&#9500;&#9472; Subcategory B</strong><br />[name of sub-issue]</td>
-<td>"[Mid-level pro claim inside B]"</td>
-<td>"[Mid-level anti claim inside B]"</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&nbsp;&#9492;&#9472; <em>Specific</em></td>
-<td>"[Specific pro claim under B]"</td>
-<td>"[Specific anti claim under B]"</td>
-</tr>
-<tr>
-<td style="background-color: #f4f9ff;"><strong>&#9492;&#9472; Subcategory C</strong><br />[name of sub-issue]</td>
-<td>"[Mid-level pro claim inside C]"</td>
-<td>"[Mid-level anti claim inside C]"</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&nbsp;&#9492;&#9472; <em>Specific</em></td>
-<td>"[Specific pro claim under C]"</td>
-<td>"[Specific anti claim under C]"</td>
+<td style="background-color: #ef9a9a;" align="center"><strong>6. Any Means Necessary</strong><br />No limiting principles</td>
+<td>Willing to harm others, violate any norm, or destroy any institution to advance the cause.</td>
+<td>Revolutionary violence and political terrorism, found across the entire political spectrum.</td>
+<td>No other principle outranks this belief.</td>
 </tr>
 </tbody>
 </table>
-<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📜 <a href="/Assumptions">Assumption Stack Behind Each Position</a></h2>
-<p style="font-size: 13px;">Not a fourth axis. Continuum 3 sorts beliefs by altitude; this takes each stance and lists the assumptions a person must accept to hold it, which is how a fight at the bottom gets traced to its real root higher up. <strong>Core split:</strong> [the single assumption that most cleanly divides the two sides]. <span style="color: #666;">See: <a href="/Assumptions">Assumptions</a>.</span></p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<div style="background-color: #fff0f0; padding: 10px; border-left: 4px solid #c00; margin: 10px 0; font-size: 13px;"><strong>Escalation is an overlay, not a matching coordinate.</strong> The system matches and groups beliefs on properties of the claim itself: direction (section 1), magnitude (section 3), and level of abstraction (section 6). Escalation describes the believer. Two people can assert the identical claim, same direction, same magnitude, same rung on the abstraction ladder, and sit four levels apart on this ladder: one holds a moderate claim (section 3 = 50%) he barely leans into (section 1 = +40%) and goes to prison for it (Level 4); another holds an extreme claim (100%) she cares about totally (+100%) and never steps outside the law (Level 2). If escalation entered matching, the system would file one claim on two pages because its holders differ. The ladder earns its place on the page anyway, because a debate's temperature is a property of the conflict worth tracking: when a topic's believers start climbing it, the <a href="/w/page/164190102/Conflict%20Resolution%20Scoring">conflict resolution pipeline</a> wants to know.</div>
+<hr />
+<h1>5. <a href="/w/page/162523572/Assumptions">Foundational Assumptions</a> at Each Position</h1>
+<p>Your position on the spectrum in section 1 depends on deeper assumptions about reality, values, and causation. This table maps those dependencies from worldview down to topic-specific claim.</p>
+<p><strong>Key Insight:</strong> [One sentence naming the real disagreement under the visible disagreement. Example: "Most disagreements about carbon taxes are really disagreements about whether markets or regulation are more trustworthy."]</p>
+<table border="1" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #f0f3f6;">
-<th width="15%">To Hold Position</th> <th width="85%">You Must Accept These Assumptions (General to Specific)</th>
+<th width="15%">To Hold Position</th> <th width="85%">You Must Believe These Assumptions (General &rarr; Specific)</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="background-color: #ffcccc; text-align: center;"><strong>-100% to -50%</strong><br />(Strongly Oppose)</td>
-<td style="font-size: 13px;"><strong>1. [Worldview]:</strong> [Description]<br /><strong>2. [Political/philosophical]:</strong> [Description]<br /><strong>3. [Causal claim]:</strong> [Description]<br /><strong>4. [Topic-specific]:</strong> [Description]</td>
+<td style="background-color: #ffcccc;" align="center"><strong>&minus;100% to &minus;50%</strong></td>
+<td><strong>1. Worldview:</strong> [Example: "Government action causes more problems than it solves."]<br /><strong>2. Political philosophy:</strong> [Example: "Markets self-correct better than regulators do."]<br /><strong>3. Causal model:</strong> [Example: "Pricing carbon shifts costs without changing behavior."]<br /><strong>4. Topic-specific:</strong> [Example: "A carbon tax will be captured by lobbyists and riddled with exemptions."]<br /><strong>5. Specific claim:</strong> [Example: "The 2018 French gilets jaunes protests prove carbon taxes are politically unworkable."]</td>
 </tr>
 <tr>
-<td style="background-color: #ffffcc; text-align: center;"><strong>-20% to +20%</strong><br />(Nuanced/Mixed)</td>
-<td style="font-size: 13px;"><strong>1. [Acknowledges complexity]:</strong> [Description]<br /><strong>2. [Both sides have valid points]:</strong> [Description]<br /><strong>3. [Context matters]:</strong> [Description]<br /><strong>4. [Implementation determines outcome]:</strong> [Description]</td>
+<td style="background-color: #ffe6e6;" align="center"><strong>&minus;50% to &minus;20%</strong></td>
+<td><strong>1. Worldview:</strong> [Example]<br /><strong>2. Values:</strong> [Example]<br /><strong>3. Causal beliefs:</strong> [Example]<br /><strong>4. Topic-specific:</strong> [Example]</td>
 </tr>
 <tr>
-<td style="background-color: #ccffcc; text-align: center;"><strong>+50% to +100%</strong><br />(Strongly Support)</td>
-<td style="font-size: 13px;"><strong>1. [Worldview]:</strong> [Description]<br /><strong>2. [Political/philosophical]:</strong> [Description]<br /><strong>3. [Causal claim]:</strong> [Description]<br /><strong>4. [Topic-specific]:</strong> [Description]</td>
+<td style="background-color: #ffffcc;" align="center"><strong>&minus;20% to +20%</strong></td>
+<td><strong>1. Acknowledges complexity:</strong> [Example]<br /><strong>2. Both sides have valid points:</strong> [Example]<br /><strong>3. Context matters:</strong> [Example]<br /><strong>4. Implementation determines outcome:</strong> [Example]</td>
+</tr>
+<tr>
+<td style="background-color: #e6ffe6;" align="center"><strong>+20% to +50%</strong></td>
+<td><strong>1. Worldview:</strong> [Example]<br /><strong>2. Values:</strong> [Example]<br /><strong>3. Causal beliefs:</strong> [Example]<br /><strong>4. Topic-specific:</strong> [Example]</td>
+</tr>
+<tr>
+<td style="background-color: #ccffcc;" align="center"><strong>+50% to +100%</strong></td>
+<td><strong>1. Worldview:</strong> [Example: "Markets fail to price externalities and need correction."]<br /><strong>2. Political philosophy:</strong> [Example: "Pigovian taxes are the textbook fix for negative externalities."]<br /><strong>3. Causal model:</strong> [Example: "Higher prices reduce consumption."]<br /><strong>4. Topic-specific:</strong> [Example: "A carbon tax cuts emissions at lower cost than mandates."]<br /><strong>5. Specific claim:</strong> [Example: "British Columbia's revenue-neutral carbon tax cut emissions without slowing growth."]</td>
 </tr>
 </tbody>
 </table>
-<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">⚖️ <a href="/Core%20Values%20Conflict" target="_blank">Core Values Conflict</a></h2>
-<p style="font-size: 13px;">Advertised values each side claims, and the motivation critics attribute. <span style="color: #666;">See: <a href="/w/page/21956745/American%20values">American Values</a>.</span></p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<hr />
+<h1>6. The Abstraction Ladder (General &harr; Specific)</h1>
+<p>The same upstream worldview can generate dozens of downstream policy positions. Tracing the chain makes explicit what is actually being argued about. See <a href="/w/page/160861572/General%20to%20Specific">General to Specific</a>.</p>
+<table border="1" cellpadding="8" width="100%">
+<thead>
+<tr style="background-color: #f0f3f6;">
+<th width="15%">Level</th> <th width="42%">Pro-Topic Chain</th> <th width="43%">Anti-Topic Chain</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center"><strong>Worldview</strong></td>
+<td>[Example: "Markets fail to price externalities."]</td>
+<td>[Example: "Government intervention distorts more than it fixes."]</td>
+</tr>
+<tr>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+</tr>
+<tr>
+<td align="center"><strong>Political principle</strong></td>
+<td>[Example: "Negative externalities should be priced in."]</td>
+<td>[Example: "Tax policy should not be used as social engineering."]</td>
+</tr>
+<tr>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+</tr>
+<tr>
+<td align="center"><strong>Position on this topic</strong></td>
+<td>[Example: "A carbon tax is the right tool here." (+50% to +100%)]</td>
+<td>[Example: "A carbon tax is the wrong tool here." (&minus;50% to &minus;100%)]</td>
+</tr>
+<tr>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+<td align="center">&darr;</td>
+</tr>
+<tr>
+<td align="center"><strong>Specific policy</strong></td>
+<td>[Example: "Pass a $50/ton federal carbon tax with full revenue rebate."]</td>
+<td>[Example: "Block any federal carbon pricing legislation."]</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h1>7. Core Values Conflict</h1>
+<p style="font-size: 13px;">Most policy disagreements are not disagreements about facts. They are disagreements about which values take priority when values conflict. This table makes the priorities on both sides explicit, including the gap between advertised values and motivations critics attribute.</p>
+<table border="1" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #f0f3f6;">
 <th width="50%">Values Supporting This Topic</th> <th width="50%">Values Opposing This Topic</th>
@@ -214,175 +327,75 @@
 </thead>
 <tbody>
 <tr>
-<td style="font-size: 13px;" valign="top"><strong>Advertised:</strong><br /> 1. [Value supporters claim to uphold]<br /> 2. [Value supporters claim to uphold]<br /><br /><strong>Critics say the actual motivation is:</strong><br /> 1. [Hidden motivation critics attribute]<br /> 2. [Hidden motivation critics attribute]</td>
-<td style="font-size: 13px;" valign="top"><strong>Advertised:</strong><br /> 1. [Value opponents claim to uphold]<br /> 2. [Value opponents claim to uphold]<br /><br /><strong>Critics say the actual motivation is:</strong><br /> 1. [Hidden motivation critics attribute]<br /> 2. [Hidden motivation critics attribute]</td>
+<td valign="top"><strong>Advertised:</strong><br /> 1. [Example: "Stewardship of future generations."]<br /> 2. [Example: "Economic efficiency."]<br /><br /><strong>Actual (per critics):</strong><br /> 1. [Example: "Expansion of federal taxing authority."]<br /> 2. [Example: "Subsidies for politically favored industries."]</td>
+<td valign="top"><strong>Advertised:</strong><br /> 1. [Example: "Protection of working-class household budgets."]<br /> 2. [Example: "Limited government."]<br /><br /><strong>Actual (per critics):</strong><br /> 1. [Example: "Protection of fossil fuel industry profits."]<br /> 2. [Example: "Denial of climate science."]</td>
 </tr>
 </tbody>
 </table>
-<h2 id="engagement" style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">⚡ The Engagement Landscape (<a href="/escalation%20spectrum">Passive &harr; Active</a>)</h2>
-<p style="font-size: 13px;"><strong>A stakeholder map, not a matching axis.</strong> It measures how far a person will go to act on a belief, which is a fact about the person, not the belief, so it never feeds the three-part address above. A casual supporter and someone willing to go to prison hold the same belief. <span style="color: #666;">See: <a href="/escalation%20spectrum">Escalation Spectrum</a>.</span></p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<hr />
+<h1>8. <a href="/w/page/162560439/Compromise">Common Ground and Compromise</a></h1>
+<p style="font-size: 13px;">Solutions that address both sides' core concerns are more durable than victories. Compromise positions belong here.</p>
+<table border="1" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #f0f3f6;">
-<th width="18%">Engagement Level</th><th width="27%">Pro-Topic: What It Looks Like</th><th width="27%">Anti-Topic: What It Looks Like</th><th width="14%">Pro Example</th><th width="14%">Anti Example</th>
+<th width="50%">What Both Sides Might Agree On</th> <th width="50%">Possible Compromise Positions</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="background-color: #e8f5e9;"><strong>1. Preference</strong><br />Passive lean</td>
-<td>Would support if convenient. Would not prioritize it.</td>
-<td>Mildly skeptical. Prefers alternatives in some contexts. Would not act.</td>
-<td>[Casual supporter]</td>
-<td>[Casual skeptic]</td>
-</tr>
-<tr>
-<td style="background-color: #c8e6c9;"><strong>2. Active Advocacy</strong><br />Engaged participant</td>
-<td>Votes, donates, signs petitions, argues publicly in favor.</td>
-<td>Votes, donates, lobbies, argues publicly against or for alternatives.</td>
-<td>[Standard civic support]</td>
-<td>[Standard civic opposition]</td>
-</tr>
-<tr>
-<td style="background-color: #fff9c4;"><strong>3. Principled Non-Compliance</strong><br />Conscientious objector</td>
-<td>Refuses to act against conscience even at personal cost. Does not obstruct others.</td>
-<td>Refuses to implement or participate even when required. Does not obstruct others.</td>
-<td>[Thomas More pattern]</td>
-<td>[Official who resigns rather than implement]</td>
-</tr>
-<tr>
-<td style="background-color: #ffe082;"><strong>4. Civil Disobedience</strong><br />Principled lawbreaking</td>
-<td>Openly breaks laws seen as unjust obstacles. Accepts consequences as moral leverage.</td>
-<td>Openly defies related laws or mandates. Accepts consequences as moral leverage.</td>
-<td>[MLK / Gandhi equivalent]</td>
-<td>[Objectors who accepted imprisonment]</td>
+<td valign="top">1. [Example: "Climate change is real and warrants response."]<br /> 2. [Example: "Working families should not bear the cost of climate policy."]<br /> 3. [Example: "Energy reliability matters."]</td>
+<td valign="top">1. [Example: "Revenue-neutral carbon tax with full rebate to households."]<br /> 2. [Example: "Border carbon adjustment to prevent leakage."]<br /> 3. [Example: "Five-year pilot in one region with sunset clause."]</td>
 </tr>
 </tbody>
 </table>
-<p style="font-size: 13px;"><strong>Key insight:</strong> Engagement is independent of the three matching axes. Someone can hold a moderate claim (50%) about a cause they feel lukewarm toward (+40%) and still go to prison for it (Level 4).</p>
-<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🤝 <a href="/w/page/162560439/Compromise">Common Ground and Compromise</a></h2>
-<p style="font-size: 13px;">The scored <a href="/w/page/156187122/cost-benefit%20analysis">cost-benefit</a> trees read sideways. Compromise Candidates are the winnable disagreements, the ones a small likelihood shift can flip, as opposed to the symbolic value conflicts no negotiation resolves. That is the payoff of scoring both sides with equal rigor.</p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<hr />
+<h1>9. Best Media and Resources</h1>
+<p style="font-size: 13px;">Curated sources sorted by direction and informational value. Direction and Magnitude are the same belief coordinates from sections 1 and 3, applied to what the source argues. The Escalation column applies section 4's ladder to the content itself: what level of action does this source advocate? A book can call for civil disobedience regardless of what any reader does. See <a href="/w/page/21958666/media">Media Framework</a>.</p>
+<table style="border-collapse: collapse;" border="1" cellpadding="8" width="100%">
 <thead>
 <tr style="background-color: #f0f3f6;">
-<th width="33%">Shared Interests<br /><span style="font-size: 85%; font-weight: normal;">Impacts both sides want</span></th> <th width="33%">Real Value Conflicts<br /><span style="font-size: 85%; font-weight: normal;">One side prices freedom, the other safety</span></th> <th width="34%">Compromise Candidates<br /><span style="font-size: 85%; font-weight: normal;">A small likelihood shift flips a category's net</span></th>
-</tr>
-</thead>
-<tbody>
-<tr style="font-size: 13px;" valign="top">
-<td>1. [Impact both sides score as a benefit]<br />2. [Shared concern or common problem]<br />3. [Goal neither side disputes]</td>
-<td>1. [Value A vs Value B, genuinely traded off]<br />2. [The irreducible disagreement]<br />3. [Where no likelihood shift resolves it]</td>
-<td>1. [Impact where a feasible change flips the sign]<br />2. [Pilot or scoped version that wins both columns]<br />3. [Incremental step with a tractable likelihood gap]</td>
-</tr>
-</tbody>
-</table>
-<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">⚖️ The Evidence Ledger</h2>
-<p style="font-size: 13px;">A highlight reel of the highest-impact evidence appearing anywhere under this topic. Evidence formally attaches to specific beliefs and is scored on its own study page; this is the cross-topic view. <span style="color: #666;">See: <a href="/w/page/159353568/Evidence%20Scores">Evidence Scoring Methodology</a>.</span></p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
-<thead>
-<tr style="background-color: #f0f3f6;">
-<th width="40%">Supporting Evidence (Pro)</th> <th width="10%">Quality</th> <th width="40%">Weakening Evidence (Con)</th> <th width="10%">Quality</th>
+<th width="28%">Title</th> <th width="12%">Medium</th> <th width="12%">Bias / Tone</th> <th width="10%">Direction</th> <th width="10%">Magnitude</th> <th width="10%">Escalation</th> <th width="18%">Key Insight</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>[Study/Data Title]<br /><span style="font-size: 85%;">[Institution/Author] (Year). Finding: [brief]</span></td>
-<td align="center"><strong>[95%]</strong><br /><span style="font-size: 75%;">(Peer Reviewed)</span></td>
-<td>[Study/Data Title]<br /><span style="font-size: 85%;">[Institution/Author] (Year). Finding: [brief]</span></td>
-<td align="center"><strong>[80%]</strong><br /><span style="font-size: 75%;">(Meta-analysis)</span></td>
+<td>[Example: "<em>Climate Shock</em> by Wagner &amp; Weitzman"]</td>
+<td>Book</td>
+<td>Academic</td>
+<td align="center">+70%</td>
+<td align="center">60%</td>
+<td align="center">2</td>
+<td>[One sentence. Example: "Frames climate policy as insurance against tail risk, not point-estimate cost-benefit."]</td>
 </tr>
 <tr>
-<td>[Historical Precedent/Statistic]<br /><span style="font-size: 85%;">[Institution/Author] (Year). Finding: [brief]</span></td>
-<td align="center"><strong>[XX%]</strong></td>
-<td>[Counter-Statistic]<br /><span style="font-size: 85%;">[Institution/Author] (Year). Finding: [brief]</span></td>
-<td align="center"><strong>[XX%]</strong></td>
+<td>[Example: "<em>Apocalypse Never</em> by Michael Shellenberger"]</td>
+<td>Book</td>
+<td>Polemic</td>
+<td align="center">&minus;60%</td>
+<td align="center">80%</td>
+<td align="center">2</td>
+<td>[One sentence. Example: "Argues climate response has been hijacked by anti-growth ideology."]</td>
 </tr>
 </tbody>
 </table>
-<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📏 <a href="/w/page/159351732/Objective%20criteria%20scores">Best Objective Criteria</a> for This Topic</h2>
-<p style="font-size: 13px;">Agree on the yardstick before measuring. Each proposed criterion is a belief with its own page, scored on four dimensions: <strong>Validity</strong> (does it capture what we claim?), <strong>Reliability</strong> (do different observers get the same reading?), <strong><a href="/w/page/159338766/Linkage%20Scores">Linkage</a></strong> (how directly it connects to the claim), and <strong><a href="/w/page/162731388/Importance%20Score">Importance</a></strong>. Arguments that connect to high-scoring criteria carry more weight. <span style="color: #666;">See: <a href="/w/page/159351732/Objective%20criteria%20scores">Objective Criteria Scoring</a>.</span></p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
+<hr />
+<h1>10. Related Topics</h1>
+<table border="1" cellpadding="10" width="100%">
 <thead>
 <tr style="background-color: #f0f3f6;">
-<th width="28%">Proposed Criterion</th> <th width="12%" align="center"><a href="/w/page/159351732/Objective%20criteria%20scores">Criteria Score</a></th> <th width="15%" align="center">Validity</th> <th width="15%" align="center">Reliability</th> <th width="15%" align="center"><a href="/w/page/159338766/Linkage%20Scores">Linkage</a></th> <th width="15%" align="center"><a href="/w/page/162731388/Importance%20Score">Importance</a></th>
+<th>Broader (Parents)</th> <th>Narrower (Children)</th> <th>Adjacent (Siblings)</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>[Criterion 1]<br /><span style="font-size: 85%; color: #666;">[what it measures and how]</span></td>
-<td align="center"><strong><span style="color: #2e7d32;">[92%]</span></strong></td>
-<td align="center">High</td>
-<td align="center">High</td>
-<td align="center">High</td>
-<td align="center">High</td>
-</tr>
-<tr>
-<td>[Criterion 2]<br /><span style="font-size: 85%; color: #666;">[one-line description]</span></td>
-<td align="center"><strong><span style="color: #f57c00;">[60%]</span></strong></td>
-<td align="center">Med</td>
-<td align="center">Low</td>
-<td align="center">Med</td>
-<td align="center">Med</td>
-</tr>
-<tr>
-<td>[Criterion 3]<br /><span style="font-size: 85%; color: #666;">[one-line description]</span></td>
-<td align="center"><strong><span style="color: #d32f2f;">[15%]</span></strong></td>
-<td align="center">Low</td>
-<td align="center">Low</td>
-<td align="center">Low</td>
-<td align="center">Low</td>
-</tr>
-<tr>
-<td style="font-size: 85%; font-style: italic; color: #555;" colspan="6">Missing a criterion? <a href="/w/page/160433328/Contact%20Me">Submit a proposal</a> with reasons for its validity, reliability, linkage, and importance. The community scores it.</td>
+<td>[Parent topic 1], [Parent topic 2]</td>
+<td>[Child topic 1], [Child topic 2]</td>
+<td>[Sibling topic 1], [Sibling topic 2]</td>
 </tr>
 </tbody>
 </table>
-<h2 style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">📚 Best Media and Resources</h2>
-<p style="font-size: 13px;">Sorted by positivity and informational value. <span style="color: #666;">See: <a href="/w/page/21958666/media">Media Framework</a>.</span></p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="8">
-<thead>
-<tr style="background-color: #f0f3f6;">
-<th width="28%">Title</th> <th width="12%">Medium</th> <th width="12%">Bias/Tone</th> <th width="10%">Positivity</th> <th width="10%">Magnitude</th> <th width="10%">Escalation</th> <th width="18%">Key Insight</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>[Title]</td>
-<td>[Book/Doc/Article]</td>
-<td>[Academic/Polemic]</td>
-<td align="center">[+XX%]</td>
-<td align="center">[XX%]</td>
-<td align="center">[1-6]</td>
-<td>[One sentence summary]</td>
-</tr>
-<tr>
-<td>[Title]</td>
-<td>[Book/Doc/Article]</td>
-<td>[Critical/Satire]</td>
-<td align="center">[-XX%]</td>
-<td align="center">[XX%]</td>
-<td align="center">[1-6]</td>
-<td>[One sentence summary]</td>
-</tr>
-</tbody>
-</table>
-<h2 id="related" style="font-family: 'Segoe UI', 'Lucida Grande', Arial, sans-serif; font-size: 20px; font-weight: bold;">🔗 Related Topics</h2>
-<p style="font-size: 13px;">The <strong>Children</strong> column is where full subcategories from Continuum 3 go once they outgrow a row and earn their own page.</p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 2em;" border="1" cellpadding="10">
-<thead>
-<tr style="background-color: #f0f3f6;">
-<th width="25%">Broader (Parents)</th> <th width="25%">Sub-Issues (Children)</th> <th width="25%">Related (Siblings)</th> <th width="25%">Opposing / Critical Views</th>
-</tr>
-</thead>
-<tbody>
-<tr style="font-size: 13px;" valign="top">
-<td>[Link to Parent 1]<br />[Link to Parent 2]</td>
-<td>[Link to Child 1]<br />[Link to Child 2]</td>
-<td>[Link to Sibling 1]<br />[Link to Sibling 2]</td>
-<td>[Link to Opposing View 1]<br />[Link to Opposing View 2]</td>
-</tr>
-</tbody>
-</table>
-<h2 style="font-size: 20px;">📬 Contribute</h2>
-<p><a href="/w/page/160433328/Contact%20Me">Contact me</a> to add beliefs, strengthen arguments, link evidence, or propose criteria.<br /><a href="https://github.com/myklob/ideastockexchange">GitHub</a> for the code and scoring algorithms.</p>
-</div>
+<hr />
+<h2>Contribute</h2>
+<p><a href="/w/page/160433328/Contact%20Me">Contact me</a> to add beliefs, strengthen arguments, or link new evidence. <a href="https://github.com/myklob/ideastockexchange">GitHub</a> for technical implementation and scoring algorithms.</p>
+<p style="font-size: 12px; color: #555;"><strong>Related design pages:</strong> <a href="/w/page/159323925/One%20Page%20Per%20Belief">One Page Per Belief</a>, <a href="/w/page/163478577/Duplication%20Scores">Duplication Scores</a>, <a href="/w/page/163478616/Independence%20Scores">Independence Scores</a>, Grouping Similar Phrasings, Grouping by Sub-Topic.</p>
 <p>&nbsp;</p>


### PR DESCRIPTION
## Summary

Restructures the topic page template and implementation to align with the "Page Design" revision (July 2026). This is a major reorganization of sections, terminology, and data model to support the new canonical architecture where every numeric score is computed from linked argument and evidence nodes (audit lock principle).

## Key Changes

**Template & Documentation**
- Updated `templates/topic-template.html` with new section order and naming:
  - Renamed "Continuum 1: Direction" → "1. The Position Spectrum"
  - Moved Evidence Ledger to section 2 (was section 8)
  - Renamed "Continuum 2: Magnitude" → "3. Claim Magnitude" with new band names (Weak/Moderate/Strong/Extreme instead of Modest/Moderate/Strong/Total)
  - Renamed "Engagement Landscape" → "4. The Engagement Landscape: Civic Escalation"
  - Renamed "Assumption Stack" → "5. Foundational Assumptions"
  - Renamed "General to Specific" → "6. The Abstraction Ladder"
  - Consolidated related topics (removed "Opposing" column)
  - Added audit lock notice explaining that all scores are computed, never hand-entered
- Simplified authoring rules and core idea documentation
- Updated section descriptions to emphasize evidence-driven scoring and belief matching

**Data Model**
- Added `evidenceId` and `evidenceIndex` fields to `DebatePosition` to link positions to evidence rows
- Extended `DebateEvidence` with new fields: `tier`, `argument`, `linkage`, `standing` (VERIFIED/DISPUTED/FALSIFIED)
- Updated Prisma schema and added migration `20260711161656_add_topic_evidence_ledger_fields`
- Updated type definitions in `src/core/types/debate-topic.ts`

**Component Updates**
- `EvidenceLedger.tsx`: Redesigned to show tier-ranked evidence with standing badges, linkage scores, and argument labels; now sorts by tier then quality
- `Spectrum1Positions.tsx`: Updated heading and description; added evidence column linking to ledger
- `Spectrum2Magnitude.tsx`: Renamed magnitude bands (Weak/Moderate/Strong/Extreme); updated sublabels (Hedged/Standard/Categorical/Maximal)
- `Spectrum3Escalation.tsx`: Renamed to "Civic Escalation"; removed per-side descriptions; added level sublabels and clarified that this describes believers, not beliefs
- `Spectrum4AbstractionLadder.tsx`: Simplified to linear ladder (Worldview → Political principle → Position on this topic → Specific policy); removed branching tree logic
- `FoundationalAssumptions.tsx`: Updated heading and added link to assumptions algorithm page
- `CoreValuesConflict.tsx`: Simplified heading
- `CommonGround.tsx`: Removed cost-benefit tree references; simplified description
- `MediaResources.tsx`: Updated heading and direction label formatting (−100% instead of -100%)
- `TopicMetrics.tsx`: Updated background color to match new design palette
- `RelatedTopics.tsx`: Removed "Opposing" section; consolidated under "Adjacent"

**Page Layout**
- Reordered sections in `src/app/debate-topics/[slug]/page.tsx` to match new canonical order (Evidence Ledger now section 2)
- Updated breadcrumb styling (italic, `>` separator instead of `›`)
- Added audit lock notice below metrics
- Removed "What this page does" blue box; replaced with "What This Page Is For" section

**AI Generator & Seeds**
- Updated `ai-generator.ts` to include `evidenceIndex` in position objects and new evidence fields
- Updated `seed-debate-topics.ts` to populate new evidence fields and use new terminology (Mixed / Conditional, Weak/Moderate/Strong/Extreme)
- Simplified abstraction rung structure (removed `rungType` and `branchName` fields)

## Notable Implementation Details

- **Audit Lock Principle**: All numeric scores now display as `[bracketed]` placeholders until computed by the ReasonRank engine. The UI

https://claude.ai/code/session_015gMKstUQsQC8E3fTXsBZyV