### PR TITLE
Structured fallacy claims with weighted community consensus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Or set `CLAUDE_DEBUG_FILE` before launching. File logging cannot be enabled mid-
 - `/beliefs/[slug]` — the canonical belief page (this is the one that matters).
 - `/beliefs/set-aside-distractions-for-real-solutions` — bespoke route, predates the canonical structure. Don't use as a template.
 - `/product-reviews/[slug]` — separate concept that reuses some belief components. Edits to belief sections may affect it; check before refactoring.
-- `/algorithms` — index of every score explainer; subpages include `reason-rank`, `linkage-scores`, `importance-score`, `truth-scores`, `evidence-scores`, `unique-scores`, `assumptions`, `topic-overlap`, `objective-criteria`, `strong-to-weak`, `belief-equivalency`, `combine-similar-beliefs`. Belief-page components link these — if you add a link, verify the target exists or use plain text (Rule 5). Wiki-style space-URL routes (`/Linkage Scores` etc.) do NOT exist; never link them.
+- `/algorithms` — index of every score explainer; subpages include `reason-rank`, `linkage-scores`, `importance-score`, `truth-scores`, `evidence-scores`, `unique-scores`, `assumptions`, `topic-overlap`, `objective-criteria`, `strong-to-weak`, `belief-equivalency`, `combine-similar-beliefs`, `fallacy-detection`. Belief-page components link these — if you add a link, verify the target exists or use plain text (Rule 5). Wiki-style space-URL routes (`/Linkage Scores` etc.) do NOT exist; never link them.
 - `/how-it-works` — the Engine of Reason explainer, with a live engine readout.
 - `/arguments/[id]/linkage` — an edge's linkage sub-debate; `/arguments/[id]/score` — the edge's impact-provenance page (factor-by-factor derivation).
 - `/contact` — contact/contribution pointers (target for all former Contact Me links).

--- a/prisma/migrations/20260718192845_structured_fallacy_claims_grouping_votes/migration.sql
+++ b/prisma/migrations/20260718192845_structured_fallacy_claims_grouping_votes/migration.sql
@@ -1,0 +1,101 @@
+-- CreateTable
+CREATE TABLE "FallacyClaim" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "argumentId" INTEGER NOT NULL,
+    "fallacyType" TEXT NOT NULL,
+    "targetFactor" TEXT NOT NULL,
+    "severity" TEXT NOT NULL,
+    "quotedText" TEXT NOT NULL,
+    "explanation" TEXT NOT NULL,
+    "missingElements" TEXT NOT NULL,
+    "evidenceLinks" TEXT NOT NULL,
+    "consequences" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "consensus" REAL,
+    "resolvedAt" DATETIME,
+    "counterLinkageArgumentId" INTEGER,
+    "submittedById" TEXT,
+    "submittedByAgentId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "FallacyClaim_argumentId_fkey" FOREIGN KEY ("argumentId") REFERENCES "Argument" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "FallacyClaim_submittedByAgentId_fkey" FOREIGN KEY ("submittedByAgentId") REFERENCES "Agent" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "FallacyClaimVote" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "fallacyClaimId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "agree" BOOLEAN NOT NULL,
+    "reasoning" TEXT,
+    "weight" REAL NOT NULL DEFAULT 1.0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FallacyClaimVote_fallacyClaimId_fkey" FOREIGN KEY ("fallacyClaimId") REFERENCES "FallacyClaim" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "GroupingVote" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "candidateId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "agree" BOOLEAN NOT NULL,
+    "reasoning" TEXT,
+    "weight" REAL NOT NULL DEFAULT 1.0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GroupingVote_candidateId_fkey" FOREIGN KEY ("candidateId") REFERENCES "EquivalenceCandidate" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_EquivalenceCandidate" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "argumentId" INTEGER NOT NULL,
+    "existingArgumentId" INTEGER NOT NULL,
+    "similarity" REAL NOT NULL,
+    "detectedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "consensus" REAL,
+    "resolvedAt" DATETIME,
+    CONSTRAINT "EquivalenceCandidate_argumentId_fkey" FOREIGN KEY ("argumentId") REFERENCES "Argument" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "EquivalenceCandidate_existingArgumentId_fkey" FOREIGN KEY ("existingArgumentId") REFERENCES "Argument" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_EquivalenceCandidate" ("argumentId", "detectedAt", "existingArgumentId", "id", "similarity") SELECT "argumentId", "detectedAt", "existingArgumentId", "id", "similarity" FROM "EquivalenceCandidate";
+DROP TABLE "EquivalenceCandidate";
+ALTER TABLE "new_EquivalenceCandidate" RENAME TO "EquivalenceCandidate";
+CREATE INDEX "EquivalenceCandidate_argumentId_idx" ON "EquivalenceCandidate"("argumentId");
+CREATE INDEX "EquivalenceCandidate_existingArgumentId_idx" ON "EquivalenceCandidate"("existingArgumentId");
+CREATE INDEX "EquivalenceCandidate_status_idx" ON "EquivalenceCandidate"("status");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FallacyClaim_counterLinkageArgumentId_key" ON "FallacyClaim"("counterLinkageArgumentId");
+
+-- CreateIndex
+CREATE INDEX "FallacyClaim_argumentId_idx" ON "FallacyClaim"("argumentId");
+
+-- CreateIndex
+CREATE INDEX "FallacyClaim_status_idx" ON "FallacyClaim"("status");
+
+-- CreateIndex
+CREATE INDEX "FallacyClaim_submittedById_idx" ON "FallacyClaim"("submittedById");
+
+-- CreateIndex
+CREATE INDEX "FallacyClaim_submittedByAgentId_idx" ON "FallacyClaim"("submittedByAgentId");
+
+-- CreateIndex
+CREATE INDEX "FallacyClaimVote_fallacyClaimId_idx" ON "FallacyClaimVote"("fallacyClaimId");
+
+-- CreateIndex
+CREATE INDEX "FallacyClaimVote_userId_idx" ON "FallacyClaimVote"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FallacyClaimVote_fallacyClaimId_userId_key" ON "FallacyClaimVote"("fallacyClaimId", "userId");
+
+-- CreateIndex
+CREATE INDEX "GroupingVote_candidateId_idx" ON "GroupingVote"("candidateId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GroupingVote_candidateId_userId_key" ON "GroupingVote"("candidateId", "userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -404,6 +404,7 @@ model Argument {
 
   linkageArguments LinkageArgument[]
   linkageVotes     LinkageVote[]
+  fallacyClaims    FallacyClaim[]
 
   equivalenceCandidatesAsNew      EquivalenceCandidate[] @relation("EquivalenceCandidateNew")
   equivalenceCandidatesAsExisting EquivalenceCandidate[] @relation("EquivalenceCandidateExisting")
@@ -579,6 +580,89 @@ model LinkageVote {
 
   @@unique([argumentId, userId])
   @@index([argumentId])
+}
+
+/// A structured fallacy accusation against an argument edge. You can't just
+/// yell "FALLACY!": every template field below is required before the claim
+/// exists, and the claim is itself an argument — it enters the linkage
+/// sub-debate as a draft counter-argument and changes nothing until the
+/// community confirms it (weighted consensus ≥ 60%, see src/lib/consensus.ts).
+/// Confirmation publishes the counter-argument; rejection retires it. No
+/// score is ever docked by the act of accusing.
+model FallacyClaim {
+  id         Int      @id @default(autoincrement())
+  argumentId Int
+  argument   Argument @relation(fields: [argumentId], references: [id])
+
+  /// Canonical type slug from FALLACY_CATALOG (e.g. "false-dilemma").
+  fallacyType String
+  /// Factor a confirmed claim damages: "relevance" | "logical-validity" | "evidence-quality".
+  /// Denormalized from the catalog at filing time so history survives catalog edits.
+  targetFactor String
+  /// "minor" | "major" — from the catalog at filing time; drives the
+  /// logical-validity ladder once confirmed.
+  severity String
+
+  // ── The accusation template (all required; validateFallacyClaimInput) ──
+  /// Exact text of the target that commits the fallacy.
+  quotedText      String
+  /// Why the quote qualifies as this fallacy type.
+  explanation     String
+  /// What is being excluded, misrepresented, or left unsupported.
+  missingElements String
+  /// JSON array of {label, url?, beliefSlug?} — the evidence the accusation
+  /// rests on (excluded alternatives, the opponent's actual position, the
+  /// contradicting studies). Types that need evidence reject an empty array.
+  evidenceLinks   String
+  /// How the fallacy affects the argument's validity if confirmed.
+  consequences    String
+
+  /// "open" | "confirmed" | "rejected" — moved only by community consensus,
+  /// never by filing.
+  status String @default("open")
+  /// Weighted agreement share (0-1) at last resolution check. Null until quorum.
+  consensus  Float?
+  resolvedAt DateTime?
+
+  /// The draft counter-argument this claim placed in the linkage sub-debate.
+  /// Published on confirmation, retired ("rejected") on rejection.
+  counterLinkageArgumentId Int? @unique
+
+  submittedById      String?
+  submittedByAgentId String?
+  submittedByAgent   Agent?  @relation("FallacyClaimSubmittedBy", fields: [submittedByAgentId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  votes FallacyClaimVote[]
+
+  @@index([argumentId])
+  @@index([status])
+  @@index([submittedById])
+  @@index([submittedByAgentId])
+}
+
+/// One community evaluation of a fallacy claim. `weight` is the voter's
+/// caller-credibility multiplier (src/lib/fallacy/calibration.ts) frozen at
+/// vote time: accurate, cross-partisan callers count more; tribal or
+/// inaccurate callers count less.
+model FallacyClaimVote {
+  id             Int          @id @default(autoincrement())
+  fallacyClaimId Int
+  fallacyClaim   FallacyClaim @relation(fields: [fallacyClaimId], references: [id])
+
+  userId    String
+  /// true = the fallacy claim is correct; false = the accusation fails.
+  agree     Boolean
+  reasoning String?
+  weight    Float   @default(1.0)
+
+  createdAt DateTime @default(now())
+
+  @@unique([fallacyClaimId, userId])
+  @@index([fallacyClaimId])
+  @@index([userId])
 }
 
 model Evidence {
@@ -2166,6 +2250,7 @@ model Agent {
   arguments         Argument[]          @relation("ArgumentSubmittedBy")
   evidence          Evidence[]          @relation("EvidenceRetrievedBy")
   linkageArguments  LinkageArgument[]   @relation("LinkageArgumentSubmittedBy")
+  fallacyClaims     FallacyClaim[]      @relation("FallacyClaimSubmittedBy")
   suggestedEvidence SuggestedEvidence[]
   forumPosts        ForumPost[]
   forumComments     ForumComment[]
@@ -2245,8 +2330,39 @@ model EquivalenceCandidate {
   similarity         Float
   detectedAt         DateTime @default(now())
 
+  /// "open" | "grouped" | "kept-separate" — moved only by community consensus
+  /// (weighted ≥ 60%, src/lib/consensus.ts), mirroring how Wikipedia settles
+  /// merge proposals. Grouping is a community verdict, not an algorithm's.
+  status     String    @default("open")
+  /// Weighted agreement share (0-1) at last resolution check. Null until quorum.
+  consensus  Float?
+  resolvedAt DateTime?
+
+  votes GroupingVote[]
+
   @@index([argumentId])
   @@index([existingArgumentId])
+  @@index([status])
+}
+
+/// One community vote on whether an EquivalenceCandidate pair really is the
+/// same claim said differently. "This is the same as [existing claim]" plus
+/// reasoning; 60% weighted agreement groups the pair.
+model GroupingVote {
+  id          Int                  @id @default(autoincrement())
+  candidateId Int
+  candidate   EquivalenceCandidate @relation(fields: [candidateId], references: [id])
+
+  userId    String
+  /// true = same claim, group them; false = genuinely different, keep separate.
+  agree     Boolean
+  reasoning String?
+  weight    Float   @default(1.0)
+
+  createdAt DateTime @default(now())
+
+  @@unique([candidateId, userId])
+  @@index([candidateId])
 }
 
 /// Knowledge-connector queue (suggestion-only). A proposal becomes an

--- a/sql/LINKAGE_ARCHITECTURE.md
+++ b/sql/LINKAGE_ARCHITECTURE.md
@@ -30,7 +30,7 @@ The database tables that back the JSON-LD when the platform graduates from "wiki
 
 The schema enforces the audit-lock principle: scores have read-only-from-application semantics, with all changes logged to `score_audit_log`. The five-step check is its own table because the check IS the audit trail.
 
-The Prisma schema in `prisma/schema.prisma` already models the same domain on SQLite (`LinkageArgument`, `LinkageVote`, `LinkageScoreType`, etc.). The MariaDB schema in this folder is the target shape when the project graduates beyond SQLite.
+The Prisma schema in `prisma/schema.prisma` already models the same domain on SQLite (`LinkageArgument`, `LinkageVote`, `LinkageScoreType`, and the accountability tables `FallacyClaim`, `FallacyClaimVote`, `EquivalenceCandidate`, `GroupingVote`). The MariaDB schema in this folder is the target shape when the project graduates beyond SQLite. Schema 1.1.0 adds the structured fallacy-claim tables (the six-field accusation template, weighted claim votes, and the `v_fallacy_claim_tally` consensus view — the SQL twin of `resolveConsensus()` in `src/lib/consensus.ts`) plus the grouping-vote tables that settle same-claim pairs at the same 60% weighted bar.
 
 ## How they interact today
 

--- a/sql/linkage_pages_schema.sql
+++ b/sql/linkage_pages_schema.sql
@@ -7,7 +7,7 @@
 -- RENDER of the data in these tables. The JSON-LD block embedded in
 -- each page is the on-the-wire serialization of these rows.
 --
--- Schema version: 1.0.0
+-- Schema version: 1.1.0 (adds fallacy claims, claim votes, grouping votes)
 -- Engine: MariaDB 10.4+ / MySQL 8.0+ (uses CHECK constraints, JSON type)
 -- Companion: src/core/scoring/scoring-engine.ts in the GitHub repo
 --   https://github.com/myklob/ideastockexchange
@@ -348,6 +348,152 @@ CREATE TABLE IF NOT EXISTS `linkage_bias_risks` (
 );
 
 
+-- -- Structured fallacy claims ----------------------------------
+-- An accusation is an argument. Filing requires every template field
+-- (the application rejects anything less) and changes NO score: the
+-- claim's counter-argument enters linkage_arguments as a draft. Only
+-- weighted community consensus (>= 60%, quorum 3) confirms the claim,
+-- publishes the counter-argument, and triggers the engine recompute.
+-- Mirrors the Prisma models FallacyClaim / FallacyClaimVote.
+
+CREATE TABLE IF NOT EXISTS `fallacy_claims` (
+  `claim_id`            VARCHAR(64)   NOT NULL,
+  `linkage_id`          VARCHAR(64)   NOT NULL,  -- the accused edge
+
+  -- Catalog classification (denormalized at filing time)
+  `fallacy_type`        VARCHAR(64)   NOT NULL,  -- e.g., 'false-dilemma'
+  `target_factor`       ENUM('relevance', 'logical-validity', 'evidence-quality') NOT NULL,
+  `severity`            ENUM('minor', 'major') NOT NULL,
+
+  -- The six-field accusation template (all NOT NULL: no bare "FALLACY!")
+  `quoted_text`         TEXT          NOT NULL,
+  `explanation`         TEXT          NOT NULL,
+  `missing_elements`    TEXT          NOT NULL,
+  `evidence_links`      JSON          NOT NULL,  -- [{label, url?, belief_slug?}]
+  `consequences`        TEXT          NOT NULL,
+
+  -- Resolution state. AUDIT-LOCKED: moved only by the consensus query
+  -- below, never by the accuser.
+  `status`              ENUM('open', 'confirmed', 'rejected') NOT NULL DEFAULT 'open',
+  `consensus`           DECIMAL(5,4)  DEFAULT NULL,  -- weighted agree share
+  `resolved_at`         TIMESTAMP     NULL DEFAULT NULL,
+
+  -- The draft counter-argument this claim placed in the sub-debate.
+  -- Published on confirmation; retired on rejection.
+  `counter_arg_id`      VARCHAR(64)   DEFAULT NULL,
+
+  -- Provenance
+  `created_at`          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  `created_by`          VARCHAR(128)  DEFAULT NULL,
+
+  PRIMARY KEY (`claim_id`),
+  INDEX `idx_claim_linkage` (`linkage_id`),
+  INDEX `idx_claim_status` (`status`),
+  INDEX `idx_claim_creator` (`created_by`),
+
+  CONSTRAINT `fk_claim_linkage` FOREIGN KEY (`linkage_id`) REFERENCES `linkages`(`linkage_id`),
+  CONSTRAINT `fk_claim_counter` FOREIGN KEY (`counter_arg_id`) REFERENCES `linkage_arguments`(`arg_id`),
+  CONSTRAINT `chk_claim_consensus` CHECK (`consensus` IS NULL OR (`consensus` >= 0 AND `consensus` <= 1))
+);
+
+
+-- -- Fallacy claim votes ----------------------------------------
+-- One row per user per claim. `weight` is the voter's caller-credibility
+-- multiplier (accuracy x cross-partisan balance, clamped to [0.3, 1.4]),
+-- computed by the application from fallacy_claims history at vote time —
+-- NEVER submitted by the voter.
+
+CREATE TABLE IF NOT EXISTS `fallacy_claim_votes` (
+  `vote_id`             VARCHAR(64)   NOT NULL,
+  `claim_id`            VARCHAR(64)   NOT NULL,
+  `user_id`             VARCHAR(128)  NOT NULL,
+  `agree`               BOOLEAN       NOT NULL,
+  `reasoning`           TEXT          DEFAULT NULL,
+  `weight`              DECIMAL(5,4)  NOT NULL DEFAULT 1.0,
+  `created_at`          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+
+  PRIMARY KEY (`vote_id`),
+  UNIQUE KEY `unique_vote_per_user` (`claim_id`, `user_id`),
+  INDEX `idx_vote_claim` (`claim_id`),
+  INDEX `idx_vote_user` (`user_id`),
+
+  CONSTRAINT `fk_vote_claim` FOREIGN KEY (`claim_id`) REFERENCES `fallacy_claims`(`claim_id`),
+  CONSTRAINT `chk_vote_weight` CHECK (`weight` >= 0.3 AND `weight` <= 1.4)
+);
+
+
+-- -- Grouping votes (same claim, different words) ----------------
+-- The redundancy scan proposes candidate pairs; the community settles
+-- them at the same 60% weighted bar. Mirrors EquivalenceCandidate /
+-- GroupingVote in the Prisma schema. Candidate pairs reference nodes
+-- because the pair is about the claims, not one particular edge.
+
+CREATE TABLE IF NOT EXISTS `grouping_candidates` (
+  `candidate_id`        VARCHAR(64)   NOT NULL,
+  `new_node_id`         VARCHAR(64)   NOT NULL,
+  `existing_node_id`    VARCHAR(64)   NOT NULL,
+  `similarity`          DECIMAL(5,4)  NOT NULL,
+  -- same-claim (>= 0.95) | probable-group (>= 0.8) | related-link (>= 0.5)
+  `band`                VARCHAR(32)   DEFAULT NULL,
+  `status`              ENUM('open', 'grouped', 'kept-separate') NOT NULL DEFAULT 'open',
+  `consensus`           DECIMAL(5,4)  DEFAULT NULL,
+  `resolved_at`         TIMESTAMP     NULL DEFAULT NULL,
+  `detected_at`         TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+
+  PRIMARY KEY (`candidate_id`),
+  INDEX `idx_candidate_new` (`new_node_id`),
+  INDEX `idx_candidate_existing` (`existing_node_id`),
+  INDEX `idx_candidate_status` (`status`),
+
+  CONSTRAINT `fk_candidate_new` FOREIGN KEY (`new_node_id`) REFERENCES `nodes`(`node_id`),
+  CONSTRAINT `fk_candidate_existing` FOREIGN KEY (`existing_node_id`) REFERENCES `nodes`(`node_id`)
+);
+
+CREATE TABLE IF NOT EXISTS `grouping_votes` (
+  `vote_id`             VARCHAR(64)   NOT NULL,
+  `candidate_id`        VARCHAR(64)   NOT NULL,
+  `user_id`             VARCHAR(128)  NOT NULL,
+  `agree`               BOOLEAN       NOT NULL,  -- true = same claim, group
+  `reasoning`           TEXT          DEFAULT NULL,
+  `weight`              DECIMAL(5,4)  NOT NULL DEFAULT 1.0,
+  `created_at`          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+
+  PRIMARY KEY (`vote_id`),
+  UNIQUE KEY `unique_grouping_vote_per_user` (`candidate_id`, `user_id`),
+  INDEX `idx_grouping_vote_candidate` (`candidate_id`),
+
+  CONSTRAINT `fk_grouping_vote_candidate` FOREIGN KEY (`candidate_id`) REFERENCES `grouping_candidates`(`candidate_id`)
+);
+
+
+-- -- Consensus tally view ---------------------------------------
+-- How the application resolves a claim: weighted agree share across the
+-- votes, settled at >= 0.6 either way once at least 3 votes exist. The
+-- same query shape runs for grouping_votes. This is the SQL twin of
+-- resolveConsensus() in src/lib/consensus.ts.
+
+CREATE OR REPLACE VIEW `v_fallacy_claim_tally` AS
+SELECT
+  c.claim_id,
+  c.fallacy_type,
+  c.status,
+  COUNT(v.vote_id)                                    AS vote_count,
+  COALESCE(SUM(v.weight), 0)                          AS total_weight,
+  COALESCE(SUM(CASE WHEN v.agree THEN v.weight END), 0)
+    / NULLIF(SUM(v.weight), 0)                        AS agree_share,
+  CASE
+    WHEN COUNT(v.vote_id) < 3 THEN 'open'
+    WHEN COALESCE(SUM(CASE WHEN v.agree THEN v.weight END), 0)
+      / NULLIF(SUM(v.weight), 0) >= 0.6 THEN 'confirmed'
+    WHEN COALESCE(SUM(CASE WHEN NOT v.agree THEN v.weight END), 0)
+      / NULLIF(SUM(v.weight), 0) >= 0.6 THEN 'rejected'
+    ELSE 'open'
+  END                                                 AS computed_outcome
+FROM fallacy_claims c
+LEFT JOIN fallacy_claim_votes v ON v.claim_id = c.claim_id
+GROUP BY c.claim_id, c.fallacy_type, c.status;
+
+
 -- =================================================================
 -- READ VIEW: full linkage page in a single query
 -- =================================================================
@@ -453,5 +599,13 @@ CREATE TABLE IF NOT EXISTS `score_audit_log` (
 -- 6. Note for SQLite parity: this schema uses MariaDB/MySQL ENUMs
 --    and CHECK constraints. The companion Prisma schema in
 --    prisma/schema.prisma already models the same domain on SQLite
---    (LinkageArgument, LinkageVote, LinkageScoreType). When
---    promoting from SQLite to MariaDB, this file is the target.
+--    (LinkageArgument, LinkageVote, FallacyClaim, FallacyClaimVote,
+--    EquivalenceCandidate, GroupingVote). When promoting from SQLite
+--    to MariaDB, this file is the target.
+--
+-- 7. Fallacy claims never dock a score at filing. The counter-argument
+--    row referenced by counter_arg_id stays in DRAFT until
+--    v_fallacy_claim_tally computes 'confirmed'; only then does the
+--    application publish it and rerun the linkage recompute. Draft and
+--    rejected linkage_arguments rows are excluded from every score
+--    aggregate.

--- a/src/app/algorithms/fallacy-detection/page.tsx
+++ b/src/app/algorithms/fallacy-detection/page.tsx
@@ -1,0 +1,156 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Fallacy Detection — Idea Stock Exchange',
+  description:
+    'Fallacy accusations as scored arguments: the required accusation template, the 60% consensus bar, the validity ladder, and the cross-partisan credibility multiplier.',
+}
+
+const container = 'max-w-[960px] mx-auto px-4 py-8 leading-7 text-[#333]'
+const code = 'bg-gray-100 border border-gray-300 px-4 py-3 font-mono my-4 rounded text-sm'
+
+function Breadcrumb() {
+  return (
+    <p className="text-right text-sm italic text-gray-600 mb-6">
+      <Link href="/" className="text-blue-700 hover:underline">Home</Link>
+      {' > '}
+      <Link href="/algorithms" className="text-blue-700 hover:underline">Algorithms</Link>
+      {' > '}
+      <strong>Fallacy Detection</strong>
+    </p>
+  )
+}
+
+export default function FallacyDetectionPage() {
+  return (
+    <div className={container}>
+      <Breadcrumb />
+      <h1 className="text-3xl font-bold mb-3">Fallacy Detection</h1>
+      <p className="text-lg text-gray-600 mb-6">
+        A fallacy accusation is an argument, not a weapon. It carries the same burdens as any
+        argument — and pays the same price when it loses.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">The problem: fallacy calling is tribal</h2>
+      <p className="mb-4">
+        On every platform, &ldquo;STRAW MAN!&rdquo; is a comment, not a case. Most accusations are
+        wrong, none require reasoning, nobody is accountable for false ones, and people spot
+        fallacies fluently in opposing arguments while staying blind to the same patterns on
+        their own side. The result is that actual logical validity becomes noise: an accusation
+        costs nothing, so it carries no information.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">The accusation template</h2>
+      <p className="mb-2">
+        Here, filing a fallacy claim requires the full template — the API rejects anything less
+        (<code className="bg-gray-100 px-1 rounded">POST /api/arguments/[id]/fallacy-claims</code>):
+      </p>
+      <ul className="list-disc ml-6 mb-4 space-y-1">
+        <li><strong>Type</strong> — a catalog entry (false dilemma, straw man, cherry-picking, &hellip;), which fixes what a confirmed claim damages and how hard.</li>
+        <li><strong>Quote</strong> — the exact text that commits the fallacy.</li>
+        <li><strong>Explanation</strong> — why the quote qualifies as this type.</li>
+        <li><strong>Missing elements</strong> — what is excluded, misrepresented, or unsupported.</li>
+        <li><strong>Evidence</strong> — exhibits, mandatory for types whose case needs them: a straw-man claim must link the opponent&apos;s actual position; a false-dilemma claim must list the excluded alternatives; a cherry-picking claim must link the contradicting evidence.</li>
+        <li><strong>Consequences</strong> — how the fallacy affects the argument&apos;s validity if confirmed.</li>
+      </ul>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Filing changes nothing</h2>
+      <p className="mb-4">
+        A filed claim enters the target&apos;s{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">linkage sub-debate</Link>{' '}
+        as a <em>draft</em> counter-argument. Drafts are displayed but never counted — the same
+        rule the automated pattern detector has always lived under. Others then argue for and
+        against the accusation itself, and vote. Only weighted community agreement of at least
+        60% (minimum three votes) confirms a claim; 60% the other way rejects it. Consensus can
+        move in both directions as votes accumulate, and the counter-argument&apos;s status
+        tracks it.
+      </p>
+      <div className={code}>
+        open &rarr; confirmed: counter-argument published, scores propagate<br />
+        open &rarr; rejected: the accusation failed its own debate; the target is untouched
+      </div>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">What confirmation costs the target</h2>
+      <p className="mb-2">
+        Each catalog entry targets the factor that fallacy actually damages: relevance fallacies
+        (ad hominem, whataboutism) draft against the linkage; formal fallacies (false dilemma,
+        slippery slope) against logical validity; evidence fallacies (cherry-picking, anecdote)
+        against{' '}
+        <Link href="/algorithms/evidence-scores" className="text-blue-700 hover:underline">evidence quality</Link>.
+        Confirmed formal fallacies feed the validity ladder:
+      </p>
+      <div className={code}>
+        no confirmed fallacy &rarr; 0.95&ensp;·&ensp;one minor &rarr; 0.75&ensp;·&ensp;one major
+        &rarr; 0.45&ensp;·&ensp;two or more &rarr; 0.25
+      </div>
+      <p className="mb-4">
+        The multiplication is the point: great evidence cannot rescue broken reasoning. And the
+        ladder rewards repair — the same evidence restated <em>without</em> the false binary
+        scores higher than it did with it, so removing the fallacy is the profitable move.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Cross-partisan calibration</h2>
+      <p className="mb-2">
+        Every voter&apos;s weight on fallacy claims is their credibility multiplier, computed
+        from their track record and clamped to [0.3, 1.4]:
+      </p>
+      <div className={code}>
+        credibility = clamp(accuracyFactor &times; balanceFactor)<br />
+        accuracyFactor = 2 &times; (claims upheld / claims resolved)<br />
+        balanceFactor&ensp; = 0.4 + 0.9 &times; (side balance of who you flag)
+      </div>
+      <p className="mb-4">
+        A caller whose claims the community upholds 82% of the time and who flags both sides of
+        debates carries well over neutral weight. A caller at 40% accuracy who only ever flags
+        one side sinks toward the floor. A new user with no history is exactly 1.0 — no
+        information, no adjustment. Accuracy alone cannot buy influence for a one-sided caller:
+        keeping your weight requires spotting fallacies in arguments you agree with, too.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Why mass accusation fails</h2>
+      <ul className="list-disc ml-6 mb-4 space-y-1">
+        <li>Each claim requires the full template — reasoning and exhibits, not a button.</li>
+        <li>Each claim must <em>win its own debate</em> at 60% weighted agreement.</li>
+        <li>Coordinated one-sided accusers arrive pre-discounted by the balance factor.</li>
+        <li>Every rejected claim permanently lowers the accuser&apos;s accuracy rate.</li>
+      </ul>
+      <p className="mb-4">
+        Gaming the system costs more than making good arguments — which is the design goal of
+        every score here.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">The automated detector</h2>
+      <p className="mb-4">
+        Agent-submitted arguments are also scanned by a pattern detector (ad hominem slurs,
+        &ldquo;everyone knows&rdquo;, correlation-as-causation, universals, isolated-study and
+        anecdote framings). Detections use the same catalog and the same rule: each becomes a
+        draft counter-argument attributed to the system detector agent, reviewable like anything
+        else. No score is ever docked because a detector fired.
+      </p>
+
+      <h2 className="text-xl font-bold mt-8 mb-2">Why this needs grouping</h2>
+      <p className="mb-4">
+        Fallacy detection only accumulates when the same debate is not fragmented across a
+        thousand pages. Because{' '}
+        <Link href="/algorithms/belief-equivalency" className="text-blue-700 hover:underline">belief equivalency</Link>{' '}
+        and{' '}
+        <Link href="/algorithms/combine-similar-beliefs" className="text-blue-700 hover:underline">merging</Link>{' '}
+        keep one page per claim, a fallacy confirmed once stays confirmed for the whole cluster —
+        nobody resets the debate by opening a fresh thread. Restatements of an argument face the
+        same consolidation: the redundancy scan proposes pairs, the community votes
+        (<code className="bg-gray-100 px-1 rounded">POST /api/equivalence-candidates/[id]/votes</code>),
+        and 60% agreement groups them while the{' '}
+        <Link href="/algorithms/unique-scores" className="text-blue-700 hover:underline">uniqueness discount</Link>{' '}
+        prices whatever overlap remains.
+      </p>
+
+      <p className="mt-8 text-sm text-gray-600">
+        Related: <Link href="/algorithms/truth-scores" className="text-blue-700 hover:underline">Truth Scores</Link> ·{' '}
+        <Link href="/algorithms/linkage-scores" className="text-blue-700 hover:underline">Linkage Scores</Link> ·{' '}
+        <Link href="/algorithms/evidence-scores" className="text-blue-700 hover:underline">Evidence Scores</Link> ·{' '}
+        <Link href="/algorithms/belief-equivalency" className="text-blue-700 hover:underline">Belief Equivalency</Link>
+      </p>
+    </div>
+  )
+}

--- a/src/app/algorithms/page.tsx
+++ b/src/app/algorithms/page.tsx
@@ -108,6 +108,12 @@ const groups: AlgorithmGroup[] = [
         description:
           'Surfacing the unstated premises that bridge low-linkage arguments, so each one becomes its own debatable node.',
       },
+      {
+        name: 'Fallacy Detection',
+        href: '/algorithms/fallacy-detection',
+        description:
+          'Fallacy accusations as scored arguments: a required template, a 60% consensus bar, and a credibility multiplier that punishes tribal calling.',
+      },
     ],
   },
   {

--- a/src/app/api/arguments/[id]/fallacy-claims/route.ts
+++ b/src/app/api/arguments/[id]/fallacy-claims/route.ts
@@ -1,0 +1,227 @@
+/**
+ * Structured fallacy claims against an argument edge.
+ *
+ * GET  /api/arguments/[id]/fallacy-claims
+ *   The argument's claims with their consensus state, plus the accusation
+ *   template (what filing requires) so a client can render the form.
+ *
+ * POST /api/arguments/[id]/fallacy-claims
+ *   File an accusation. You can't just yell "FALLACY!": every template field
+ *   is required (validateFallacyClaimInput), and types whose case needs
+ *   exhibits (straw man, false dilemma, cherry-picking, ...) must carry
+ *   evidence links. Filing changes NO score: the claim enters the target's
+ *   linkage sub-debate as a DRAFT counter-argument and only community
+ *   consensus on the votes route publishes it.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { isGraphFrozen, GRAPH_FREEZE_MESSAGE } from '@/lib/markets/epoch'
+import { catalogEntry, FALLACY_CATALOG } from '@/lib/fallacy/catalog'
+import {
+  validateFallacyClaimInput,
+  counterStatementFor,
+  type FallacyClaimInput,
+  type FallacyEvidenceLink,
+} from '@/lib/fallacy/claims'
+import { resolveConsensus, CONSENSUS_THRESHOLD, CONSENSUS_QUORUM } from '@/lib/consensus'
+
+interface PostBody extends Partial<FallacyClaimInput> {
+  submittedById?: string
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const argumentId = Number(id)
+  if (!Number.isInteger(argumentId)) {
+    return NextResponse.json({ error: 'Invalid argument id.' }, { status: 400 })
+  }
+
+  const argument = await prisma.argument.findUnique({
+    where: { id: argumentId },
+    select: {
+      id: true,
+      side: true,
+      parentBelief: { select: { slug: true, statement: true } },
+      belief: { select: { slug: true, statement: true } },
+      fallacyClaims: { include: { votes: true }, orderBy: { createdAt: 'asc' } },
+    },
+  })
+  if (!argument) return NextResponse.json({ error: 'Argument not found.' }, { status: 404 })
+
+  return NextResponse.json({
+    argument: {
+      id: argument.id,
+      side: argument.side,
+      parentBelief: argument.parentBelief,
+      childBelief: argument.belief,
+    },
+    claims: argument.fallacyClaims.map(claim => {
+      const consensus = resolveConsensus(
+        claim.votes.map(v => ({ agree: v.agree, weight: v.weight })),
+      )
+      return {
+        id: claim.id,
+        fallacyType: claim.fallacyType,
+        targetFactor: claim.targetFactor,
+        severity: claim.severity,
+        quotedText: claim.quotedText,
+        explanation: claim.explanation,
+        missingElements: claim.missingElements,
+        evidenceLinks: JSON.parse(claim.evidenceLinks) as FallacyEvidenceLink[],
+        consequences: claim.consequences,
+        status: claim.status,
+        consensus: claim.consensus,
+        live: {
+          agreeShare: consensus.agreeShare,
+          voteCount: consensus.voteCount,
+          threshold: CONSENSUS_THRESHOLD,
+          quorum: CONSENSUS_QUORUM,
+        },
+      }
+    }),
+    template: {
+      requiredFields: [
+        'fallacyType',
+        'quotedText',
+        'explanation',
+        'missingElements',
+        'evidenceLinks',
+        'consequences',
+      ],
+      fallacyTypes: [...FALLACY_CATALOG.values()].map(e => ({
+        slug: e.slug,
+        label: e.label,
+        targetFactor: e.targetFactor,
+        severity: e.severity,
+        evidenceRequirement: e.evidenceRequirement,
+      })),
+      note:
+        'An accusation is an argument. Filing changes no score: the claim enters the ' +
+        'linkage sub-debate as a draft counter-argument and takes effect only if the ' +
+        `community confirms it (weighted agreement >= ${CONSENSUS_THRESHOLD * 100}%).`,
+    },
+  })
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const argumentId = Number(id)
+  if (!Number.isInteger(argumentId)) {
+    return NextResponse.json({ error: 'Invalid argument id.' }, { status: 400 })
+  }
+
+  if (isGraphFrozen(new Date())) {
+    return NextResponse.json({ error: GRAPH_FREEZE_MESSAGE }, { status: 423 })
+  }
+
+  let body: PostBody
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  // Audit lock: an accusation never carries a score.
+  const forbidden = ['severity', 'weight', 'consensus', 'status', 'score']
+  const submitted = Object.keys(body as Record<string, unknown>).filter(k => forbidden.includes(k))
+  if (submitted.length > 0) {
+    return NextResponse.json(
+      {
+        error:
+          `Fields never accepted from the accuser (${submitted.join(', ')}): severity comes ` +
+          'from the catalog, weight from the track record, status from community consensus.',
+      },
+      { status: 422 },
+    )
+  }
+
+  const input: FallacyClaimInput = {
+    fallacyType: body.fallacyType ?? '',
+    quotedText: body.quotedText ?? '',
+    explanation: body.explanation ?? '',
+    missingElements: body.missingElements ?? '',
+    evidenceLinks: Array.isArray(body.evidenceLinks) ? body.evidenceLinks : [],
+    consequences: body.consequences ?? '',
+  }
+  const issues = validateFallacyClaimInput(input)
+  if (issues.length > 0) {
+    return NextResponse.json(
+      { error: 'Incomplete accusation template. An accusation is an argument; build the case.', issues },
+      { status: 422 },
+    )
+  }
+  const entry = catalogEntry(input.fallacyType)!
+
+  const argument = await prisma.argument.findUnique({
+    where: { id: argumentId },
+    select: { id: true },
+  })
+  if (!argument) return NextResponse.json({ error: 'Argument not found.' }, { status: 404 })
+
+  const created = await prisma.$transaction(async tx => {
+    // The claim's counter-argument enters the sub-debate as a DRAFT: visible,
+    // reviewable, counted only after confirmation.
+    const counter = await tx.linkageArgument.create({
+      data: {
+        argumentId,
+        side: 'disagree',
+        statement: counterStatementFor(input, entry),
+        pattern: entry.slug,
+        status: 'draft',
+        targetFactor: entry.targetFactor,
+        fallacyType: entry.slug,
+        rationale:
+          'Structured fallacy claim filed with the full accusation template. ' +
+          'Draft until community consensus confirms the claim.',
+      },
+    })
+
+    const claim = await tx.fallacyClaim.create({
+      data: {
+        argumentId,
+        fallacyType: entry.slug,
+        targetFactor: entry.targetFactor,
+        severity: entry.severity,
+        quotedText: input.quotedText.trim(),
+        explanation: input.explanation.trim(),
+        missingElements: input.missingElements.trim(),
+        evidenceLinks: JSON.stringify(input.evidenceLinks),
+        consequences: input.consequences.trim(),
+        counterLinkageArgumentId: counter.id,
+        submittedById: body.submittedById?.trim() || null,
+      },
+    })
+
+    await tx.auditLog.create({
+      data: {
+        action: 'file_fallacy_claim',
+        targetType: 'FallacyClaim',
+        targetId: String(claim.id),
+        rationale: input.explanation.trim(),
+        payload: JSON.stringify({ argumentId, ...input }),
+      },
+    })
+
+    return { claim, counter }
+  })
+
+  return NextResponse.json(
+    {
+      claimId: created.claim.id,
+      counterLinkageArgumentId: created.counter.id,
+      status: created.claim.status,
+      note:
+        'Filed. No score changed: the counter-argument is a draft in the linkage sub-debate. ' +
+        `The claim takes effect only if weighted community agreement reaches ${CONSENSUS_THRESHOLD * 100}% ` +
+        `(minimum ${CONSENSUS_QUORUM} votes) on POST /api/fallacy-claims/${created.claim.id}/votes.`,
+    },
+    { status: 201 },
+  )
+}

--- a/src/app/api/arguments/[id]/linkage/route.ts
+++ b/src/app/api/arguments/[id]/linkage/route.ts
@@ -54,9 +54,11 @@ export async function GET(
     return NextResponse.json({ error: 'Argument not found' }, { status: 404 })
   }
 
-  // Compute current linkage score from stored LinkageArguments
+  // Compute current linkage score from stored LinkageArguments. Published
+  // rows only: drafts are visible in the response but never counted.
+  const publishedLinkageArgs = arg.linkageArguments.filter(la => la.status === 'published')
   const computedLinkageScore = calculateLinkageFromArguments(
-    arg.linkageArguments.map(la => ({ side: la.side, strength: la.strength }))
+    publishedLinkageArgs.map(la => ({ side: la.side, strength: la.strength }))
   )
 
   // Apply depth attenuation for display purposes
@@ -80,8 +82,8 @@ export async function GET(
       attenuatedScore,
       depthFactor: Math.pow(0.5, arg.depth),
       formula: `(A − D) / (A + D)  →  depth-attenuated × 0.5^${arg.depth}`,
-      proCount: arg.linkageArguments.filter(la => la.side === 'agree').length,
-      conCount: arg.linkageArguments.filter(la => la.side === 'disagree').length,
+      proCount: publishedLinkageArgs.filter(la => la.side === 'agree').length,
+      conCount: publishedLinkageArgs.filter(la => la.side === 'disagree').length,
     },
   })
 }

--- a/src/app/api/equivalence-candidates/[id]/votes/route.ts
+++ b/src/app/api/equivalence-candidates/[id]/votes/route.ts
@@ -1,0 +1,180 @@
+/**
+ * Community grouping votes on an EquivalenceCandidate pair — the "this is
+ * the same as [existing claim]" flow. The redundancy scan proposes pairs;
+ * the community decides. 60% weighted agreement groups the pair
+ * (status "grouped"), 60% disagreement keeps it separate. Grouping is a
+ * community verdict recorded for the engine and reviewers: the uniqueness
+ * discount already prices the overlap, and a grouped verdict is the signal
+ * to merge the pages (see /algorithms/combine-similar-beliefs).
+ *
+ * POST body: { userId: string, agree: boolean, reasoning?: string }
+ *   agree = "same claim, group them"; disagree = "genuinely different".
+ * GET returns the pair, tally, and current status.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { resolveConsensus, CONSENSUS_THRESHOLD, CONSENSUS_QUORUM } from '@/lib/consensus'
+import { similarityBand } from '@/lib/agent-ingest/similarity'
+
+const OUTCOME_TO_STATUS = {
+  upheld: 'grouped',
+  rejected: 'kept-separate',
+  open: 'open',
+} as const
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const candidateId = Number(id)
+  if (!Number.isInteger(candidateId)) {
+    return NextResponse.json({ error: 'Invalid candidate id.' }, { status: 400 })
+  }
+
+  const candidate = await prisma.equivalenceCandidate.findUnique({
+    where: { id: candidateId },
+    include: {
+      argument: { select: { id: true, claim: true, belief: { select: { slug: true, statement: true } } } },
+      existingArgument: { select: { id: true, claim: true, belief: { select: { slug: true, statement: true } } } },
+      votes: { orderBy: { createdAt: 'asc' } },
+    },
+  })
+  if (!candidate) return NextResponse.json({ error: 'Candidate not found.' }, { status: 404 })
+
+  const consensus = resolveConsensus(candidate.votes.map(v => ({ agree: v.agree, weight: v.weight })))
+  return NextResponse.json({
+    candidateId: candidate.id,
+    similarity: candidate.similarity,
+    band: similarityBand(candidate.similarity),
+    status: candidate.status,
+    newArgument: {
+      id: candidate.argument.id,
+      claim: candidate.argument.claim ?? candidate.argument.belief.statement,
+      beliefSlug: candidate.argument.belief.slug,
+    },
+    existingArgument: {
+      id: candidate.existingArgument.id,
+      claim: candidate.existingArgument.claim ?? candidate.existingArgument.belief.statement,
+      beliefSlug: candidate.existingArgument.belief.slug,
+    },
+    consensus: {
+      agreeShare: consensus.agreeShare,
+      voteCount: consensus.voteCount,
+      threshold: CONSENSUS_THRESHOLD,
+      quorum: CONSENSUS_QUORUM,
+    },
+    votes: candidate.votes.map(v => ({
+      userId: v.userId,
+      agree: v.agree,
+      reasoning: v.reasoning,
+      weight: v.weight,
+    })),
+  })
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const candidateId = Number(id)
+  if (!Number.isInteger(candidateId)) {
+    return NextResponse.json({ error: 'Invalid candidate id.' }, { status: 400 })
+  }
+
+  let body: { userId?: string; agree?: boolean; reasoning?: string; weight?: unknown }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  if (body.weight !== undefined) {
+    return NextResponse.json({ error: 'weight is never accepted from the voter.' }, { status: 422 })
+  }
+  const userId = body.userId?.trim()
+  if (!userId) return NextResponse.json({ error: 'userId is required.' }, { status: 422 })
+  if (typeof body.agree !== 'boolean') {
+    return NextResponse.json({ error: 'agree must be true or false.' }, { status: 422 })
+  }
+
+  const candidate = await prisma.equivalenceCandidate.findUnique({
+    where: { id: candidateId },
+    select: { id: true, status: true },
+  })
+  if (!candidate) return NextResponse.json({ error: 'Candidate not found.' }, { status: 404 })
+
+  const result = await prisma.$transaction(async tx => {
+    await tx.groupingVote.upsert({
+      where: { candidateId_userId: { candidateId, userId } },
+      create: {
+        candidateId,
+        userId,
+        agree: body.agree as boolean,
+        reasoning: body.reasoning?.trim() || null,
+      },
+      update: { agree: body.agree as boolean, reasoning: body.reasoning?.trim() || null },
+    })
+    await tx.auditLog.create({
+      data: {
+        action: 'grouping_vote',
+        targetType: 'EquivalenceCandidate',
+        targetId: String(candidateId),
+        rationale:
+          body.reasoning?.trim() ||
+          `${userId} voted the pair ${body.agree ? 'equivalent (group)' : 'distinct (keep separate)'}.`,
+        payload: JSON.stringify({ userId, agree: body.agree }),
+      },
+    })
+
+    const votes = await tx.groupingVote.findMany({
+      where: { candidateId },
+      select: { agree: true, weight: true },
+    })
+    const consensus = resolveConsensus(votes)
+    const newStatus = OUTCOME_TO_STATUS[consensus.outcome]
+
+    if (newStatus !== candidate.status) {
+      await tx.equivalenceCandidate.update({
+        where: { id: candidateId },
+        data: {
+          status: newStatus,
+          consensus: consensus.agreeShare,
+          resolvedAt: newStatus === 'open' ? null : new Date(),
+        },
+      })
+      await tx.auditLog.create({
+        data: {
+          action: 'resolve_equivalence_candidate',
+          targetType: 'EquivalenceCandidate',
+          targetId: String(candidateId),
+          rationale:
+            `Weighted community agreement ${((consensus.agreeShare ?? 0) * 100).toFixed(0)}% ` +
+            `across ${consensus.voteCount} votes moved the pair to "${newStatus}".`,
+        },
+      })
+    } else {
+      await tx.equivalenceCandidate.update({
+        where: { id: candidateId },
+        data: { consensus: consensus.agreeShare },
+      })
+    }
+
+    return { consensus, newStatus }
+  })
+
+  return NextResponse.json({
+    candidateId,
+    status: result.newStatus,
+    agreeShare: result.consensus.agreeShare,
+    voteCount: result.consensus.voteCount,
+    note:
+      result.newStatus === 'grouped'
+        ? 'Grouped: the community agreed these are the same claim. One page per claim — the merge flow consolidates their analyses.'
+        : result.newStatus === 'kept-separate'
+          ? 'Kept separate: the community found a real difference between the claims.'
+          : `Open: needs ${CONSENSUS_QUORUM}+ votes and ${CONSENSUS_THRESHOLD * 100}% weighted agreement either way.`,
+  })
+}

--- a/src/app/api/fallacy-claims/[id]/votes/route.ts
+++ b/src/app/api/fallacy-claims/[id]/votes/route.ts
@@ -1,0 +1,234 @@
+/**
+ * Community resolution of a structured fallacy claim.
+ *
+ * POST /api/fallacy-claims/[id]/votes
+ *   Body: { userId: string, agree: boolean, reasoning?: string }
+ *   One vote per user (re-voting updates). Vote weight is the voter's
+ *   caller-credibility multiplier — accuracy plus cross-partisan balance
+ *   (src/lib/fallacy/calibration.ts) — frozen at vote time. After each vote
+ *   the claim is re-resolved at the 60% weighted threshold:
+ *     confirmed → the claim's counter-argument is PUBLISHED into the linkage
+ *                 sub-debate (strength by severity) and scores propagate;
+ *     rejected  → the counter-argument is retired;
+ *     open      → the counter-argument stays (or returns to) draft.
+ *   Consensus can move in both directions as votes accumulate; the counter-
+ *   argument's status always tracks the current outcome.
+ *
+ * GET /api/fallacy-claims/[id]/votes
+ *   Current tally and consensus state.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { isGraphFrozen, GRAPH_FREEZE_MESSAGE } from '@/lib/markets/epoch'
+import { propagateFromLinkageChange } from '@/lib/propagate-belief-scores'
+import { resolveConsensus, CONSENSUS_THRESHOLD, CONSENSUS_QUORUM } from '@/lib/consensus'
+import { counterArgumentStrength } from '@/lib/fallacy/claims'
+import { callerCredibilityFor } from '@/lib/fallacy/caller-record'
+import type { FallacySeverity } from '@/lib/fallacy/catalog'
+
+const OUTCOME_TO_CLAIM_STATUS = {
+  upheld: 'confirmed',
+  rejected: 'rejected',
+  open: 'open',
+} as const
+
+const OUTCOME_TO_COUNTER_STATUS = {
+  upheld: 'published',
+  rejected: 'rejected',
+  open: 'draft',
+} as const
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const claimId = Number(id)
+  if (!Number.isInteger(claimId)) {
+    return NextResponse.json({ error: 'Invalid fallacy claim id.' }, { status: 400 })
+  }
+
+  const claim = await prisma.fallacyClaim.findUnique({
+    where: { id: claimId },
+    include: { votes: { orderBy: { createdAt: 'asc' } } },
+  })
+  if (!claim) return NextResponse.json({ error: 'Fallacy claim not found.' }, { status: 404 })
+
+  const consensus = resolveConsensus(claim.votes.map(v => ({ agree: v.agree, weight: v.weight })))
+  return NextResponse.json({
+    claimId: claim.id,
+    status: claim.status,
+    consensus: {
+      agreeShare: consensus.agreeShare,
+      voteCount: consensus.voteCount,
+      totalWeight: consensus.totalWeight,
+      threshold: CONSENSUS_THRESHOLD,
+      quorum: CONSENSUS_QUORUM,
+    },
+    votes: claim.votes.map(v => ({
+      userId: v.userId,
+      agree: v.agree,
+      reasoning: v.reasoning,
+      weight: v.weight,
+    })),
+  })
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const claimId = Number(id)
+  if (!Number.isInteger(claimId)) {
+    return NextResponse.json({ error: 'Invalid fallacy claim id.' }, { status: 400 })
+  }
+
+  if (isGraphFrozen(new Date())) {
+    return NextResponse.json({ error: GRAPH_FREEZE_MESSAGE }, { status: 423 })
+  }
+
+  let body: { userId?: string; agree?: boolean; reasoning?: string; weight?: unknown }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  if (body.weight !== undefined) {
+    return NextResponse.json(
+      { error: 'weight is never accepted: it is computed from the voter’s track record.' },
+      { status: 422 },
+    )
+  }
+  const userId = body.userId?.trim()
+  if (!userId) {
+    return NextResponse.json({ error: 'userId is required.' }, { status: 422 })
+  }
+  if (typeof body.agree !== 'boolean') {
+    return NextResponse.json({ error: 'agree must be true or false.' }, { status: 422 })
+  }
+
+  const claim = await prisma.fallacyClaim.findUnique({
+    where: { id: claimId },
+    select: {
+      id: true,
+      argumentId: true,
+      severity: true,
+      status: true,
+      counterLinkageArgumentId: true,
+    },
+  })
+  if (!claim) return NextResponse.json({ error: 'Fallacy claim not found.' }, { status: 404 })
+
+  // Credibility is computed BEFORE this vote is stored, so voting on your own
+  // pending accusations never lifts your own weight.
+  const weight = await callerCredibilityFor(userId)
+
+  const { consensus, statusChanged, newStatus, counterStatusChanged } =
+    await prisma.$transaction(async tx => {
+      await tx.fallacyClaimVote.upsert({
+        where: { fallacyClaimId_userId: { fallacyClaimId: claimId, userId } },
+        create: {
+          fallacyClaimId: claimId,
+          userId,
+          agree: body.agree as boolean,
+          reasoning: body.reasoning?.trim() || null,
+          weight,
+        },
+        update: { agree: body.agree as boolean, reasoning: body.reasoning?.trim() || null, weight },
+      })
+      await tx.auditLog.create({
+        data: {
+          action: 'fallacy_claim_vote',
+          targetType: 'FallacyClaim',
+          targetId: String(claimId),
+          rationale: body.reasoning?.trim() || `${userId} voted ${body.agree ? 'agree' : 'disagree'}.`,
+          payload: JSON.stringify({ userId, agree: body.agree, weight }),
+        },
+      })
+
+      const votes = await tx.fallacyClaimVote.findMany({
+        where: { fallacyClaimId: claimId },
+        select: { agree: true, weight: true },
+      })
+      const consensus = resolveConsensus(votes)
+
+      const newStatus = OUTCOME_TO_CLAIM_STATUS[consensus.outcome]
+      const statusChanged = newStatus !== claim.status
+      if (statusChanged) {
+        await tx.fallacyClaim.update({
+          where: { id: claimId },
+          data: {
+            status: newStatus,
+            consensus: consensus.agreeShare,
+            resolvedAt: newStatus === 'open' ? null : new Date(),
+          },
+        })
+        await tx.auditLog.create({
+          data: {
+            action: 'resolve_fallacy_claim',
+            targetType: 'FallacyClaim',
+            targetId: String(claimId),
+            rationale:
+              `Weighted community agreement ${((consensus.agreeShare ?? 0) * 100).toFixed(0)}% ` +
+              `across ${consensus.voteCount} votes moved the claim to "${newStatus}".`,
+          },
+        })
+      } else {
+        await tx.fallacyClaim.update({
+          where: { id: claimId },
+          data: { consensus: consensus.agreeShare },
+        })
+      }
+
+      // Keep the counter-argument's status in lockstep with the outcome. This
+      // is the ONLY path that publishes it — confirmation, never filing.
+      let counterStatusChanged = false
+      if (claim.counterLinkageArgumentId != null) {
+        const counterStatus = OUTCOME_TO_COUNTER_STATUS[consensus.outcome]
+        const counter = await tx.linkageArgument.findUnique({
+          where: { id: claim.counterLinkageArgumentId },
+          select: { status: true },
+        })
+        if (counter && counter.status !== counterStatus) {
+          await tx.linkageArgument.update({
+            where: { id: claim.counterLinkageArgumentId },
+            data: {
+              status: counterStatus,
+              strength: counterArgumentStrength(claim.severity as FallacySeverity),
+            },
+          })
+          counterStatusChanged = true
+        }
+      }
+
+      return { consensus, statusChanged, newStatus, counterStatusChanged }
+    })
+
+  // The confirmed counter-argument now counts in the linkage sub-debate (or
+  // stopped counting, if consensus moved back). Recompute and ripple upward.
+  const propagation = counterStatusChanged
+    ? await propagateFromLinkageChange(claim.argumentId)
+    : null
+
+  return NextResponse.json({
+    claimId,
+    status: newStatus,
+    agreeShare: consensus.agreeShare,
+    voteCount: consensus.voteCount,
+    voteWeight: weight,
+    resolved: statusChanged,
+    propagation: propagation && {
+      updatedArgumentIds: propagation.updatedArgumentIds,
+      updatedBeliefIds: propagation.updatedBeliefIds,
+    },
+    note:
+      newStatus === 'confirmed'
+        ? 'Claim confirmed: the counter-argument is published in the linkage sub-debate and scores propagated.'
+        : newStatus === 'rejected'
+          ? 'Claim rejected: the accusation failed its own debate. The target is untouched.'
+          : `Open: needs ${CONSENSUS_QUORUM}+ votes and ${CONSENSUS_THRESHOLD * 100}% weighted agreement either way.`,
+  })
+}

--- a/src/app/arguments/[id]/linkage/page.tsx
+++ b/src/app/arguments/[id]/linkage/page.tsx
@@ -409,15 +409,19 @@ export default async function LinkagePage({ params }: PageProps) {
     }),
   ])
 
+  // Draft rows (e.g. detector or fallacy-claim counter-arguments awaiting
+  // review) are displayed but never counted: an accusation is an argument,
+  // and it moves nothing until published.
+  const publishedLinkageArgs = arg.linkageArguments.filter(la => la.status === 'published')
   const proArgs = arg.linkageArguments.filter(la => la.side === 'agree')
   const conArgs = arg.linkageArguments.filter(la => la.side === 'disagree')
-  const proWeight = proArgs.reduce((s, la) => s + la.strength, 0)
-  const conWeight = conArgs.reduce((s, la) => s + la.strength, 0)
+  const proWeight = publishedLinkageArgs.filter(la => la.side === 'agree').reduce((s, la) => s + la.strength, 0)
+  const conWeight = publishedLinkageArgs.filter(la => la.side === 'disagree').reduce((s, la) => s + la.strength, 0)
 
   const linkageScore = calculateLinkageFromArguments(
-    arg.linkageArguments.map(la => ({ side: la.side, strength: la.strength }))
+    publishedLinkageArgs.map(la => ({ side: la.side, strength: la.strength }))
   )
-  const hasLinkageDebate = arg.linkageArguments.length > 0
+  const hasLinkageDebate = publishedLinkageArgs.length > 0
   const canonicalLinkage = hasLinkageDebate ? linkageScore : null
 
   const direction = arg.side === 'agree' ? 'Supports' : 'Weakens'
@@ -446,6 +450,9 @@ export default async function LinkagePage({ params }: PageProps) {
           <>
             {la.pattern && <strong>{patternName(la.pattern)}: </strong>}
             {la.statement}
+            {la.status !== 'published' && (
+              <span className="ml-2 text-xs italic text-gray-500">({la.status} &mdash; not counted)</span>
+            )}
           </>
         ) : (
           <span>&nbsp;</span>

--- a/src/core/schemas/belief-data.schema.xsd
+++ b/src/core/schemas/belief-data.schema.xsd
@@ -1,93 +1,286 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-  <!-- ═══ Belief Analysis Document ═══ -->
+  <!-- ═══ Belief Analysis Document ═══
+       The normalized graph shape the pipeline emits and the Prisma schema
+       stores: Belief NODES carry scores; Arguments are EDGES joining a
+       reason to its conclusion; FallacyClaims are structured accusations
+       against an edge; GroupingCandidates are same-claim pairs awaiting the
+       community grouping vote. belief-outline-data.xml is the worked
+       example; belief-html.converter.xslt renders this shape. -->
   <xs:element name="BeliefAnalysis">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="Belief" minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="Beliefs">
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="BeliefID"  type="xs:string"  minOccurs="0"/>
-              <xs:element name="Statement" type="xs:string"/>
-              <xs:element name="Category"  type="xs:string"  minOccurs="0"/>
-              <xs:element name="Subcategory" type="xs:string" minOccurs="0"/>
-              <xs:element name="DeweyNumber" type="xs:string" minOccurs="0"/>
-              <xs:element name="Positivity" type="xs:decimal" minOccurs="0"/>
-              <xs:element name="Score"     type="xs:decimal" minOccurs="0"/>
-              <xs:element name="ClaimStrength" type="xs:decimal" minOccurs="0"/>
-              <xs:element name="Falsifiability" type="xs:string" minOccurs="0"/>
+              <xs:element name="Belief" minOccurs="1" maxOccurs="unbounded" type="BeliefType"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
 
-              <!-- Definitions section (template v2) -->
-              <xs:element name="Definitions" minOccurs="0">
-                <xs:complexType>
-                  <xs:sequence>
-                    <xs:element name="Definition" minOccurs="0" maxOccurs="unbounded">
-                      <xs:complexType>
-                        <xs:sequence>
-                          <xs:element name="Term"       type="xs:string"/>
-                          <xs:element name="Definition" type="xs:string"/>
-                          <xs:element name="SortOrder"  type="xs:integer" minOccurs="0"/>
-                        </xs:sequence>
-                      </xs:complexType>
-                    </xs:element>
-                  </xs:sequence>
-                </xs:complexType>
-              </xs:element>
+        <xs:element name="Arguments" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="SupportingArgument" type="SupportingArgumentType"/>
+                <xs:element name="WeakeningArgument"  type="WeakeningArgumentType"/>
+              </xs:choice>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
 
-              <!-- Testable Predictions section (template v2) -->
-              <xs:element name="TestablePredictions" minOccurs="0">
-                <xs:complexType>
-                  <xs:sequence>
-                    <xs:element name="Prediction" minOccurs="0" maxOccurs="unbounded">
-                      <xs:complexType>
-                        <xs:sequence>
-                          <xs:element name="Statement"          type="xs:string"/>
-                          <xs:element name="Timeframe"          type="xs:string" minOccurs="0"/>
-                          <xs:element name="VerificationMethod" type="xs:string" minOccurs="0"/>
-                          <xs:element name="SortOrder"          type="xs:integer" minOccurs="0"/>
-                        </xs:sequence>
-                      </xs:complexType>
-                    </xs:element>
-                  </xs:sequence>
-                </xs:complexType>
-              </xs:element>
+        <xs:element name="Links" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Link" minOccurs="0" maxOccurs="unbounded" type="LinkType"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
 
-              <xs:element name="Impact" minOccurs="0">
-                <xs:complexType>
-                  <xs:sequence>
-                    <xs:element name="StrengthenPercentage" type="xs:string"/>
-                    <xs:element name="WeakenPercentage"     type="xs:string"/>
-                  </xs:sequence>
-                </xs:complexType>
-              </xs:element>
+        <!-- Structured fallacy accusations against argument edges. -->
+        <xs:element name="FallacyClaims" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="FallacyClaim" minOccurs="0" maxOccurs="unbounded" type="FallacyClaimType"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
 
-              <xs:element name="Reasons" minOccurs="0">
-                <xs:complexType>
-                  <xs:sequence>
-                    <xs:element name="Agree" minOccurs="0" maxOccurs="unbounded">
-                      <xs:complexType>
-                        <xs:sequence>
-                          <xs:element name="Reason" minOccurs="1" maxOccurs="unbounded" type="ReasonType"/>
-                        </xs:sequence>
-                      </xs:complexType>
-                    </xs:element>
-                    <xs:element name="Disagree" minOccurs="0" maxOccurs="unbounded">
-                      <xs:complexType>
-                        <xs:sequence>
-                          <xs:element name="Reason" minOccurs="1" maxOccurs="unbounded" type="ReasonType"/>
-                        </xs:sequence>
-                      </xs:complexType>
-                    </xs:element>
-                  </xs:sequence>
-                </xs:complexType>
-              </xs:element>
+        <!-- Same-claim pairs awaiting (or settled by) the grouping vote. -->
+        <xs:element name="GroupingCandidates" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Candidate" minOccurs="0" maxOccurs="unbounded" type="GroupingCandidateType"/>
             </xs:sequence>
           </xs:complexType>
         </xs:element>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+
+  <!-- ═══ Belief node ═══ -->
+  <xs:complexType name="BeliefType">
+    <xs:sequence>
+      <xs:element name="BeliefID"  type="xs:string"  minOccurs="0"/>
+      <xs:element name="Statement" type="xs:string"/>
+      <xs:element name="Category"  type="xs:string"  minOccurs="0"/>
+      <xs:element name="Subcategory" type="xs:string" minOccurs="0"/>
+      <xs:element name="DeweyNumber" type="xs:string" minOccurs="0"/>
+      <xs:element name="ParentID"  type="xs:string"  minOccurs="0"/>
+      <!-- supporting | weakening | root -->
+      <xs:element name="Side"      type="xs:string"  minOccurs="0"/>
+      <xs:element name="Positivity" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="Score"     type="xs:decimal" minOccurs="0"/>
+      <xs:element name="ClaimStrength" type="xs:decimal" minOccurs="0"/>
+      <!-- Engine-computed node scores (audit-locked: never hand-edited). -->
+      <xs:element name="TruthScore"      type="xs:decimal" minOccurs="0"/>
+      <xs:element name="LinkageScore"    type="xs:decimal" minOccurs="0"/>
+      <xs:element name="ImportanceScore" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="UniquenessScore" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="ReasonRank"      type="xs:decimal" minOccurs="0"/>
+      <xs:element name="PropagatedScore" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="SourceUrl"    type="xs:string" minOccurs="0"/>
+      <!-- T1..T4 evidence tier -->
+      <xs:element name="EvidenceType" type="xs:string" minOccurs="0"/>
+      <xs:element name="Falsifiability" type="xs:string" minOccurs="0"/>
+
+      <!-- Definitions section (template v2) -->
+      <xs:element name="Definitions" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Definition" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Term"       type="xs:string"/>
+                  <xs:element name="Definition" type="xs:string"/>
+                  <xs:element name="SortOrder"  type="xs:integer" minOccurs="0"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <!-- Testable Predictions section (template v2) -->
+      <xs:element name="TestablePredictions" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Prediction" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Statement"          type="xs:string"/>
+                  <xs:element name="Timeframe"          type="xs:string" minOccurs="0"/>
+                  <xs:element name="VerificationMethod" type="xs:string" minOccurs="0"/>
+                  <xs:element name="SortOrder"          type="xs:integer" minOccurs="0"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <xs:element name="Impact" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="StrengthenPercentage" type="xs:string"/>
+            <xs:element name="WeakenPercentage"     type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <xs:element name="Reasons" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Agree" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Reason" minOccurs="1" maxOccurs="unbounded" type="ReasonType"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="Disagree" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Reason" minOccurs="1" maxOccurs="unbounded" type="ReasonType"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- ═══ Argument edges (reason → conclusion) ═══ -->
+  <xs:complexType name="SupportingArgumentType">
+    <xs:sequence>
+      <xs:element name="ArgumentID"           type="xs:string" minOccurs="0"/>
+      <xs:element name="ConclusionID"         type="xs:string"/>
+      <xs:element name="SupportingArgumentID" type="xs:string"/>
+      <xs:element name="LinkageScore"    type="xs:decimal" minOccurs="0"/>
+      <xs:element name="ImportanceScore" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="UniquenessScore" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="PropagatedScore" type="xs:decimal" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="WeakeningArgumentType">
+    <xs:sequence>
+      <xs:element name="ArgumentID"          type="xs:string" minOccurs="0"/>
+      <xs:element name="ConclusionID"        type="xs:string"/>
+      <xs:element name="WeakeningArgumentID" type="xs:string"/>
+      <xs:element name="LinkageScore"    type="xs:decimal" minOccurs="0"/>
+      <xs:element name="ImportanceScore" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="UniquenessScore" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="PropagatedScore" type="xs:decimal" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="LinkType">
+    <xs:sequence>
+      <xs:element name="LinkID"               type="xs:string"/>
+      <xs:element name="IfThisBeliefWereTrueID" type="xs:string"/>
+      <xs:element name="AffectedBeliefID"     type="xs:string"/>
+      <!-- Supporting | Weakening -->
+      <xs:element name="LinkType"             type="xs:string"/>
+      <xs:element name="JustificationText"    type="xs:string" minOccurs="0"/>
+      <xs:element name="OtherNecessaryLinkBeliefIDs" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="BeliefID" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- ═══ Structured fallacy claims ═══
+       Mirrors the FallacyClaim / FallacyClaimVote tables: the six required
+       template fields, the consensus state, and the weighted votes. Filing
+       never changes a score; Status moves only by weighted community
+       consensus (>= 60%, quorum 3). -->
+  <xs:complexType name="FallacyClaimType">
+    <xs:sequence>
+      <xs:element name="FallacyClaimID"   type="xs:string" minOccurs="0"/>
+      <!-- The accused edge: ConclusionID + ArgumentID identify it. -->
+      <xs:element name="TargetConclusionID" type="xs:string"/>
+      <xs:element name="TargetArgumentID"   type="xs:string"/>
+      <!-- Catalog slug, e.g. false-dilemma, straw-man, cherry-picking. -->
+      <xs:element name="FallacyType"  type="xs:string"/>
+      <!-- relevance | logical-validity | evidence-quality -->
+      <xs:element name="TargetFactor" type="xs:string"/>
+      <!-- minor | major -->
+      <xs:element name="Severity"     type="xs:string"/>
+      <!-- The six-field accusation template (all required to file). -->
+      <xs:element name="QuotedText"      type="xs:string"/>
+      <xs:element name="Explanation"     type="xs:string"/>
+      <xs:element name="MissingElements" type="xs:string"/>
+      <xs:element name="EvidenceLinks" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="EvidenceLink" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Label"      type="xs:string"/>
+                  <xs:element name="Url"        type="xs:string" minOccurs="0"/>
+                  <xs:element name="BeliefSlug" type="xs:string" minOccurs="0"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Consequences" type="xs:string"/>
+      <!-- open | confirmed | rejected -->
+      <xs:element name="Status"    type="xs:string"/>
+      <!-- Weighted agreement share at last resolution (0-1). -->
+      <xs:element name="Consensus" type="xs:decimal" minOccurs="0"/>
+      <xs:element name="Votes" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Vote" minOccurs="0" maxOccurs="unbounded" type="WeightedVoteType"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- ═══ Grouping candidates (same claim, different words) ═══
+       Mirrors EquivalenceCandidate / GroupingVote: the redundancy scan
+       proposes the pair; the community vote settles it. -->
+  <xs:complexType name="GroupingCandidateType">
+    <xs:sequence>
+      <xs:element name="CandidateID"        type="xs:string" minOccurs="0"/>
+      <xs:element name="NewArgumentID"      type="xs:string"/>
+      <xs:element name="ExistingArgumentID" type="xs:string"/>
+      <xs:element name="Similarity"         type="xs:decimal"/>
+      <!-- same-claim | probable-group | related-link | distinct -->
+      <xs:element name="Band"               type="xs:string" minOccurs="0"/>
+      <!-- open | grouped | kept-separate -->
+      <xs:element name="Status"             type="xs:string"/>
+      <xs:element name="Consensus"          type="xs:decimal" minOccurs="0"/>
+      <xs:element name="Votes" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Vote" minOccurs="0" maxOccurs="unbounded" type="WeightedVoteType"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- One weighted community vote. Weight is the voter's caller-credibility
+       multiplier (accuracy × cross-partisan balance, clamped to [0.3, 1.4]),
+       computed from their track record — never submitted. -->
+  <xs:complexType name="WeightedVoteType">
+    <xs:sequence>
+      <xs:element name="UserID"    type="xs:string"/>
+      <xs:element name="Agree"     type="xs:boolean"/>
+      <xs:element name="Weight"    type="xs:decimal" minOccurs="0"/>
+      <xs:element name="Reasoning" type="xs:string"  minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
 
   <!-- ═══ Equivalence Analysis Document ═══ -->
   <xs:element name="EquivalenceAnalysisDocument">

--- a/src/core/schemas/belief-html.converter.xslt
+++ b/src/core/schemas/belief-html.converter.xslt
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Renders a BeliefAnalysis document (belief-data.schema.xsd) to HTML.
+     The XML is the source of truth; this output is a render, never edited.
+     Worked example input: belief-outline-data.xml. -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:template match="/BeliefAnalysis">
@@ -23,6 +26,9 @@
                     border: 1px solid black;
                     padding: 5px;
                 }
+                .status-confirmed { color: #7f1d1d; font-weight: bold; }
+                .status-rejected { color: #4b5563; }
+                .status-open { color: #92400e; }
             </style>
         </head>
         <body>
@@ -74,49 +80,117 @@
 
                     <div class="table-container">
                         <!-- Reasons to Agree Table -->
-                        <xsl:if test="/BeliefAnalysis/Arguments/Argument[ConclusionID=current()/BeliefID and ArgumentType='Supporting']">
+                        <xsl:if test="/BeliefAnalysis/Arguments/SupportingArgument[ConclusionID=current()/BeliefID]">
                             <table class="belief-table">
                                 <caption>Reasons to Agree</caption>
                                 <tr>
                                     <th>Statement</th>
-                                    <th>Score</th>
+                                    <th>Impact</th>
                                     <th>Linkage</th>
+                                    <th>Uniqueness</th>
                                 </tr>
-                                <xsl:for-each select="/BeliefAnalysis/Arguments/Argument[ConclusionID=current()/BeliefID and ArgumentType='Supporting']">
-                                    <xsl:variable name="argID" select="ArgumentID"/>
+                                <xsl:for-each select="/BeliefAnalysis/Arguments/SupportingArgument[ConclusionID=current()/BeliefID]">
+                                    <xsl:sort select="PropagatedScore" data-type="number" order="descending"/>
+                                    <xsl:variable name="argID" select="SupportingArgumentID"/>
                                     <xsl:variable name="linkedBelief" select="/BeliefAnalysis/Beliefs/Belief[BeliefID = $argID]"/>
                                     <tr>
                                         <td><xsl:value-of select="$linkedBelief/Statement"/></td>
-                                        <td><xsl:value-of select="$linkedBelief/Score"/></td>
+                                        <td><xsl:value-of select="PropagatedScore"/></td>
                                         <td><xsl:value-of select="LinkageScore"/></td>
+                                        <td><xsl:value-of select="UniquenessScore"/></td>
                                     </tr>
                                 </xsl:for-each>
                             </table>
                         </xsl:if>
 
                         <!-- Reasons to Disagree Table -->
-                        <xsl:if test="/BeliefAnalysis/Arguments/Argument[ConclusionID=current()/BeliefID and ArgumentType='Weakening']">
+                        <xsl:if test="/BeliefAnalysis/Arguments/WeakeningArgument[ConclusionID=current()/BeliefID]">
                             <table class="belief-table">
                                 <caption>Reasons to Disagree</caption>
                                 <tr>
                                     <th>Statement</th>
-                                    <th>Score</th>
+                                    <th>Impact</th>
                                     <th>Linkage</th>
+                                    <th>Uniqueness</th>
                                 </tr>
-                                <xsl:for-each select="/BeliefAnalysis/Arguments/Argument[ConclusionID=current()/BeliefID and ArgumentType='Weakening']">
-                                    <xsl:variable name="argID" select="ArgumentID"/>
+                                <xsl:for-each select="/BeliefAnalysis/Arguments/WeakeningArgument[ConclusionID=current()/BeliefID]">
+                                    <xsl:sort select="PropagatedScore" data-type="number" order="descending"/>
+                                    <xsl:variable name="argID" select="WeakeningArgumentID"/>
                                     <xsl:variable name="linkedBelief" select="/BeliefAnalysis/Beliefs/Belief[BeliefID = $argID]"/>
                                     <tr>
                                         <td><xsl:value-of select="$linkedBelief/Statement"/></td>
-                                        <td><xsl:value-of select="$linkedBelief/Score"/></td>
+                                        <td><xsl:value-of select="PropagatedScore"/></td>
                                         <td><xsl:value-of select="LinkageScore"/></td>
+                                        <td><xsl:value-of select="UniquenessScore"/></td>
                                     </tr>
                                 </xsl:for-each>
                             </table>
                         </xsl:if>
                     </div>
+
+                    <!-- Fallacy Claims against this belief's argument edges.
+                         An accusation is an argument: it shows its full
+                         template and its consensus state. Only "confirmed"
+                         claims have touched any score. -->
+                    <xsl:if test="/BeliefAnalysis/FallacyClaims/FallacyClaim[TargetConclusionID=current()/BeliefID]">
+                        <h4>⚖️ Fallacy Claims</h4>
+                        <table class="belief-table" style="width:100%">
+                            <tr>
+                                <th>Type</th>
+                                <th>Quoted Text</th>
+                                <th>What&#8217;s Missing</th>
+                                <th>Status</th>
+                                <th>Consensus</th>
+                            </tr>
+                            <xsl:for-each select="/BeliefAnalysis/FallacyClaims/FallacyClaim[TargetConclusionID=current()/BeliefID]">
+                                <tr>
+                                    <td>
+                                        <xsl:value-of select="FallacyType"/>
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:value-of select="Severity"/>
+                                        <xsl:text> &#8594; </xsl:text>
+                                        <xsl:value-of select="TargetFactor"/>
+                                        <xsl:text>)</xsl:text>
+                                    </td>
+                                    <td><xsl:value-of select="QuotedText"/></td>
+                                    <td><xsl:value-of select="MissingElements"/></td>
+                                    <td>
+                                        <span class="status-{Status}"><xsl:value-of select="Status"/></span>
+                                    </td>
+                                    <td><xsl:value-of select="Consensus"/></td>
+                                </tr>
+                            </xsl:for-each>
+                        </table>
+                    </xsl:if>
                 </div>
             </xsl:for-each>
+
+            <!-- Grouped restatements: same claim, different words, settled
+                 by community vote. Grouped rows are priced by the
+                 uniqueness discount instead of counting twice. -->
+            <xsl:if test="GroupingCandidates/Candidate">
+                <h4>🔗 Grouping Candidates</h4>
+                <table class="belief-table" style="width:100%">
+                    <tr>
+                        <th>New Argument</th>
+                        <th>Existing Argument</th>
+                        <th>Similarity</th>
+                        <th>Band</th>
+                        <th>Status</th>
+                        <th>Consensus</th>
+                    </tr>
+                    <xsl:for-each select="GroupingCandidates/Candidate">
+                        <tr>
+                            <td><xsl:value-of select="NewArgumentID"/></td>
+                            <td><xsl:value-of select="ExistingArgumentID"/></td>
+                            <td><xsl:value-of select="Similarity"/></td>
+                            <td><xsl:value-of select="Band"/></td>
+                            <td><xsl:value-of select="Status"/></td>
+                            <td><xsl:value-of select="Consensus"/></td>
+                        </tr>
+                    </xsl:for-each>
+                </table>
+            </xsl:if>
         </body>
     </html>
 </xsl:template>

--- a/src/core/schemas/belief-outline-data.xml
+++ b/src/core/schemas/belief-outline-data.xml
@@ -1,64 +1,268 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="belief-html.converter.xslt"?>
+<!--
+  Worked example of the belief-analysis data model (belief-data.schema.xsd).
+
+  This is the same normalized graph the live app stores via Prisma
+  (prisma/schema.prisma) and the pipeline emits (pipeline/generators/
+  xml_generator.py): Belief NODES carry engine-computed scores; Argument
+  EDGES join a reason to its conclusion with linkage / importance /
+  uniqueness weights; FallacyClaims are structured accusations against an
+  edge; GroupingCandidates are same-claim pairs settled by community vote.
+
+  How the code interacts with this data:
+    - POST /api/beliefs/[id]/arguments        adds a node + edge (no scores
+      accepted: the engine computes them and propagates upward)
+    - POST /api/arguments/[id]/fallacy-claims files a FallacyClaim (all six
+      template fields required; filing changes no score)
+    - POST /api/fallacy-claims/[id]/votes     weighted community vote; at
+      >= 60% agreement the claim is confirmed and its counter-argument is
+      published into the linkage sub-debate, then scores propagate
+    - POST /api/equivalence-candidates/[id]/votes settles a grouping pair
+      the same way (grouped / kept-separate)
+
+  Every score below is engine output (audit-locked): edit the graph, never
+  the numbers. The worked numbers mirror the fallacy ladder: the same
+  evidence argued WITH a confirmed false dilemma propagates 0.80 x 0.45 x
+  0.85 = 0.306; repaired without it, 0.80 x 0.90 x 0.85 = 0.612.
+-->
 <BeliefAnalysis>
   <Beliefs>
     <Belief>
       <BeliefID>1</BeliefID>
-      <Statement>Global Warming is largely caused by humans</Statement>
-      <!--"Score" is calculated in the xslt. It is the supporting sub-scores minus the weakening sub-scores (e.g., reasons, evidnece, up-votes,etc) -->
+      <Statement>Climate change requires an urgent, significant policy response</Statement>
+      <Category>Environment</Category>
+      <Subcategory>Climate policy</Subcategory>
+      <Side>root</Side>
+      <TruthScore>0.7200</TruthScore>
+      <ReasonRank>0.681000</ReasonRank>
+      <PropagatedScore>0.681000</PropagatedScore>
+      <EvidenceType>T1</EvidenceType>
     </Belief>
     <Belief>
       <BeliefID>2</BeliefID>
-      <Statement>We Should Tax the production of carbon</Statement>
+      <Statement>Either we drastically reduce emissions immediately or we face catastrophic climate change</Statement>
+      <Category>Environment</Category>
+      <Subcategory>Climate policy</Subcategory>
+      <ParentID>1</ParentID>
+      <Side>supporting</Side>
+      <TruthScore>0.8000</TruthScore>
+      <LinkageScore>0.8500</LinkageScore>
+      <ImportanceScore>1.0000</ImportanceScore>
+      <UniquenessScore>1.0000</UniquenessScore>
+      <ReasonRank>0.360000</ReasonRank>
+      <!-- 0.80 truth x 0.45 validity (confirmed major fallacy) x 0.85 linkage -->
+      <PropagatedScore>0.306000</PropagatedScore>
+      <EvidenceType>T1</EvidenceType>
     </Belief>
     <Belief>
       <BeliefID>3</BeliefID>
-      <Statement>We should tax the use of carbon</Statement>
+      <Statement>Urgent, significant emissions reductions are needed to avoid the worst climate outcomes</Statement>
+      <Category>Environment</Category>
+      <Subcategory>Climate policy</Subcategory>
+      <ParentID>1</ParentID>
+      <Side>supporting</Side>
+      <TruthScore>0.8000</TruthScore>
+      <LinkageScore>0.8500</LinkageScore>
+      <ImportanceScore>1.0000</ImportanceScore>
+      <UniquenessScore>0.9000</UniquenessScore>
+      <ReasonRank>0.720000</ReasonRank>
+      <!-- Same evidence, fallacy removed: 0.80 x 0.90 x 0.85 -->
+      <PropagatedScore>0.612000</PropagatedScore>
+      <EvidenceType>T1</EvidenceType>
     </Belief>
     <Belief>
       <BeliefID>4</BeliefID>
-      <Statement>Global warming is a problem</Statement>
+      <Statement>IPCC AR6 outlines multiple emission pathways with materially different outcomes</Statement>
+      <Category>Environment</Category>
+      <Subcategory>Climate science</Subcategory>
+      <ParentID>3</ParentID>
+      <Side>supporting</Side>
+      <TruthScore>0.9500</TruthScore>
+      <LinkageScore>0.9000</LinkageScore>
+      <ImportanceScore>0.8000</ImportanceScore>
+      <UniquenessScore>1.0000</UniquenessScore>
+      <ReasonRank>0.950000</ReasonRank>
+      <PropagatedScore>0.684000</PropagatedScore>
+      <SourceUrl>https://www.ipcc.ch/report/ar6/syr/</SourceUrl>
+      <EvidenceType>T1</EvidenceType>
     </Belief>
     <Belief>
       <BeliefID>5</BeliefID>
-      <Statement>We can address global warming with more benefits and fewer costs than ignoring it</Statement>
+      <Statement>Natural variability accounts for most of the recent observed warming</Statement>
+      <Category>Environment</Category>
+      <Subcategory>Climate science</Subcategory>
+      <ParentID>1</ParentID>
+      <Side>weakening</Side>
+      <TruthScore>0.2000</TruthScore>
+      <LinkageScore>0.6000</LinkageScore>
+      <ImportanceScore>0.7000</ImportanceScore>
+      <UniquenessScore>1.0000</UniquenessScore>
+      <ReasonRank>0.200000</ReasonRank>
+      <PropagatedScore>0.084000</PropagatedScore>
+      <EvidenceType>T3</EvidenceType>
     </Belief>
     <Belief>
       <BeliefID>6</BeliefID>
-        <Statement>Taxing things, such as carbon, usually reduces its production. The market is usually rational; if carbon is more expensive, people and companies will avoid producing it.</Statement>
+      <Statement>We must cut emissions right away or face climate disaster</Statement>
+      <Category>Environment</Category>
+      <Subcategory>Climate policy</Subcategory>
+      <ParentID>1</ParentID>
+      <Side>supporting</Side>
+      <TruthScore>0.8000</TruthScore>
+      <LinkageScore>0.8500</LinkageScore>
+      <ImportanceScore>1.0000</ImportanceScore>
+      <!-- Restatement of belief 2: grouped by community vote, so the
+           uniqueness discount prices away nearly all of its weight. -->
+      <UniquenessScore>0.1300</UniquenessScore>
+      <ReasonRank>0.360000</ReasonRank>
+      <PropagatedScore>0.039780</PropagatedScore>
+      <EvidenceType>T1</EvidenceType>
     </Belief>
-    <Belief>
-      <BeliefID>7</BeliefID>
-      <Statement>Scientific studies show a significant correlation between human activities and global temperature rise.</Statement>
-      <Score>8.5</Score>
-    </Belief>
-      <BeliefID>8</BeliefID>
-      <Statement>Some climatologists argue that natural factors play a more significant role in global warming.</Statement>
-     <Score>8.5</Score>
-    <!-- Additional beliefs... -->
   </Beliefs>
-<Arguments>
-  <SupportingArgument>
-    <ConclusionID>1</ConclusionID>
-    <SupportingArgumentID>7</SupportingArgumentID>
-    <LinkageScore>50</LinkageScore>
-  </SupportingArgument>
-  <WeakeningArgument>
-     <ConclusionID>1</ConclusionID>
-     <WeakeningArgumentID>8</WeakeningArgumentID>
-     <LinkageScore>40</LinkageScore>
-  </WeakeningArgument>
-</Arguments>
-<Links>
-  <Link>
-    <LinkID>1</LinkID>
-    <IfThisBeliefWereTrueID>1</IfThisBeliefWereTrueID>
-    <AffectedBeliefID>2</AffectedBeliefID>
-    <LinkType>Supporting</LinkType>
-    <JustificationText>Taxing things, such as carbon, usually reduces its production. The market is usually rational; if carbon is more expensive, people and companies will avoid producing it.</JustificationText>
-    <OtherNecessaryLinkBeliefIDs>
-      <BeliefID>4</BeliefID>
-      <BeliefID>5</BeliefID>
-    </OtherNecessaryLinkBeliefIDs>
-   </Link>
+
+  <Arguments>
+    <SupportingArgument>
+      <ArgumentID>A1</ArgumentID>
+      <ConclusionID>1</ConclusionID>
+      <SupportingArgumentID>2</SupportingArgumentID>
+      <LinkageScore>0.8500</LinkageScore>
+      <ImportanceScore>1.0000</ImportanceScore>
+      <UniquenessScore>1.0000</UniquenessScore>
+      <PropagatedScore>0.306000</PropagatedScore>
+    </SupportingArgument>
+    <SupportingArgument>
+      <ArgumentID>A2</ArgumentID>
+      <ConclusionID>1</ConclusionID>
+      <SupportingArgumentID>3</SupportingArgumentID>
+      <LinkageScore>0.8500</LinkageScore>
+      <ImportanceScore>1.0000</ImportanceScore>
+      <UniquenessScore>0.9000</UniquenessScore>
+      <PropagatedScore>0.612000</PropagatedScore>
+    </SupportingArgument>
+    <SupportingArgument>
+      <ArgumentID>A3</ArgumentID>
+      <ConclusionID>3</ConclusionID>
+      <SupportingArgumentID>4</SupportingArgumentID>
+      <LinkageScore>0.9000</LinkageScore>
+      <ImportanceScore>0.8000</ImportanceScore>
+      <UniquenessScore>1.0000</UniquenessScore>
+      <PropagatedScore>0.684000</PropagatedScore>
+    </SupportingArgument>
+    <WeakeningArgument>
+      <ArgumentID>A4</ArgumentID>
+      <ConclusionID>1</ConclusionID>
+      <WeakeningArgumentID>5</WeakeningArgumentID>
+      <LinkageScore>0.6000</LinkageScore>
+      <ImportanceScore>0.7000</ImportanceScore>
+      <UniquenessScore>1.0000</UniquenessScore>
+      <PropagatedScore>0.084000</PropagatedScore>
+    </WeakeningArgument>
+    <SupportingArgument>
+      <ArgumentID>A5</ArgumentID>
+      <ConclusionID>1</ConclusionID>
+      <SupportingArgumentID>6</SupportingArgumentID>
+      <LinkageScore>0.8500</LinkageScore>
+      <ImportanceScore>1.0000</ImportanceScore>
+      <UniquenessScore>0.1300</UniquenessScore>
+      <PropagatedScore>0.039780</PropagatedScore>
+    </SupportingArgument>
+  </Arguments>
+
+  <Links>
+    <Link>
+      <LinkID>1</LinkID>
+      <IfThisBeliefWereTrueID>4</IfThisBeliefWereTrueID>
+      <AffectedBeliefID>2</AffectedBeliefID>
+      <LinkType>Weakening</LinkType>
+      <JustificationText>If IPCC AR6 outlines multiple pathways with different outcomes, then "either drastic action or catastrophe" excludes real alternatives.</JustificationText>
+      <OtherNecessaryLinkBeliefIDs>
+        <BeliefID>1</BeliefID>
+      </OtherNecessaryLinkBeliefIDs>
+    </Link>
   </Links>
+
+  <FallacyClaims>
+    <FallacyClaim>
+      <FallacyClaimID>FC1</FallacyClaimID>
+      <TargetConclusionID>1</TargetConclusionID>
+      <TargetArgumentID>A1</TargetArgumentID>
+      <FallacyType>false-dilemma</FallacyType>
+      <TargetFactor>logical-validity</TargetFactor>
+      <Severity>major</Severity>
+      <QuotedText>Either we drastically reduce emissions immediately or we face catastrophic climate change</QuotedText>
+      <Explanation>Presents two extreme options when many intermediate paths exist: gradual reduction over decades, adaptation alongside mitigation, technological options such as carbon capture, and policy mixes rather than all-or-nothing.</Explanation>
+      <MissingElements>Gradual emission-reduction pathways; adaptation strategies; carbon capture scale-up; hybrid policy portfolios.</MissingElements>
+      <EvidenceLinks>
+        <EvidenceLink>
+          <Label>IPCC AR6 emission scenarios (T1)</Label>
+          <Url>https://www.ipcc.ch/report/ar6/syr/</Url>
+          <BeliefSlug>ipcc-ar6-outlines-multiple-emission-pathways</BeliefSlug>
+        </EvidenceLink>
+        <EvidenceLink>
+          <Label>National adaptation programs in progress (T2)</Label>
+        </EvidenceLink>
+      </EvidenceLinks>
+      <Consequences>Polarizes the debate and excludes middle-ground solutions that may be more feasible; if confirmed, logical validity falls to the major-fallacy rung (0.45).</Consequences>
+      <Status>confirmed</Status>
+      <Consensus>0.7800</Consensus>
+      <Votes>
+        <Vote>
+          <UserID>user-a</UserID>
+          <Agree>true</Agree>
+          <Weight>1.31</Weight>
+          <Reasoning>AR6 lists multiple pathways between "drastic now" and "catastrophe"; the binary is false.</Reasoning>
+        </Vote>
+        <Vote>
+          <UserID>user-b</UserID>
+          <Agree>true</Agree>
+          <Weight>1.05</Weight>
+          <Reasoning>Adaptation programs are a real excluded alternative.</Reasoning>
+        </Vote>
+        <Vote>
+          <UserID>user-c</UserID>
+          <Agree>false</Agree>
+          <!-- Tribal track record (one-sided flags, 40% accuracy): weight reduced. -->
+          <Weight>0.34</Weight>
+          <Reasoning>The science says act now; urgency justifies the framing.</Reasoning>
+        </Vote>
+        <Vote>
+          <UserID>user-d</UserID>
+          <Agree>true</Agree>
+          <Weight>1.00</Weight>
+        </Vote>
+      </Votes>
+    </FallacyClaim>
+  </FallacyClaims>
+
+  <GroupingCandidates>
+    <Candidate>
+      <CandidateID>GC1</CandidateID>
+      <NewArgumentID>A5</NewArgumentID>
+      <ExistingArgumentID>A1</ExistingArgumentID>
+      <Similarity>0.8700</Similarity>
+      <Band>probable-group</Band>
+      <Status>grouped</Status>
+      <Consensus>0.8300</Consensus>
+      <Votes>
+        <Vote>
+          <UserID>user-a</UserID>
+          <Agree>true</Agree>
+          <Weight>1.31</Weight>
+          <Reasoning>Same claim, same evidence, different words. One page per claim.</Reasoning>
+        </Vote>
+        <Vote>
+          <UserID>user-d</UserID>
+          <Agree>true</Agree>
+          <Weight>1.00</Weight>
+        </Vote>
+        <Vote>
+          <UserID>user-e</UserID>
+          <Agree>false</Agree>
+          <Weight>1.00</Weight>
+          <Reasoning>"Right away" is a timing claim, not just a restatement.</Reasoning>
+        </Vote>
+      </Votes>
+    </Candidate>
+  </GroupingCandidates>
 </BeliefAnalysis>

--- a/src/lib/agent-ingest/fallacy-detector.ts
+++ b/src/lib/agent-ingest/fallacy-detector.ts
@@ -7,8 +7,15 @@
 //
 // Deliberately returns NO numeric fields: the invariant "fallacy detection
 // changes zero score fields" is enforced by this module's shape.
+//
+// Every fallacyType here is a slug in the canonical catalog
+// (src/lib/fallacy/catalog.ts), which also backs the structured accusation
+// template humans file. targetFactor is resolved from the catalog so the
+// two paths can never disagree about what a given fallacy damages.
 
-export type FallacyTargetFactor = 'relevance' | 'logical-validity' | 'evidence-quality'
+import { catalogEntry, type FallacyTargetFactor } from '@/lib/fallacy/catalog'
+
+export type { FallacyTargetFactor }
 
 export interface FallacyDetection {
   fallacyType: string
@@ -21,7 +28,6 @@ export interface FallacyDetection {
 
 interface DetectorRule {
   fallacyType: string
-  targetFactor: FallacyTargetFactor
   pattern: RegExp
   counter: (match: string) => string
 }
@@ -29,7 +35,6 @@ interface DetectorRule {
 const RULES: DetectorRule[] = [
   {
     fallacyType: 'ad-hominem',
-    targetFactor: 'relevance',
     pattern: /\b(liar|liars|idiot|idiots|stupid|corrupt|dishonest|evil|fraud|frauds|shill|shills|crook|crooks)\b/i,
     counter: match =>
       `This argument attacks the source's character ("${match}") rather than the claim. ` +
@@ -37,7 +42,6 @@ const RULES: DetectorRule[] = [
   },
   {
     fallacyType: 'appeal-to-popularity',
-    targetFactor: 'relevance',
     pattern: /\b(everyone knows|everybody knows|most people (?:agree|believe|think)|nobody (?:believes|thinks|doubts)|it is widely believed)\b/i,
     counter: match =>
       `This argument appeals to popularity ("${match}"). How many people hold a belief is not ` +
@@ -45,7 +49,6 @@ const RULES: DetectorRule[] = [
   },
   {
     fallacyType: 'false-cause',
-    targetFactor: 'logical-validity',
     pattern: /\bcorrelat\w+\b[^.]*\b(caus\w+|proves?|proof)\b|\b(caus\w+|proves?|proof)\b[^.]*\bcorrelat\w+\b/i,
     counter: match =>
       `This argument treats correlation as causation ("${match.trim()}"). The stated relationship ` +
@@ -53,7 +56,6 @@ const RULES: DetectorRule[] = [
   },
   {
     fallacyType: 'overgeneralization',
-    targetFactor: 'logical-validity',
     pattern: /\b(always|never|without exception|in every case)\b/i,
     counter: match =>
       `This argument asserts a universal ("${match}"). A single counterexample falsifies a ` +
@@ -61,7 +63,6 @@ const RULES: DetectorRule[] = [
   },
   {
     fallacyType: 'cherry-picking',
-    targetFactor: 'evidence-quality',
     pattern: /\b(one study|a single (?:study|case|example)|the only (?:study|evidence)|one survey)\b/i,
     counter: match =>
       `This argument rests on an isolated source ("${match}"). Evidence quality depends on the ` +
@@ -69,7 +70,6 @@ const RULES: DetectorRule[] = [
   },
   {
     fallacyType: 'anecdotal-evidence',
-    targetFactor: 'evidence-quality',
     pattern: /\b(i know (?:a|someone)|my (?:friend|uncle|aunt|neighbor|cousin)|personal experience)\b/i,
     counter: match =>
       `This argument offers an anecdote ("${match}") as evidence. Anecdotes are T4 sources; ` +
@@ -89,9 +89,11 @@ export function detectFallacies(text: string): FallacyDetection[] {
     const match = text.match(rule.pattern)
     if (match) {
       const matched = match[0]
+      const entry = catalogEntry(rule.fallacyType)
+      if (!entry) continue
       detections.push({
         fallacyType: rule.fallacyType,
-        targetFactor: rule.targetFactor,
+        targetFactor: entry.targetFactor,
         counterStatement: rule.counter(matched),
         matchedText: matched,
       })

--- a/src/lib/agent-ingest/similarity.ts
+++ b/src/lib/agent-ingest/similarity.ts
@@ -63,3 +63,26 @@ export const EQUIVALENCE_CANDIDATE_THRESHOLD = 0.5
  *  overlap remains). Anti-topic-drift: restating stops counting as
  *  contributing. */
 export const RESTATEMENT_SPEEDBUMP_THRESHOLD = 0.8
+
+/** At or above this, two statements read as the same claim in different
+ *  words: the pair goes straight to the community grouping vote as the
+ *  presumptive merge. */
+export const SAME_CLAIM_THRESHOLD = 0.95
+
+// ── Similarity bands ──────────────────────────────────────────────────────
+// What each range of textSimilarity means for the one-page-per-claim rule.
+// The bands route; the community vote (GroupingVote, 60% weighted consensus)
+// decides. No band auto-merges anything.
+
+export type SimilarityBand =
+  | 'same-claim' // ≥ 0.95: same claim, propose grouping
+  | 'probable-group' // ≥ 0.8: restatement speed bump + grouping vote
+  | 'related-link' // ≥ 0.5: candidate row — link the cluster, don't group
+  | 'distinct' // below: different claims
+
+export function similarityBand(similarity: number): SimilarityBand {
+  if (similarity >= SAME_CLAIM_THRESHOLD) return 'same-claim'
+  if (similarity >= RESTATEMENT_SPEEDBUMP_THRESHOLD) return 'probable-group'
+  if (similarity >= EQUIVALENCE_CANDIDATE_THRESHOLD) return 'related-link'
+  return 'distinct'
+}

--- a/src/lib/consensus.ts
+++ b/src/lib/consensus.ts
@@ -1,0 +1,59 @@
+// Weighted community consensus, shared by every "the community decides"
+// resolution: fallacy claims (confirm/reject) and equivalence candidates
+// (group/keep separate). An accusation or merge proposal changes nothing on
+// its own — it must win a weighted vote at the threshold below. Weights let
+// calibrated contributors count more than tribal ones; the weights themselves
+// come from track records, never from filing volume.
+
+export interface ConsensusVote {
+  agree: boolean
+  weight: number
+}
+
+export interface ConsensusOptions {
+  /** Weighted share required to settle in either direction. */
+  threshold?: number
+  /** Minimum number of votes before anything settles. */
+  quorum?: number
+}
+
+export type ConsensusOutcome = 'upheld' | 'rejected' | 'open'
+
+export interface ConsensusResult {
+  outcome: ConsensusOutcome
+  /** Weighted agreement share in [0,1]; null when there are no votes. */
+  agreeShare: number | null
+  voteCount: number
+  totalWeight: number
+}
+
+/** The essay's bar: 60% weighted agreement settles a claim. */
+export const CONSENSUS_THRESHOLD = 0.6
+/** Below this many votes nothing settles, whatever the share says. */
+export const CONSENSUS_QUORUM = 3
+
+export function resolveConsensus(
+  votes: ConsensusVote[],
+  options: ConsensusOptions = {},
+): ConsensusResult {
+  const threshold = options.threshold ?? CONSENSUS_THRESHOLD
+  const quorum = options.quorum ?? CONSENSUS_QUORUM
+
+  let agreeWeight = 0
+  let totalWeight = 0
+  for (const vote of votes) {
+    const weight = Number.isFinite(vote.weight) && vote.weight > 0 ? vote.weight : 0
+    totalWeight += weight
+    if (vote.agree) agreeWeight += weight
+  }
+
+  const agreeShare = totalWeight > 0 ? agreeWeight / totalWeight : null
+
+  let outcome: ConsensusOutcome = 'open'
+  if (votes.length >= quorum && agreeShare !== null) {
+    if (agreeShare >= threshold) outcome = 'upheld'
+    else if (1 - agreeShare >= threshold) outcome = 'rejected'
+  }
+
+  return { outcome, agreeShare, voteCount: votes.length, totalWeight }
+}

--- a/src/lib/fallacy/calibration.ts
+++ b/src/lib/fallacy/calibration.ts
@@ -1,0 +1,79 @@
+// Cross-partisan calibration: how much weight a user's fallacy work carries.
+//
+// The tribal failure mode is selective vision — seeing fallacies fluently in
+// the other side's arguments and never in your own. The countermeasure is a
+// track record: accuracy (did the community uphold your past claims?) and
+// balance (do you flag both sides of debates, or only one?). The product of
+// those two factors, clamped, is the credibility multiplier applied to this
+// user's fallacy-claim votes. Filing volume never raises it; only being
+// right and being even-handed do.
+
+export interface CallerRecord {
+  /** Resolved claims the community confirmed. */
+  upheld: number
+  /** Resolved claims the community rejected. */
+  rejected: number
+  /** Claims filed against agree-side arguments (any status). */
+  flaggedAgreeSide: number
+  /** Claims filed against disagree-side arguments (any status). */
+  flaggedDisagreeSide: number
+}
+
+export const CREDIBILITY_FLOOR = 0.3
+export const CREDIBILITY_CEILING = 1.4
+
+/** Below these sample sizes a factor stays neutral (1.0): no penalty and no
+ *  boost until there is enough history to mean anything. */
+export const MIN_RESOLVED_FOR_ACCURACY = 3
+export const MIN_FLAGGED_FOR_BALANCE = 5
+
+// Balance factor is linear in the side ratio: fully one-sided → 0.4, evenly
+// split → 1.3, neutral (1.0) at a ratio of 2:3. +1 smoothing keeps a single
+// early claim from reading as proof of tribalism.
+const BALANCE_FLOOR = 0.4
+const BALANCE_SLOPE = 0.9
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, value))
+}
+
+/** min/max ratio of the two side counts, smoothed; 1 = perfectly balanced. */
+export function sideBalance(record: CallerRecord): number {
+  const a = Math.max(0, record.flaggedAgreeSide)
+  const b = Math.max(0, record.flaggedDisagreeSide)
+  return (Math.min(a, b) + 1) / (Math.max(a, b) + 1)
+}
+
+/** Share of resolved claims the community upheld; null with no history. */
+export function accuracyRate(record: CallerRecord): number | null {
+  const resolved = record.upheld + record.rejected
+  return resolved > 0 ? record.upheld / resolved : null
+}
+
+/**
+ * The credibility multiplier in [0.3, 1.4].
+ *
+ *   multiplier = clamp(accuracyFactor × balanceFactor)
+ *   accuracyFactor = 2 × accuracy   (0.5 accuracy is neutral)
+ *   balanceFactor  = 0.4 + 0.9 × sideBalance
+ *
+ * Anchors from the design essay: a caller with 40% accuracy who flags one
+ * side almost exclusively lands at the floor (severe tribal bias, influence
+ * reduced); a caller with 82% accuracy who flags both sides lands well above
+ * 1 (impartiality raises influence). A new user with no history is exactly
+ * 1.0 — no information, no adjustment.
+ */
+export function callerCredibility(record: CallerRecord): number {
+  const accuracy = accuracyRate(record)
+  const resolved = record.upheld + record.rejected
+  const accuracyFactor =
+    accuracy !== null && resolved >= MIN_RESOLVED_FOR_ACCURACY ? 2 * accuracy : 1
+
+  const totalFlagged = record.flaggedAgreeSide + record.flaggedDisagreeSide
+  const balanceFactor =
+    totalFlagged >= MIN_FLAGGED_FOR_BALANCE
+      ? BALANCE_FLOOR + BALANCE_SLOPE * sideBalance(record)
+      : 1
+
+  return clamp(accuracyFactor * balanceFactor, CREDIBILITY_FLOOR, CREDIBILITY_CEILING)
+}

--- a/src/lib/fallacy/caller-record.ts
+++ b/src/lib/fallacy/caller-record.ts
@@ -1,0 +1,33 @@
+// Database derivation of a user's caller record. Side balance uses which
+// side of its parent debate each accused argument sat on — an observable
+// proxy for the essay's own-position/opposing-position split: a tribal
+// caller flags one side of every debate they enter, and that skew is visible
+// here without asking anyone to declare an ideology.
+
+import { prisma } from '@/lib/prisma'
+import { callerCredibility, type CallerRecord } from './calibration'
+
+export async function callerRecordFor(userId: string): Promise<CallerRecord> {
+  const claims = await prisma.fallacyClaim.findMany({
+    where: { submittedById: userId },
+    select: { status: true, argument: { select: { side: true } } },
+  })
+
+  const record: CallerRecord = {
+    upheld: 0,
+    rejected: 0,
+    flaggedAgreeSide: 0,
+    flaggedDisagreeSide: 0,
+  }
+  for (const claim of claims) {
+    if (claim.status === 'confirmed') record.upheld++
+    else if (claim.status === 'rejected') record.rejected++
+    if (claim.argument.side === 'agree') record.flaggedAgreeSide++
+    else record.flaggedDisagreeSide++
+  }
+  return record
+}
+
+export async function callerCredibilityFor(userId: string): Promise<number> {
+  return callerCredibility(await callerRecordFor(userId))
+}

--- a/src/lib/fallacy/catalog.ts
+++ b/src/lib/fallacy/catalog.ts
@@ -1,0 +1,210 @@
+// The canonical fallacy catalog: one source of truth for every place a
+// fallacy type is named — the automated detector, the structured accusation
+// template, the confirmation ladder, and the explainer page. An accusation
+// must name a catalog entry; the entry decides which score factor a CONFIRMED
+// claim damages and how hard, and what evidence the accusation must carry
+// before it is even accepted as a claim.
+
+export type FallacyTargetFactor = 'relevance' | 'logical-validity' | 'evidence-quality'
+export type FallacySeverity = 'minor' | 'major'
+
+export interface FallacyCatalogEntry {
+  slug: string
+  label: string
+  /** Which factor a confirmed claim damages. Relevance fallacies argue against
+   *  the linkage, formal fallacies against logical validity, evidence
+   *  fallacies against evidence quality. */
+  targetFactor: FallacyTargetFactor
+  /** Drives the logical-validity ladder once confirmed (see claims.ts). */
+  severity: FallacySeverity
+  definition: string
+  /** What a filed claim must demonstrate for the community to confirm it. */
+  detectionCriteria: string[]
+  /** What the evidenceLinks field must contain. When set, an accusation with
+   *  no evidence links is rejected at validation — the accusation is an
+   *  argument, and this type's argument needs exhibits. */
+  evidenceRequirement: string | null
+  /** The honest boundary: when this pattern is NOT a fallacy. */
+  notFallacyWhen?: string
+}
+
+const ENTRIES: FallacyCatalogEntry[] = [
+  {
+    slug: 'false-dilemma',
+    label: 'False Dilemma',
+    targetFactor: 'logical-validity',
+    severity: 'major',
+    definition: 'Presents only two options when more exist.',
+    detectionCriteria: [
+      'Uses either/or framing',
+      'Excludes reasonable middle ground',
+      'The excluded alternatives can be demonstrated to exist',
+    ],
+    evidenceRequirement: 'List the excluded alternatives with evidence they exist.',
+    notFallacyWhen: 'Only two options logically exist (a genuine dichotomy).',
+  },
+  {
+    slug: 'ad-hominem',
+    label: 'Ad Hominem',
+    targetFactor: 'relevance',
+    severity: 'major',
+    definition: 'Attacks the person making the argument instead of the argument.',
+    detectionCriteria: [
+      'Attacks character, motives, or identity',
+      'Does not address the substance',
+      'Implies the argument is wrong because of who said it',
+    ],
+    evidenceRequirement: null,
+    notFallacyWhen: 'A relevant conflict of interest is documented with evidence.',
+  },
+  {
+    slug: 'straw-man',
+    label: 'Straw Man',
+    targetFactor: 'relevance',
+    severity: 'major',
+    definition: "Misrepresents the opponent's position to make it easier to attack.",
+    detectionCriteria: [
+      'Distorts what the opponent said',
+      'Attacks the weakened version',
+      'The discrepancy with the actual position can be shown',
+    ],
+    evidenceRequirement: "Link the opponent's actual stated position showing the discrepancy.",
+  },
+  {
+    slug: 'slippery-slope',
+    label: 'Slippery Slope',
+    targetFactor: 'logical-validity',
+    severity: 'major',
+    definition:
+      'Claims a small step inevitably leads to an extreme outcome without showing the mechanism.',
+    detectionCriteria: [
+      'No causal mechanism for the progression',
+      'Relies on fear of the endpoint',
+      'Each step does not follow from the previous',
+    ],
+    evidenceRequirement: 'Show the missing causal mechanism between the steps.',
+    notFallacyWhen: 'The causal mechanism for each step is demonstrated with evidence.',
+  },
+  {
+    slug: 'appeal-to-authority',
+    label: 'Appeal to Authority (improper)',
+    targetFactor: 'evidence-quality',
+    severity: 'minor',
+    definition:
+      'Treats a claim as settled because an authority said so, outside their expertise or against the body of evidence.',
+    detectionCriteria: [
+      'The cited authority is outside their domain, or',
+      'The authority contradicts the weight of higher-tier evidence',
+    ],
+    evidenceRequirement: null,
+    notFallacyWhen:
+      'Citing a genuine domain expert consistent with the evidence base (that is T2 evidence, not a fallacy).',
+  },
+  {
+    slug: 'cherry-picking',
+    label: 'Cherry Picking / Suppressed Evidence',
+    targetFactor: 'evidence-quality',
+    severity: 'major',
+    definition: 'Cites only favorable evidence while ignoring contradicting evidence.',
+    detectionCriteria: [
+      'Higher-tier contradicting evidence exists',
+      'A pattern of selecting only supportive sources',
+    ],
+    evidenceRequirement: 'Link the contradicting evidence being ignored.',
+  },
+  {
+    slug: 'moving-goalposts',
+    label: 'Moving the Goalposts',
+    targetFactor: 'logical-validity',
+    severity: 'minor',
+    definition: 'Changes the standard of proof after the original standard was met.',
+    detectionCriteria: [
+      'An earlier stated criterion was satisfied',
+      'A new criterion was then substituted without conceding the first',
+    ],
+    evidenceRequirement: 'Quote the earlier criterion and show it was met before the switch.',
+  },
+  {
+    slug: 'whataboutism',
+    label: 'Tu Quoque / Whataboutism',
+    targetFactor: 'relevance',
+    severity: 'minor',
+    definition: "Deflects a charge by pointing at the accuser's conduct instead of answering it.",
+    detectionCriteria: [
+      'Responds to a claim with an unrelated counter-charge',
+      'The counter-charge does not bear on whether the original claim is true',
+    ],
+    evidenceRequirement: null,
+  },
+  {
+    slug: 'post-hoc',
+    label: 'Post Hoc Ergo Propter Hoc',
+    targetFactor: 'logical-validity',
+    severity: 'major',
+    definition: 'Infers causation from mere temporal sequence.',
+    detectionCriteria: [
+      'B followed A is the whole causal case',
+      'Confounders and coincidence are not ruled out',
+    ],
+    evidenceRequirement: null,
+  },
+  {
+    slug: 'hasty-generalization',
+    label: 'Hasty Generalization',
+    targetFactor: 'logical-validity',
+    severity: 'minor',
+    definition: 'Draws a broad conclusion from an unrepresentative sample.',
+    detectionCriteria: [
+      'The sample is small or self-selected',
+      'The conclusion sweeps far beyond what the sample supports',
+    ],
+    evidenceRequirement: null,
+  },
+  // ── Types the automated detector also fires on ──────────────────────────
+  {
+    slug: 'appeal-to-popularity',
+    label: 'Appeal to Popularity',
+    targetFactor: 'relevance',
+    severity: 'minor',
+    definition: 'Treats how many people hold a belief as evidence that it is true.',
+    detectionCriteria: ['"Everyone knows" / "most people agree" carries the argument'],
+    evidenceRequirement: null,
+  },
+  {
+    slug: 'false-cause',
+    label: 'False Cause',
+    targetFactor: 'logical-validity',
+    severity: 'major',
+    definition: 'Treats correlation as causation without ruling out confounders or reverse causation.',
+    detectionCriteria: ['A correlation is presented as proving a causal claim'],
+    evidenceRequirement: null,
+  },
+  {
+    slug: 'overgeneralization',
+    label: 'Overgeneralization',
+    targetFactor: 'logical-validity',
+    severity: 'minor',
+    definition: 'Asserts a universal ("always", "never") that the evidence cannot support.',
+    detectionCriteria: ['Universal quantifier where a single counterexample falsifies the claim'],
+    evidenceRequirement: null,
+  },
+  {
+    slug: 'anecdotal-evidence',
+    label: 'Anecdotal Evidence',
+    targetFactor: 'evidence-quality',
+    severity: 'minor',
+    definition: 'Offers a personal story as if it were systematic evidence.',
+    detectionCriteria: ['An anecdote (T4 source) carries the evidential weight'],
+    evidenceRequirement: null,
+  },
+]
+
+export const FALLACY_CATALOG: ReadonlyMap<string, FallacyCatalogEntry> = new Map(
+  ENTRIES.map(e => [e.slug, e]),
+)
+
+export function catalogEntry(slug: string): FallacyCatalogEntry | undefined {
+  return FALLACY_CATALOG.get(slug)
+}
+
+export const FALLACY_TYPE_SLUGS: readonly string[] = ENTRIES.map(e => e.slug)

--- a/src/lib/fallacy/claims.ts
+++ b/src/lib/fallacy/claims.ts
@@ -1,0 +1,144 @@
+// Structured fallacy claims: the accusation template, the confirmation
+// ladder, and the bridge into the scoring engine.
+//
+// The rule this module enforces is the one the tribal version of fallacy
+// calling breaks: an accusation is an argument, so it carries the same
+// burdens as one. Filing requires every template field; a filed claim
+// changes nothing; only a claim CONFIRMED by weighted community consensus
+// (src/lib/consensus.ts) touches the target — and then only through the
+// catalog's target factor for that fallacy type.
+
+import type { DetectedFallacy } from '@/core/types/schlicht'
+import { catalogEntry, type FallacyCatalogEntry, type FallacySeverity } from './catalog'
+
+export interface FallacyEvidenceLink {
+  label: string
+  url?: string
+  beliefSlug?: string
+}
+
+/** The six required template fields. Matches the FallacyClaim columns. */
+export interface FallacyClaimInput {
+  fallacyType: string
+  quotedText: string
+  explanation: string
+  missingElements: string
+  evidenceLinks: FallacyEvidenceLink[]
+  consequences: string
+}
+
+export interface FallacyClaimIssue {
+  field: string
+  message: string
+}
+
+const MIN_EXPLANATION_LENGTH = 40
+
+/**
+ * "Can't just click a fallacy button." Every field of the accusation
+ * template must be filled before a claim exists. Returns the full list of
+ * issues so the caller sees everything missing at once.
+ */
+export function validateFallacyClaimInput(input: FallacyClaimInput): FallacyClaimIssue[] {
+  const issues: FallacyClaimIssue[] = []
+
+  const entry = catalogEntry(input.fallacyType)
+  if (!entry) {
+    issues.push({
+      field: 'fallacyType',
+      message: `Unknown fallacy type "${input.fallacyType}". Pick a catalog entry.`,
+    })
+  }
+
+  if (!input.quotedText?.trim()) {
+    issues.push({
+      field: 'quotedText',
+      message: 'Quote the exact text that commits the fallacy.',
+    })
+  }
+  if ((input.explanation?.trim().length ?? 0) < MIN_EXPLANATION_LENGTH) {
+    issues.push({
+      field: 'explanation',
+      message: `Explain why the quote qualifies as this fallacy type (min ${MIN_EXPLANATION_LENGTH} chars).`,
+    })
+  }
+  if (!input.missingElements?.trim()) {
+    issues.push({
+      field: 'missingElements',
+      message: 'Name what is being excluded, misrepresented, or left unsupported.',
+    })
+  }
+  if (!input.consequences?.trim()) {
+    issues.push({
+      field: 'consequences',
+      message: "State how the fallacy affects the argument's validity if confirmed.",
+    })
+  }
+
+  const links = input.evidenceLinks ?? []
+  const emptyLink = links.some(l => !l.label?.trim())
+  if (emptyLink) {
+    issues.push({ field: 'evidenceLinks', message: 'Every evidence link needs a label.' })
+  }
+  if (entry?.evidenceRequirement && links.length === 0) {
+    issues.push({
+      field: 'evidenceLinks',
+      message: `${entry.label} accusations need exhibits: ${entry.evidenceRequirement}`,
+    })
+  }
+
+  return issues
+}
+
+// ── The confirmation ladder ───────────────────────────────────────────────
+// Logical-validity multipliers once claims are CONFIRMED (never before):
+//   no confirmed fallacy → 0.95   one minor → 0.75
+//   one major            → 0.45   two or more confirmed → 0.25
+// The same evidence argued without the fallacy scores HIGHER — removing the
+// fallacy is the profitable move, which is the point.
+
+export const VALIDITY_NO_FALLACY = 0.95
+export const VALIDITY_MINOR = 0.75
+export const VALIDITY_MAJOR = 0.45
+export const VALIDITY_MULTIPLE = 0.25
+
+export function logicalValidityMultiplier(confirmed: { severity: string }[]): number {
+  if (confirmed.length === 0) return VALIDITY_NO_FALLACY
+  if (confirmed.length >= 2) return VALIDITY_MULTIPLE
+  return confirmed[0].severity === 'major' ? VALIDITY_MAJOR : VALIDITY_MINOR
+}
+
+/**
+ * Bridge confirmed claims into the scoring engine's DetectedFallacy shape.
+ * scoreArgument applies truth × (1 − Σ|impact|/100), so the impacts are sized
+ * to land exactly on the ladder's multiplier for the whole set.
+ */
+export function confirmedClaimsToDetectedFallacies(
+  confirmed: { fallacyType: string; severity: string; quotedText: string }[],
+): DetectedFallacy[] {
+  if (confirmed.length === 0) return []
+  const totalPenalty = (1 - logicalValidityMultiplier(confirmed)) * 100
+  const perClaim = totalPenalty / confirmed.length
+  return confirmed.map(c => ({
+    type: c.fallacyType,
+    description: `Confirmed by community consensus: "${c.quotedText}"`,
+    impact: -perClaim,
+  }))
+}
+
+/**
+ * The draft counter-argument a filed claim places into the target's linkage
+ * sub-debate. Draft until the community confirms the claim; published on
+ * confirmation, retired on rejection.
+ */
+export function counterStatementFor(input: FallacyClaimInput, entry: FallacyCatalogEntry): string {
+  return (
+    `${entry.label} claimed: "${input.quotedText}" — ${input.explanation} ` +
+    `Missing: ${input.missingElements}`
+  )
+}
+
+/** Sub-debate weight of a confirmed counter-argument, by severity. */
+export function counterArgumentStrength(severity: FallacySeverity): number {
+  return severity === 'major' ? 0.8 : 0.5
+}

--- a/src/lib/propagate-belief-scores.ts
+++ b/src/lib/propagate-belief-scores.ts
@@ -462,9 +462,18 @@ export async function propagateFromArgumentChange(argumentId: number): Promise<P
  * @param argumentId - The argument whose linkage sub-debate just changed.
  */
 export async function propagateFromLinkageChange(argumentId: number): Promise<PropagationResult> {
+  // Published rows only: draft counter-arguments (detector output, pending
+  // fallacy claims) are stored, not scored — they enter this aggregate the
+  // moment they are published, and never before.
   const arg = await prisma.argument.findUnique({
     where: { id: argumentId },
-    select: { beliefId: true, linkageArguments: { select: { side: true, strength: true } } },
+    select: {
+      beliefId: true,
+      linkageArguments: {
+        where: { status: 'published' },
+        select: { side: true, strength: true },
+      },
+    },
   })
 
   if (!arg) {

--- a/tests/unit/lib/agent-ingest/similarity.test.ts
+++ b/tests/unit/lib/agent-ingest/similarity.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest'
 import {
   textSimilarity,
   normalizeTokens,
+  similarityBand,
   EQUIVALENCE_CANDIDATE_THRESHOLD,
+  RESTATEMENT_SPEEDBUMP_THRESHOLD,
+  SAME_CLAIM_THRESHOLD,
 } from '@/lib/agent-ingest/similarity'
 
 describe('textSimilarity (redundancy scan, stored not scored)', () => {
@@ -25,5 +28,21 @@ describe('textSimilarity (redundancy scan, stored not scored)', () => {
 
   it('normalizes inflections so reworded verbs still collide', () => {
     expect(normalizeTokens('reduces reducing reduced')).toEqual(['reduc', 'reduc', 'reduc'])
+  })
+})
+
+describe('similarityBand (routes pairs; the community vote decides)', () => {
+  it('maps each threshold to its band', () => {
+    expect(similarityBand(1)).toBe('same-claim')
+    expect(similarityBand(SAME_CLAIM_THRESHOLD)).toBe('same-claim')
+    expect(similarityBand(RESTATEMENT_SPEEDBUMP_THRESHOLD)).toBe('probable-group')
+    expect(similarityBand(EQUIVALENCE_CANDIDATE_THRESHOLD)).toBe('related-link')
+    expect(similarityBand(0.49)).toBe('distinct')
+    expect(similarityBand(0)).toBe('distinct')
+  })
+
+  it('keeps the bands ordered: same-claim ⊂ probable-group ⊂ related-link', () => {
+    expect(SAME_CLAIM_THRESHOLD).toBeGreaterThan(RESTATEMENT_SPEEDBUMP_THRESHOLD)
+    expect(RESTATEMENT_SPEEDBUMP_THRESHOLD).toBeGreaterThan(EQUIVALENCE_CANDIDATE_THRESHOLD)
   })
 })

--- a/tests/unit/lib/consensus.test.ts
+++ b/tests/unit/lib/consensus.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { resolveConsensus, CONSENSUS_THRESHOLD, CONSENSUS_QUORUM } from '@/lib/consensus'
+
+const vote = (agree: boolean, weight = 1) => ({ agree, weight })
+
+describe('resolveConsensus (60% weighted, quorum-gated)', () => {
+  it('stays open with no votes', () => {
+    const r = resolveConsensus([])
+    expect(r.outcome).toBe('open')
+    expect(r.agreeShare).toBeNull()
+  })
+
+  it('stays open below quorum even at 100% agreement', () => {
+    const r = resolveConsensus([vote(true), vote(true)])
+    expect(r.voteCount).toBeLessThan(CONSENSUS_QUORUM)
+    expect(r.outcome).toBe('open')
+  })
+
+  it('upholds at the threshold with quorum met', () => {
+    // 3 agree, 2 disagree = 60% exactly
+    const r = resolveConsensus([vote(true), vote(true), vote(true), vote(false), vote(false)])
+    expect(r.agreeShare).toBeCloseTo(CONSENSUS_THRESHOLD)
+    expect(r.outcome).toBe('upheld')
+  })
+
+  it('rejects when disagreement reaches the threshold', () => {
+    const r = resolveConsensus([vote(false), vote(false), vote(false), vote(true), vote(true)])
+    expect(r.outcome).toBe('rejected')
+  })
+
+  it('stays open in the contested middle band', () => {
+    // 5 agree, 4 disagree = 55.6%: neither side reaches 60%
+    const votes = [...Array(5).fill(vote(true)), ...Array(4).fill(vote(false))]
+    const r = resolveConsensus(votes)
+    expect(r.outcome).toBe('open')
+  })
+
+  it('weights votes: calibrated voters can outweigh a larger tribal bloc', () => {
+    // Three coordinated accusers at reduced weight vs two calibrated voters.
+    const votes = [
+      vote(true, 0.3),
+      vote(true, 0.3),
+      vote(true, 0.3),
+      vote(false, 1.4),
+      vote(false, 1.4),
+    ]
+    const r = resolveConsensus(votes)
+    expect(r.outcome).toBe('rejected')
+  })
+
+  it('ignores non-positive and non-finite weights', () => {
+    const votes = [vote(true, -5), vote(true, NaN), vote(false, 1), vote(false, 1), vote(false, 1)]
+    const r = resolveConsensus(votes)
+    expect(r.agreeShare).toBe(0)
+    expect(r.outcome).toBe('rejected')
+  })
+})

--- a/tests/unit/lib/fallacy/calibration.test.ts
+++ b/tests/unit/lib/fallacy/calibration.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import {
+  callerCredibility,
+  sideBalance,
+  accuracyRate,
+  CREDIBILITY_FLOOR,
+  CREDIBILITY_CEILING,
+  type CallerRecord,
+} from '@/lib/fallacy/calibration'
+
+// The two worked examples from the design essay.
+// User X: 40% consensus accuracy, flags one side almost exclusively.
+const tribalCaller: CallerRecord = {
+  upheld: 8,
+  rejected: 12,
+  flaggedAgreeSide: 2,
+  flaggedDisagreeSide: 78,
+}
+// User Y: 82% consensus accuracy, flags both sides.
+const calibratedCaller: CallerRecord = {
+  upheld: 41,
+  rejected: 9,
+  flaggedAgreeSide: 22,
+  flaggedDisagreeSide: 53,
+}
+
+describe('callerCredibility (cross-partisan calibration)', () => {
+  it('a new user with no history is exactly neutral', () => {
+    expect(
+      callerCredibility({ upheld: 0, rejected: 0, flaggedAgreeSide: 0, flaggedDisagreeSide: 0 }),
+    ).toBe(1)
+  })
+
+  it('severe tribal bias plus low accuracy lands near the floor', () => {
+    const m = callerCredibility(tribalCaller)
+    expect(m).toBeGreaterThanOrEqual(CREDIBILITY_FLOOR)
+    expect(m).toBeLessThanOrEqual(0.4)
+  })
+
+  it('balanced, accurate calling raises influence above 1', () => {
+    expect(callerCredibility(calibratedCaller)).toBeGreaterThanOrEqual(1.2)
+  })
+
+  it('a perfect record clamps at the ceiling', () => {
+    const m = callerCredibility({
+      upheld: 20,
+      rejected: 0,
+      flaggedAgreeSide: 10,
+      flaggedDisagreeSide: 10,
+    })
+    expect(m).toBe(CREDIBILITY_CEILING)
+  })
+
+  it('an always-wrong caller clamps at the floor, never zero', () => {
+    const m = callerCredibility({
+      upheld: 0,
+      rejected: 20,
+      flaggedAgreeSide: 10,
+      flaggedDisagreeSide: 10,
+    })
+    expect(m).toBe(CREDIBILITY_FLOOR)
+  })
+
+  it('accuracy alone cannot buy influence for a one-sided caller', () => {
+    // Perfect accuracy, purely one-sided: the balance factor still drags the
+    // multiplier below neutral. Maintaining influence requires flagging your
+    // own side's fallacies too.
+    const m = callerCredibility({
+      upheld: 10,
+      rejected: 0,
+      flaggedAgreeSide: 0,
+      flaggedDisagreeSide: 10,
+    })
+    expect(m).toBeLessThan(1)
+  })
+
+  it('small samples stay neutral: three one-sided flags are not yet tribalism', () => {
+    const m = callerCredibility({
+      upheld: 0,
+      rejected: 0,
+      flaggedAgreeSide: 0,
+      flaggedDisagreeSide: 3,
+    })
+    expect(m).toBe(1)
+  })
+})
+
+describe('components', () => {
+  it('sideBalance is 1 when perfectly even, small when one-sided', () => {
+    expect(
+      sideBalance({ upheld: 0, rejected: 0, flaggedAgreeSide: 10, flaggedDisagreeSide: 10 }),
+    ).toBe(1)
+    expect(
+      sideBalance({ upheld: 0, rejected: 0, flaggedAgreeSide: 0, flaggedDisagreeSide: 50 }),
+    ).toBeLessThan(0.05)
+  })
+
+  it('accuracyRate is null with no resolved claims', () => {
+    expect(
+      accuracyRate({ upheld: 0, rejected: 0, flaggedAgreeSide: 5, flaggedDisagreeSide: 5 }),
+    ).toBeNull()
+  })
+})

--- a/tests/unit/lib/fallacy/claims.test.ts
+++ b/tests/unit/lib/fallacy/claims.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateFallacyClaimInput,
+  logicalValidityMultiplier,
+  confirmedClaimsToDetectedFallacies,
+  counterArgumentStrength,
+  VALIDITY_NO_FALLACY,
+  VALIDITY_MINOR,
+  VALIDITY_MAJOR,
+  VALIDITY_MULTIPLE,
+  type FallacyClaimInput,
+} from '@/lib/fallacy/claims'
+import { FALLACY_CATALOG, catalogEntry } from '@/lib/fallacy/catalog'
+import { detectFallacies } from '@/lib/agent-ingest/fallacy-detector'
+
+const completeClaim = (overrides: Partial<FallacyClaimInput> = {}): FallacyClaimInput => ({
+  fallacyType: 'false-dilemma',
+  quotedText: 'Either we drastically reduce emissions immediately or we face catastrophe',
+  explanation:
+    'Presents only two extreme options when many intermediate paths exist: gradual reduction, adaptation, carbon capture, policy mixes.',
+  missingElements: 'Gradual pathways, adaptation strategies, technological options.',
+  evidenceLinks: [{ label: 'IPCC AR6 emission scenarios', url: 'https://www.ipcc.ch/report/ar6/' }],
+  consequences: 'Polarizes the debate and excludes feasible middle-ground policy.',
+  ...overrides,
+})
+
+describe('validateFallacyClaimInput (an accusation is an argument)', () => {
+  it('accepts a complete template', () => {
+    expect(validateFallacyClaimInput(completeClaim())).toEqual([])
+  })
+
+  it('rejects a bare "FALLACY!" with one issue per missing field', () => {
+    const issues = validateFallacyClaimInput({
+      fallacyType: 'false-dilemma',
+      quotedText: '',
+      explanation: '',
+      missingElements: '',
+      evidenceLinks: [],
+      consequences: '',
+    })
+    const fields = issues.map(i => i.field)
+    expect(fields).toContain('quotedText')
+    expect(fields).toContain('explanation')
+    expect(fields).toContain('missingElements')
+    expect(fields).toContain('evidenceLinks')
+    expect(fields).toContain('consequences')
+  })
+
+  it('rejects unknown fallacy types', () => {
+    const issues = validateFallacyClaimInput(completeClaim({ fallacyType: 'being-wrong' }))
+    expect(issues.some(i => i.field === 'fallacyType')).toBe(true)
+  })
+
+  it('rejects a one-word explanation', () => {
+    const issues = validateFallacyClaimInput(completeClaim({ explanation: 'obviously' }))
+    expect(issues.some(i => i.field === 'explanation')).toBe(true)
+  })
+
+  it('requires exhibits for evidence-demanding types (straw man needs the actual position)', () => {
+    const issues = validateFallacyClaimInput(
+      completeClaim({ fallacyType: 'straw-man', evidenceLinks: [] }),
+    )
+    expect(issues.some(i => i.field === 'evidenceLinks')).toBe(true)
+  })
+
+  it('allows empty exhibits for types with no evidence requirement', () => {
+    const issues = validateFallacyClaimInput(
+      completeClaim({ fallacyType: 'ad-hominem', evidenceLinks: [] }),
+    )
+    expect(issues).toEqual([])
+  })
+})
+
+describe('logicalValidityMultiplier (the confirmation ladder)', () => {
+  it('matches the ladder: none 0.95, minor 0.75, major 0.45, multiple 0.25', () => {
+    expect(logicalValidityMultiplier([])).toBe(VALIDITY_NO_FALLACY)
+    expect(logicalValidityMultiplier([{ severity: 'minor' }])).toBe(VALIDITY_MINOR)
+    expect(logicalValidityMultiplier([{ severity: 'major' }])).toBe(VALIDITY_MAJOR)
+    expect(
+      logicalValidityMultiplier([{ severity: 'minor' }, { severity: 'major' }]),
+    ).toBe(VALIDITY_MULTIPLE)
+  })
+
+  it('rewards removing the fallacy: the de-fallacied argument scores higher', () => {
+    // Same evidence, fallacy removed: 0.95 multiplier beats 0.45. Restating
+    // the point without the false binary is the profitable move.
+    expect(VALIDITY_NO_FALLACY).toBeGreaterThan(VALIDITY_MAJOR)
+  })
+})
+
+describe('confirmedClaimsToDetectedFallacies (bridge into scoreArgument)', () => {
+  it('sizes impacts so the engine lands exactly on the ladder multiplier', () => {
+    const confirmed = [
+      { fallacyType: 'false-dilemma', severity: 'major', quotedText: 'either/or' },
+      { fallacyType: 'cherry-picking', severity: 'major', quotedText: 'one study' },
+    ]
+    const detected = confirmedClaimsToDetectedFallacies(confirmed)
+    // scoreArgument applies truth × (1 − Σ|impact|/100)
+    const penalty = detected.reduce((s, d) => s + Math.abs(d.impact) / 100, 0)
+    expect(1 - penalty).toBeCloseTo(VALIDITY_MULTIPLE)
+    expect(detected.every(d => d.impact < 0)).toBe(true)
+  })
+
+  it('returns nothing when nothing is confirmed', () => {
+    expect(confirmedClaimsToDetectedFallacies([])).toEqual([])
+  })
+})
+
+describe('catalog coherence', () => {
+  it('every automated detector type is a catalog entry', () => {
+    const detections = detectFallacies(
+      'He is a liar. Everyone knows this. Correlation proves causation here. ' +
+        'It always works. One study confirms it. My uncle saw it happen.',
+    )
+    expect(detections.length).toBeGreaterThanOrEqual(6)
+    for (const d of detections) {
+      const entry = catalogEntry(d.fallacyType)
+      expect(entry, `detector type ${d.fallacyType} missing from catalog`).toBeDefined()
+      expect(d.targetFactor).toBe(entry!.targetFactor)
+    }
+  })
+
+  it('major counter-arguments carry more sub-debate weight than minor ones', () => {
+    expect(counterArgumentStrength('major')).toBeGreaterThan(counterArgumentStrength('minor'))
+  })
+
+  it('every entry names a valid target factor and severity', () => {
+    for (const entry of FALLACY_CATALOG.values()) {
+      expect(['relevance', 'logical-validity', 'evidence-quality']).toContain(entry.targetFactor)
+      expect(['minor', 'major']).toContain(entry.severity)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Implements the fallacy accusation system as a scored argument: filing requires a complete template (type, quote, explanation, missing elements, evidence links, consequences), changes no score on its own, and only community consensus (≥60% weighted agreement, quorum 3) confirms the claim and publishes its counter-argument into the linkage sub-debate.

## Key Changes

**Schema & Data Model**
- Extended `belief-data.schema.xsd` with `FallacyClaims`, `GroupingCandidates`, and `Links` elements; updated worked example `belief-outline-data.xml` with fallacy ladder demonstration (same evidence with/without confirmed false dilemma: 0.306 vs 0.612 propagated score)
- Added Prisma models `FallacyClaim`, `FallacyClaimVote`, `GroupingVote`, `EquivalenceCandidate` with audit-locked status fields
- SQL schema v1.1.0 adds `fallacy_claims`, `fallacy_claim_votes`, `grouping_votes` tables with consensus resolution queries

**Fallacy Catalog & Validation**
- `src/lib/fallacy/catalog.ts`: canonical catalog (false dilemma, ad hominem, straw man, slippery slope, cherry-picking, etc.) with target factor (relevance/logical-validity/evidence-quality), severity (minor/major), detection criteria, and evidence requirements
- `src/lib/fallacy/claims.ts`: accusation template validation (all six fields required), logical-validity ladder (0.45 for major fallacy, 0.70 for minor), counter-argument strength derivation
- `src/lib/fallacy/calibration.ts`: cross-partisan credibility multiplier (accuracy × balance, clamped 0.3–1.4) applied to voter weights; tribal callers (high accuracy but one-sided) land near floor

**API Routes**
- `POST /api/arguments/[id]/fallacy-claims`: file a structured accusation (validates template, creates draft counter-argument, changes no score)
- `GET /api/arguments/[id]/fallacy-claims`: list claims with consensus state and template schema
- `POST /api/fallacy-claims/[id]/votes`: weighted community vote; at ≥60% agreement claim is confirmed, counter-argument published, scores propagate
- `GET /api/fallacy-claims/[id]/votes`: current tally and consensus state
- `POST /api/equivalence-candidates/[id]/votes`: settle grouping pairs (grouped/kept-separate) the same way

**Consensus Engine**
- `src/lib/consensus.ts`: shared resolution logic for fallacy claims and equivalence candidates (60% threshold, quorum 3, weighted votes)
- `src/lib/fallacy/caller-record.ts`: derives user's caller record (upheld/rejected counts, side balance) for credibility computation

**UI & Documentation**
- `src/app/algorithms/fallacy-detection/page.tsx`: explainer covering the accusation template, 60% consensus bar, validity ladder, and cross-partisan calibration
- Updated `belief-html.converter.xslt` to render fallacy claims with status styling (confirmed/rejected/open)
- Updated `/algorithms` index to link fallacy-detection page

**Tests**
- `tests/unit/lib/fallacy/claims.test.ts`: template validation, validity multiplier, confirmed-claims-to-detected-fallacies bridge
- `tests/unit/lib/fallacy/calibration.test.ts`: credibility multiplier (tribal vs calibrated callers, floor/ceiling clamping)
- `tests/unit/lib/consensus.test.ts`: weighted consensus resolution (quorum gating, threshold, outcome tracking)
- `tests/unit/lib/agent-ingest/similarity.test.ts`: similarity band classification

## Notable Implementation Details

- **Accusation is an argument:** Filing requires every template field; the claim itself enters the linkage sub-debate as a draft counter-argument and changes nothing until confirmed.
- **Audit-locked status:** Claim and counter-argument status move only via consensus resolution, never by accuser action.
- **Validity ladder:** Confirmed major fallacy multiplies logical

https://claude.ai/code/session_012bxUib1DbdYeHQ7T3Z8swW