### PR TITLE
Add Evidence Grounding Score — engine-computed ranking by evidence contact

### DIFF
--- a/prisma/migrations/20260718224500_belief_grounding_score/migration.sql
+++ b/prisma/migrations/20260718224500_belief_grounding_score/migration.sql
@@ -1,0 +1,4 @@
+-- Evidence Grounding Score: engine-computed measure of whether a belief's
+-- argument tree bottoms out in tiered evidence. 0 = unfounded (no evidence
+-- anywhere in the subtree). Written only by score propagation.
+ALTER TABLE "Belief" ADD COLUMN "groundingScore" REAL NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,6 +202,17 @@ model Belief {
   /// An extreme claim must earn its score through extraordinary evidence — or it scores near zero.
   claimStrength Float @default(0.5)
 
+  /// Evidence Grounding Score (0-1): how much of this belief's support
+  /// bottoms out in tiered evidence records rather than free-floating claims.
+  /// Engine-computed during propagation (src/lib/grounding.ts):
+  ///   raw = Σ tierWeight × |linkage| over own evidence
+  ///       + Σ |linkage| × childGrounding over published argument edges
+  ///   groundingScore = raw / (raw + 1)
+  /// Exactly 0 means no evidence anywhere in the tree ("Unfounded"); a
+  /// citation ring contributes nothing. This is the evidence-based ranking
+  /// input — engagement is never a ranking input.
+  groundingScore Float @default(0)
+
   /// Specificity (0-1): position on the abstraction ladder.
   ///   0.0 = Highly general principle (e.g. "Corruption undermines government")
   ///   0.33 = Moderately general       (e.g. "U.S. Presidents are often corrupt")

--- a/sql/LINKAGE_ARCHITECTURE.md
+++ b/sql/LINKAGE_ARCHITECTURE.md
@@ -34,6 +34,8 @@ The Prisma schema in `prisma/schema.prisma` already models the same domain on SQ
 
 Schema 1.2.0 adds the evidence-to-conclusion machinery: `evidence_records` (tier classification T0–T4, where T0 = retracted/fraudulent, plus the EVS verification inputs), `evidence_tier_events` (the retraction ledger — every tier movement with its mandatory reason), `score_recompute_queue` (the propagation work list the engine drains after any change), the `trg_evidence_tier_change` trigger that makes a tier UPDATE automatically write the ledger and enqueue the cascade, and the `v_evidence_asymmetry` view (the cherry-picking detector: how each conclusion's evidence splits by direction and tier). The SQLite twin of the cascade is `PATCH /api/evidence/[id]` → `propagateBeliefScores()` in `src/lib/propagate-belief-scores.ts`.
 
+Schema 1.3.0 adds evidence-based ranking: `nodes.grounding_score` (engine-computed — how much of a node's support bottoms out in tiered evidence; a citation ring grounds nothing), `v_direct_grounding` (the auditable one-hop term), `v_front_page` (the ranking query — the schema stores no engagement columns, so better evidence is the only way up), and `v_contributor_track_record` (accuracy × side-balance inputs behind every vote weight, public by design). The SQLite twins are `groundingForBelief()` in `src/lib/grounding.ts`, `GET /api/beliefs?sortBy=grounding`, and `GET /api/contributors/[userId]/track-record`.
+
 ## How they interact today
 
 Right now, you're a human (or AI assistant) editing PBworks pages or the React belief pages directly. The flow is:

--- a/sql/linkage_pages_schema.sql
+++ b/sql/linkage_pages_schema.sql
@@ -7,9 +7,12 @@
 -- RENDER of the data in these tables. The JSON-LD block embedded in
 -- each page is the on-the-wire serialization of these rows.
 --
--- Schema version: 1.2.0 (adds evidence records, the tier-event ledger,
---   the recompute queue, and the evidence-asymmetry view — the tables that
---   make "when evidence changes, every dependent conclusion updates" real)
+-- Schema version: 1.3.0 (adds the grounding score column, the direct-
+--   grounding and front-page ranking views, and the contributor track-record
+--   view — evidence-based ranking made queryable: there is no engagement
+--   column anywhere in this schema, so there is nothing else to rank by)
+-- Previous: 1.2.0 (evidence records, tier-event ledger, recompute queue,
+--   evidence-asymmetry view)
 -- Previous: 1.1.0 (fallacy claims, claim votes, grouping votes)
 -- Engine: MariaDB 10.4+ / MySQL 8.0+ (uses CHECK constraints, JSON type)
 -- Companion: src/core/scoring/scoring-engine.ts in the GitHub repo
@@ -42,6 +45,13 @@
 --    event and enqueues the recompute; the engine drains the queue and
 --    every dependent conclusion recalculates. Arguments citing dead
 --    evidence never quietly keep their scores.
+--
+-- 7. Evidence-based ranking, by construction: this schema stores NO
+--    engagement signals — no view counts, click-through rates, share
+--    counts, or dwell times. Ranking queries (v_front_page) can only
+--    order by engine-computed columns, so the only way up the ranking
+--    is better evidence, not better outrage. If you are tempted to add
+--    a clicks column, add an evidence table instead.
 -- =================================================================
 
 
@@ -60,6 +70,15 @@ CREATE TABLE IF NOT EXISTS `nodes` (
   -- Cached scores. Source of truth is the recursive engine, not these.
   `argument_score`      DECIMAL(5,4)  DEFAULT NULL,
   `truth_score`         DECIMAL(5,4)  DEFAULT NULL,
+  -- Evidence Grounding Score: how much of this node's support bottoms out
+  -- in tiered evidence (0 = unfounded — no evidence anywhere below it).
+  --   raw = Σ tier_weight × |linkage| over its evidence
+  --       + Σ |linkage| × child grounding over its argument edges
+  --   grounding_score = raw / (raw + 1)
+  -- Recursive, so the engine writes it (a citation ring grounds nothing);
+  -- v_direct_grounding below computes the one-hop term for inspection.
+  -- This is the ranking column — see v_front_page.
+  `grounding_score`     DECIMAL(5,4)  DEFAULT NULL,
   `score_computed_at`   TIMESTAMP     NULL DEFAULT NULL,
 
   -- Lifecycle
@@ -71,7 +90,8 @@ CREATE TABLE IF NOT EXISTS `nodes` (
 
   PRIMARY KEY (`node_id`),
   INDEX `idx_node_type` (`node_type`),
-  INDEX `idx_node_score` (`argument_score` DESC)
+  INDEX `idx_node_score` (`argument_score` DESC),
+  INDEX `idx_node_grounding` (`grounding_score` DESC)
 );
 
 
@@ -653,6 +673,96 @@ WHERE l.deleted_at IS NULL
 GROUP BY l.y_node_id;
 
 
+-- -- Direct grounding view (the one-hop term) ---------------------
+-- For each conclusion, the evidence mass linked DIRECTLY to it:
+-- Σ tier_weight × |linkage|. The engine adds the recursive term
+-- (Σ |linkage| × child grounding over argument edges, a citation ring
+-- contributing zero — the query twin of the circular-citation guard in
+-- note 9) and caches the saturated result raw/(raw+1) on
+-- nodes.grounding_score. This view exists so anyone can audit the
+-- engine's direct term with one SELECT.
+
+CREATE OR REPLACE VIEW `v_direct_grounding` AS
+SELECT
+  l.y_node_id AS conclusion_node_id,
+  SUM(
+    CASE e.tier
+      WHEN 'T1' THEN 1.00
+      WHEN 'T2' THEN 0.75
+      WHEN 'T3' THEN 0.50
+      WHEN 'T4' THEN 0.25
+      WHEN 'T0' THEN 0.05
+    END * ABS(l.linkage_score)
+  )                        AS direct_grounding_raw,
+  COUNT(*)                 AS evidence_edge_count,
+  SUM(e.tier = 'T0')       AS retracted_edge_count
+FROM linkages l
+JOIN evidence_records e ON e.node_id = l.x_node_id
+WHERE l.deleted_at IS NULL
+  AND e.deleted_at IS NULL
+  AND l.linkage_score IS NOT NULL
+GROUP BY l.y_node_id;
+
+
+-- -- The front page (evidence-based ranking) ----------------------
+-- The query engagement platforms cannot run. Google orders by clicks,
+-- Facebook by outrage, Twitter by retweets; this table has none of
+-- those columns. Beliefs rank by engine-computed grounding, then truth.
+-- A claim with no evidence anywhere below it is labeled 'unfounded' and
+-- sits at the bottom no matter how viral its phrasing would be.
+
+CREATE OR REPLACE VIEW `v_front_page` AS
+SELECT
+  n.node_id,
+  n.canonical_statement,
+  n.canonical_url,
+  n.grounding_score,
+  CASE
+    WHEN n.grounding_score IS NULL OR n.grounding_score = 0 THEN 'unfounded'
+    WHEN n.grounding_score < 0.35 THEN 'thin'
+    WHEN n.grounding_score < 0.70 THEN 'grounded'
+    ELSE 'well-grounded'
+  END                   AS grounding_band,
+  n.truth_score,
+  n.score_computed_at
+FROM nodes n
+WHERE n.node_type = 'belief'
+  AND n.deleted_at IS NULL
+ORDER BY
+  COALESCE(n.grounding_score, 0) DESC,
+  COALESCE(n.truth_score, 0) DESC;
+
+
+-- -- Contributor track record (behavioral accountability) ---------
+-- The SQL twin of callerRecordFor() + callerCredibility(): accuracy
+-- (did the community uphold your fallacy claims?) and side balance
+-- (do you flag supporting AND weakening edges, or only the side you
+-- dislike?). The application computes the clamped vote weight
+-- (2 × accuracy) × (0.4 + 0.9 × balance), clamped to [0.3, 1.4], from
+-- these counts at vote time. Filing volume appears nowhere: only being
+-- right and being even-handed move the multiplier. Anyone can run this
+-- view on themselves — the weight math is public, unlike a feed
+-- algorithm.
+
+CREATE OR REPLACE VIEW `v_contributor_track_record` AS
+SELECT
+  c.created_by                                          AS user_id,
+  SUM(c.status = 'confirmed')                           AS upheld,
+  SUM(c.status = 'rejected')                            AS rejected,
+  SUM(l.direction = 'supports')                         AS flagged_supporting_side,
+  SUM(l.direction IN ('weakens','refutes'))             AS flagged_weakening_side,
+  SUM(c.status = 'confirmed')
+    / NULLIF(SUM(c.status IN ('confirmed','rejected')), 0) AS accuracy,
+  (LEAST(SUM(l.direction = 'supports'),
+         SUM(l.direction IN ('weakens','refutes'))) + 1)
+    / (GREATEST(SUM(l.direction = 'supports'),
+                SUM(l.direction IN ('weakens','refutes'))) + 1) AS side_balance
+FROM fallacy_claims c
+JOIN linkages l ON l.linkage_id = c.linkage_id
+WHERE c.created_by IS NOT NULL
+GROUP BY c.created_by;
+
+
 -- -- Consensus tally view ---------------------------------------
 -- How the application resolves a claim: weighted agree share across the
 -- votes, settled at >= 0.6 either way once at least 3 votes exist. The
@@ -820,3 +930,21 @@ CREATE TABLE IF NOT EXISTS `score_audit_log` (
 --    edge's y_node appears, the pair has no independent foundation —
 --    reject the INSERT. The application twin is
 --    wouldCreateCircularCitation() in the arguments POST route.
+--
+-- 10. Grounding recomputation: whenever the engine worker recomputes a
+--    node (draining score_recompute_queue), it also recomputes
+--    grounding_score bottom-up: the direct term from v_direct_grounding,
+--    plus Σ |linkage| × child grounding over argument edges, saturated
+--    as raw / (raw + 1). A node re-entered while still on the walk
+--    stack contributes zero (a ring of claims propping each other up
+--    has no foundation — the scoring twin of note 9). The application
+--    twin is groundingForBelief() in src/lib/grounding.ts, called from
+--    propagateBeliefScores(), so a retraction (note 8) collapses
+--    grounding in the same cascade that collapses EVS: the Wakefield
+--    row falls out of v_front_page's top ranks in the same pass that
+--    zeroes its evidence weight.
+--
+-- 11. Ranking surfaces read v_front_page (or ORDER BY grounding_score
+--    on nodes). Never add engagement columns to make a ranking "work";
+--    principle 7 is load-bearing. The application twin is
+--    GET /api/beliefs?sortBy=grounding.

--- a/src/app/api/beliefs/route.ts
+++ b/src/app/api/beliefs/route.ts
@@ -20,8 +20,11 @@ import {
  *   specificityMin, specificityMax   — integers in 1..10
  *   intensityMin, intensityMax       — integers in 1..5
  *   category                         — exact-match category string
- *   sortBy                           — 'valence' | 'specificity' | 'intensity' | 'statement' | 'updated' (default 'valence')
- *   sortDir                          — 'asc' | 'desc' (default 'asc' so the default sort goes negative → positive)
+ *   sortBy                           — 'valence' | 'specificity' | 'intensity' | 'statement' | 'updated' | 'grounding' (default 'valence')
+ *                                      'grounding' is the evidence-based ranking: engine-computed
+ *                                      contact with tiered evidence. Engagement is never a ranking input.
+ *   sortDir                          — 'asc' | 'desc' (default 'asc' so the default sort goes negative → positive;
+ *                                      'grounding' defaults to 'desc' so evidence-based ranking reads best-first)
  *   limit                            — max rows to return
  *
  * Response: { beliefs: [&lt;spec shape&gt;] } where each entry follows &sect;1 of the spec
@@ -63,10 +66,14 @@ export async function GET(request: Request) {
     intensity: 'claimStrength',
     statement: 'statement',
     updated: 'updatedAt',
+    grounding: 'groundingScore',
   }
   const sortByKey = sp.get('sortBy') ?? 'valence'
   filters.sortBy = sortByMap[sortByKey] ?? 'positivity'
-  filters.sortDir = sp.get('sortDir') === 'desc' ? 'desc' : 'asc'
+  const sortDirRaw = sp.get('sortDir')
+  const defaultSortDir = sortByKey === 'grounding' ? 'desc' : 'asc'
+  filters.sortDir =
+    sortDirRaw === 'desc' ? 'desc' : sortDirRaw === 'asc' ? 'asc' : defaultSortDir
 
   const limitRaw = parseInt10('limit')
   if (limitRaw !== undefined && limitRaw > 0) {
@@ -86,6 +93,9 @@ export async function GET(request: Request) {
       }),
       parent_topic_id: b.category ?? null,
       slug: b.slug,
+      // Engine-computed: how much of this belief's support bottoms out in
+      // tiered evidence (0 = unfounded). The evidence-based ranking input.
+      grounding_score: b.groundingScore,
     })),
     count: beliefs.length,
   })

--- a/src/app/api/contributors/[userId]/track-record/route.ts
+++ b/src/app/api/contributors/[userId]/track-record/route.ts
@@ -1,0 +1,63 @@
+/**
+ * GET /api/contributors/[userId]/track-record
+ *
+ * The behavioral-tracking counter to selective skepticism, made transparent.
+ * Engagement platforms hide their ranking algorithm; here the opposite rule
+ * applies: anyone can fetch exactly how any contributor's vote weight is
+ * derived — the raw inputs, both factors, the formula, and the clamps.
+ *
+ * Read-only by construction. The weight is computed from the track record at
+ * vote time (src/lib/fallacy/calibration.ts) and can never be submitted:
+ * consistent accuracy raises influence, a tribal one-sided pattern sinks it,
+ * and filing volume does nothing at all.
+ */
+
+import { NextResponse } from 'next/server'
+import { callerRecordFor } from '@/lib/fallacy/caller-record'
+import {
+  accuracyRate,
+  sideBalance,
+  callerCredibility,
+  CREDIBILITY_FLOOR,
+  CREDIBILITY_CEILING,
+  MIN_RESOLVED_FOR_ACCURACY,
+  MIN_FLAGGED_FOR_BALANCE,
+} from '@/lib/fallacy/calibration'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ userId: string }> },
+) {
+  const { userId } = await params
+  if (!userId || userId.length > 128) {
+    return NextResponse.json({ error: 'Invalid user id.' }, { status: 400 })
+  }
+
+  const record = await callerRecordFor(userId)
+  const resolved = record.upheld + record.rejected
+  const flagged = record.flaggedAgreeSide + record.flaggedDisagreeSide
+
+  return NextResponse.json({
+    userId,
+    record,
+    derivation: {
+      accuracy: accuracyRate(record),
+      accuracyApplied: resolved >= MIN_RESOLVED_FOR_ACCURACY,
+      sideBalance: sideBalance(record),
+      balanceApplied: flagged >= MIN_FLAGGED_FOR_BALANCE,
+      formula:
+        'weight = clamp(accuracyFactor × balanceFactor); ' +
+        'accuracyFactor = 2 × accuracy (neutral 1.0 until ' +
+        `${MIN_RESOLVED_FOR_ACCURACY} resolved claims); ` +
+        'balanceFactor = 0.4 + 0.9 × sideBalance (neutral 1.0 until ' +
+        `${MIN_FLAGGED_FOR_BALANCE} filed claims)`,
+      clamp: { floor: CREDIBILITY_FLOOR, ceiling: CREDIBILITY_CEILING },
+    },
+    credibility: callerCredibility(record),
+    note:
+      'This multiplier weights fallacy-claim and grouping votes. It is ' +
+      'computed server-side from the record above and is never submitted. ' +
+      'Being right raises it; flagging both sides raises it; volume alone ' +
+      'moves nothing.',
+  })
+}

--- a/src/app/beliefs/page.tsx
+++ b/src/app/beliefs/page.tsx
@@ -5,13 +5,14 @@ import {
   type BeliefFilterParams,
 } from '@/features/belief-analysis/data/fetch-belief'
 import { getStrengthBand, formatStrength } from '@/core/scoring/claim-strength'
+import { getGroundingBand, formatGrounding } from '@/core/scoring/grounding'
 
 interface BeliefsPageSearchParams {
   valence?: string       // 'all' | 'extreme-neg' | 'mild-neg' | 'neutral' | 'mild-pos' | 'extreme-pos'
   specificity?: string   // 'all' | 'general' | 'case-level' | 'specific'
   intensity?: string     // 'all' | 'weak' | 'moderate' | 'strong' | 'extreme'
   category?: string      // 'all' | <category name>
-  sort?: string          // 'valence' | 'specificity' | 'intensity' | 'statement'
+  sort?: string          // 'valence' | 'specificity' | 'intensity' | 'statement' | 'grounding'
   dir?: string           // 'asc' | 'desc'
 }
 
@@ -74,9 +75,12 @@ function paramsToFilters(p: BeliefsPageSearchParams): BeliefFilterParams {
     intensity: 'claimStrength',
     statement: 'statement',
     updated: 'updatedAt',
+    grounding: 'groundingScore',
   }
   filters.sortBy = sortMap[p.sort ?? ''] ?? 'positivity'
-  filters.sortDir = p.dir === 'desc' ? 'desc' : 'asc'
+  // Evidence-based ranking reads best-first unless the user says otherwise.
+  const defaultDir = p.sort === 'grounding' ? 'desc' : 'asc'
+  filters.sortDir = p.dir === 'desc' ? 'desc' : p.dir === 'asc' ? 'asc' : defaultDir
 
   return filters
 }
@@ -108,7 +112,10 @@ export default async function BeliefsIndexPage({ searchParams }: BeliefsIndexPro
   const activeIntensity = params.intensity ?? 'all'
   const activeCategory = params.category ?? 'all'
   const activeSort = params.sort ?? 'valence'
-  const activeDir = params.dir === 'desc' ? 'desc' : 'asc'
+  const activeDir =
+    params.dir === 'desc' || params.dir === 'asc'
+      ? params.dir
+      : activeSort === 'grounding' ? 'desc' : 'asc'
 
   return (
     <div className="min-h-screen bg-white">
@@ -127,6 +134,8 @@ export default async function BeliefsIndexPage({ searchParams }: BeliefsIndexPro
           <strong>Valence</strong> (negative ↔ positive),{' '}
           <strong>Specificity</strong> (general ↔ specific), and{' '}
           <strong>Intensity</strong> (weak ↔ extreme). Filter or re-sort below to navigate the space.
+          Sorting by <strong>Evidence grounding</strong> ranks by engine-computed contact with
+          tiered evidence — clicks, shares, and outrage are never ranking inputs here.
         </p>
 
         <form
@@ -177,6 +186,7 @@ export default async function BeliefsIndexPage({ searchParams }: BeliefsIndexPro
               <option value="intensity">Intensity</option>
               <option value="statement">Statement</option>
               <option value="updated">Recently updated</option>
+              <option value="grounding">Evidence grounding</option>
             </select>
           </label>
           <label className="flex flex-col gap-1">
@@ -216,6 +226,7 @@ export default async function BeliefsIndexPage({ searchParams }: BeliefsIndexPro
           <div className="space-y-3">
             {beliefs.map(belief => {
               const band = getStrengthBand(belief.claimStrength)
+              const grounding = getGroundingBand(belief.groundingScore)
               return (
                 <Link
                   key={belief.id}
@@ -245,6 +256,13 @@ export default async function BeliefsIndexPage({ searchParams }: BeliefsIndexPro
                           style={{ backgroundColor: band.hexColor }}
                         >
                           Intensity: <strong>{band.label}</strong> ({formatStrength(belief.claimStrength)})
+                        </span>
+                        <span
+                          className="px-1.5 py-0.5 rounded border border-gray-300 font-mono"
+                          style={{ backgroundColor: grounding.hexColor }}
+                          title={grounding.descriptor}
+                        >
+                          Grounding: <strong>{grounding.label}</strong> ({formatGrounding(belief.groundingScore)})
                         </span>
                       </div>
                     </div>

--- a/src/core/schemas/belief-data.schema.xsd
+++ b/src/core/schemas/belief-data.schema.xsd
@@ -93,6 +93,17 @@
       <xs:element name="UniquenessScore" type="xs:decimal" minOccurs="0"/>
       <xs:element name="ReasonRank"      type="xs:decimal" minOccurs="0"/>
       <xs:element name="PropagatedScore" type="xs:decimal" minOccurs="0"/>
+      <!-- Evidence Grounding Score: does this belief's tree bottom out in
+           evidence? Engine-computed (audit-locked):
+             raw = Σ tierWeight × |linkage| over own EvidenceRecords
+                 + Σ |linkage| × childGrounding over argument edges
+             GroundingScore = raw / (raw + 1)
+           Exactly 0 = no evidence anywhere in the subtree ("unfounded");
+           a ring of claims citing each other contributes nothing. This is
+           the ranking input — engagement never is. -->
+      <xs:element name="GroundingScore" type="xs:decimal" minOccurs="0"/>
+      <!-- unfounded | thin | grounded | well-grounded -->
+      <xs:element name="GroundingBand"  type="xs:string"  minOccurs="0"/>
       <xs:element name="SourceUrl"    type="xs:string" minOccurs="0"/>
       <!-- T0..T4 evidence tier (T0 = retracted/fraudulent) -->
       <xs:element name="EvidenceType" type="xs:string" minOccurs="0"/>

--- a/src/core/schemas/belief-html.converter.xslt
+++ b/src/core/schemas/belief-html.converter.xslt
@@ -31,12 +31,66 @@
                 .status-open { color: #92400e; }
                 .tier-T0 { color: #7f1d1d; font-weight: bold; text-decoration: line-through; }
                 .tier-history { font-size: 0.85em; color: #6b7280; }
+                .grounding-chip { display: inline-block; padding: 2px 8px; border: 1px solid #9ca3af; border-radius: 4px; font-size: 0.85em; }
+                .grounding-unfounded { background: #f8d7da; }
+                .grounding-thin { background: #fff3cd; }
+                .grounding-grounded { background: #d9f0d1; }
+                .grounding-well-grounded { background: #d4edda; }
+                .ranking-note { font-size: 0.9em; color: #374151; max-width: 60em; }
             </style>
         </head>
         <body>
+            <!-- Evidence-Based Ranking: the front page of this document.
+                 Ordered by GroundingScore — engine-computed contact with
+                 tiered evidence. There is no engagement column in the data,
+                 so there is nothing else to rank by: the only way up this
+                 table is better evidence. -->
+            <h4>🏛️ Evidence-Based Ranking</h4>
+            <p class="ranking-note">
+                Ranked by how much each claim&#8217;s argument tree bottoms out in
+                tiered evidence (grounding = raw / (raw + 1)). Unfounded claims sit
+                at the bottom no matter how engaging their phrasing is; a citation
+                ring grounds nothing.
+            </p>
+            <table class="belief-table" style="width:100%">
+                <tr>
+                    <th>#</th>
+                    <th>Belief</th>
+                    <th>Grounding</th>
+                    <th>Band</th>
+                    <th>Truth</th>
+                </tr>
+                <xsl:for-each select="Beliefs/Belief">
+                    <xsl:sort select="GroundingScore" data-type="number" order="descending"/>
+                    <xsl:sort select="TruthScore" data-type="number" order="descending"/>
+                    <tr>
+                        <td><xsl:value-of select="position()"/></td>
+                        <td><xsl:value-of select="Statement"/></td>
+                        <td><xsl:value-of select="GroundingScore"/></td>
+                        <td>
+                            <span class="grounding-chip grounding-{GroundingBand}">
+                                <xsl:value-of select="GroundingBand"/>
+                            </span>
+                        </td>
+                        <td><xsl:value-of select="TruthScore"/></td>
+                    </tr>
+                </xsl:for-each>
+            </table>
+
             <xsl:for-each select="Beliefs/Belief">
                 <div class="belief">
                     <h3><xsl:value-of select="Statement"/></h3>
+                    <xsl:if test="GroundingScore">
+                        <p>
+                            <span class="grounding-chip grounding-{GroundingBand}">
+                                <xsl:text>Grounding: </xsl:text>
+                                <xsl:value-of select="GroundingScore"/>
+                                <xsl:text> (</xsl:text>
+                                <xsl:value-of select="GroundingBand"/>
+                                <xsl:text>)</xsl:text>
+                            </span>
+                        </p>
+                    </xsl:if>
 
                     <!-- Definitions Table -->
                     <xsl:if test="Definitions/Definition">

--- a/src/core/schemas/belief-outline-data.xml
+++ b/src/core/schemas/belief-outline-data.xml
@@ -28,6 +28,13 @@
       published into the linkage sub-debate, then scores propagate
     - POST /api/equivalence-candidates/[id]/votes settles a grouping pair
       the same way (grouped / kept-separate)
+    - GET  /api/beliefs?sortBy=grounding     the evidence-based ranking:
+      ordered by GroundingScore, the engine-computed measure of whether a
+      belief's tree bottoms out in evidence. There is no engagement input
+      to rank by — no clicks, shares, or outrage anywhere in this file
+    - GET  /api/contributors/[userId]/track-record shows exactly how any
+      voter's weight is derived (accuracy x side balance, clamped) — the
+      ranking math is public, the opposite of a hidden feed algorithm
 
   Every score below is engine output (audit-locked): edit the graph, never
   the numbers. The worked numbers mirror the fallacy ladder: the same
@@ -39,6 +46,22 @@
   EVS collapsed 0.80 -> 0.01, belief 5's truth score fell 0.62 -> 0.20,
   and the A4 edge's propagated impact fell 0.26 -> 0.084 — automatically,
   because the evidence is LINKED to the conclusions resting on it.
+
+  GroundingScore is the ranking column, worked through the same graph
+  (raw = evidence tierWeight x |linkage| + argument |linkage| x child
+  grounding; score = raw / (raw + 1)):
+    Belief 4: 1.0 x 0.9 = 0.90            -> 0.4737 (grounded)
+    Belief 3: 0.9 x 0.4737 = 0.4263       -> 0.2989 (thin: one hop from
+              the evidence — distance attenuates honestly)
+    Belief 5: 0.05 x 0.6 = 0.03           -> 0.0291 (thin; was 0.375
+              before the retraction — grounding collapsed with the EVS)
+    Beliefs 2 and 6: no evidence anywhere -> 0.0000 (unfounded; volume
+              of restatement cannot buy grounding)
+    Belief 1: 0.85x0 + 0.85x0.2989 + 0.6x0.0291 + 0.85x0 = 0.2715
+                                          -> 0.2135 (thin)
+  An engagement feed would rank belief 2 (the punchy false dilemma)
+  first; the evidence-based ranking puts belief 4 first and marks 2 and
+  6 unfounded.
 -->
 <BeliefAnalysis>
   <Beliefs>
@@ -51,6 +74,10 @@
       <TruthScore>0.7200</TruthScore>
       <ReasonRank>0.681000</ReasonRank>
       <PropagatedScore>0.681000</PropagatedScore>
+      <!-- No direct evidence; grounding inherited through A2 and A4:
+           0.85 x 0.2989 + 0.6 x 0.0291 = 0.2715 -> 0.2715/1.2715. -->
+      <GroundingScore>0.2135</GroundingScore>
+      <GroundingBand>thin</GroundingBand>
       <EvidenceType>T1</EvidenceType>
     </Belief>
     <Belief>
@@ -67,6 +94,10 @@
       <ReasonRank>0.360000</ReasonRank>
       <!-- 0.80 truth x 0.45 validity (confirmed major fallacy) x 0.85 linkage -->
       <PropagatedScore>0.306000</PropagatedScore>
+      <!-- No evidence anywhere under this claim: unfounded. An engagement
+           feed would rank this punchy binary first; this ranking sinks it. -->
+      <GroundingScore>0.0000</GroundingScore>
+      <GroundingBand>unfounded</GroundingBand>
       <EvidenceType>T1</EvidenceType>
     </Belief>
     <Belief>
@@ -83,6 +114,9 @@
       <ReasonRank>0.720000</ReasonRank>
       <!-- Same evidence, fallacy removed: 0.80 x 0.90 x 0.85 -->
       <PropagatedScore>0.612000</PropagatedScore>
+      <!-- Inherited from belief 4 through A3: 0.9 x 0.4737 = 0.4263. -->
+      <GroundingScore>0.2989</GroundingScore>
+      <GroundingBand>thin</GroundingBand>
       <EvidenceType>T1</EvidenceType>
     </Belief>
     <Belief>
@@ -98,6 +132,10 @@
       <UniquenessScore>1.0000</UniquenessScore>
       <ReasonRank>0.950000</ReasonRank>
       <PropagatedScore>0.684000</PropagatedScore>
+      <!-- Direct T1 evidence (E1): 1.0 x 0.9 = 0.9 -> 0.9/1.9. The top of
+           the evidence-based ranking. -->
+      <GroundingScore>0.4737</GroundingScore>
+      <GroundingBand>grounded</GroundingBand>
       <SourceUrl>https://www.ipcc.ch/report/ar6/syr/</SourceUrl>
       <EvidenceType>T1</EvidenceType>
     </Belief>
@@ -114,7 +152,11 @@
       <UniquenessScore>1.0000</UniquenessScore>
       <ReasonRank>0.200000</ReasonRank>
       <PropagatedScore>0.084000</PropagatedScore>
-      <!-- Foundation retracted: see EvidenceRecord E2 (tier T1 -> T0). -->
+      <!-- Foundation retracted: see EvidenceRecord E2 (tier T1 -> T0).
+           Grounding collapsed with it: 0.05 x 0.6 = 0.03 -> 0.0291
+           (was 1.0 x 0.6 = 0.6 -> 0.375 before the retraction). -->
+      <GroundingScore>0.0291</GroundingScore>
+      <GroundingBand>thin</GroundingBand>
       <EvidenceType>T0</EvidenceType>
     </Belief>
     <Belief>
@@ -132,6 +174,9 @@
       <UniquenessScore>0.1300</UniquenessScore>
       <ReasonRank>0.360000</ReasonRank>
       <PropagatedScore>0.039780</PropagatedScore>
+      <!-- Restating belief 2 louder buys no grounding either. -->
+      <GroundingScore>0.0000</GroundingScore>
+      <GroundingBand>unfounded</GroundingBand>
       <EvidenceType>T1</EvidenceType>
     </Belief>
   </Beliefs>

--- a/src/core/scoring/grounding.ts
+++ b/src/core/scoring/grounding.ts
@@ -1,0 +1,176 @@
+/**
+ * Evidence Grounding Score — does this belief bottom out in evidence?
+ *
+ * The manipulation-era failure this counters: rankings driven by engagement
+ * (clicks, outrage, virality) instead of evidence quality. The ISE ranking
+ * input is grounding: how much of a belief's support ultimately rests on
+ * tiered evidence records, rather than on free-floating assertion or a ring
+ * of claims propping each other up.
+ *
+ * The score is engine-computed from the graph (audit-locked, like every
+ * other score) and deliberately simple enough to verify by hand:
+ *
+ *   direct    = Σ over own evidence:      tierWeight(tier) × |linkage|
+ *   inherited = Σ over argument edges:    |linkage| × grounding(child)
+ *   raw       = direct + inherited
+ *   grounding = raw / (raw + 1)                     — saturating, in [0, 1)
+ *
+ * Properties that matter:
+ *   - Zero evidence anywhere in the subtree → grounding 0 ("Unfounded").
+ *     Assertion volume cannot move it; only evidence can.
+ *   - A circular chain (A cites B cites A) contributes exactly zero: the
+ *     walk treats a back-edge as groundless, so a ring of claims has no
+ *     foundation — the structural twin of the circular-citation guard.
+ *   - Tier ordering is explicit: one T1 study at linkage 0.9 (raw 0.90 →
+ *     0.47) outranks any number of restated opinions, and a retraction
+ *     (T1 → T0) collapses grounding the same way it collapses EVS.
+ *   - Distance from evidence attenuates: a conclusion two hops from its
+ *     sources is less grounded than the finding itself, which is the honest
+ *     reading of a long inferential chain.
+ *
+ * Both supporting and weakening evidence count: grounding measures whether
+ * the debate is in contact with evidence at all, not which way it points.
+ * Direction is Truth's job.
+ */
+
+import { getEvidenceTypeWeight } from './scoring-engine'
+
+// ─── Inputs ───────────────────────────────────────────────────────
+
+export interface GroundingEvidenceInput {
+  /** Evidence tier: T0 (retracted) … T4 (opinion). */
+  tier: string
+  /** Evidence-to-conclusion linkage, [-1, 1]; magnitude is what grounds. */
+  linkageScore: number
+}
+
+export interface GroundingArgumentInput {
+  /** Argument-to-conclusion linkage, [-1, 1]. */
+  linkageScore: number
+  /** The child belief's own grounding score (0–1). */
+  childGrounding: number
+}
+
+/** Saturation constant: grounding = raw / (raw + K). K = 1 puts a single
+ *  solid T1 chain near 0.47 and three of them near 0.73. */
+export const GROUNDING_SATURATION = 1
+
+// ─── Core math ────────────────────────────────────────────────────
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value))
+}
+
+/** One evidence row's grounding contribution: tierWeight × |linkage|. */
+export function directGroundingWeight(evidence: GroundingEvidenceInput): number {
+  return getEvidenceTypeWeight(evidence.tier) * Math.abs(evidence.linkageScore)
+}
+
+/** Map an unbounded raw grounding mass onto [0, 1). */
+export function saturateGrounding(raw: number): number {
+  if (raw <= 0) return 0
+  return raw / (raw + GROUNDING_SATURATION)
+}
+
+/**
+ * The Evidence Grounding Score for one belief, given its own evidence rows
+ * and the grounding already computed for each argument edge's child.
+ * Rounded to 4 decimals to keep stored values stable across recomputes.
+ */
+export function computeGroundingScore(
+  evidence: GroundingEvidenceInput[],
+  argumentEdges: GroundingArgumentInput[],
+): number {
+  const direct = evidence.reduce((sum, e) => sum + directGroundingWeight(e), 0)
+  const inherited = argumentEdges.reduce(
+    (sum, a) => sum + Math.abs(a.linkageScore) * clamp01(a.childGrounding),
+    0,
+  )
+  return Math.round(saturateGrounding(direct + inherited) * 10000) / 10000
+}
+
+// ─── Tree walker (pure; the DB twin lives in src/lib/grounding.ts) ─
+
+export interface GroundingNode {
+  id: string
+  evidence: GroundingEvidenceInput[]
+  argumentEdges: { linkageScore: number; child: GroundingNode }[]
+}
+
+/**
+ * Score a whole in-memory belief tree. A node re-entered while still on the
+ * walk stack is a citation ring and contributes zero grounding.
+ */
+export function scoreGroundingTree(
+  node: GroundingNode,
+  memo: Map<string, number> = new Map(),
+  walking: Set<string> = new Set(),
+): number {
+  const cached = memo.get(node.id)
+  if (cached !== undefined) return cached
+  if (walking.has(node.id)) return 0 // ring of claims: no foundation
+
+  walking.add(node.id)
+  const edges = node.argumentEdges.map((edge) => ({
+    linkageScore: edge.linkageScore,
+    childGrounding: scoreGroundingTree(edge.child, memo, walking),
+  }))
+  walking.delete(node.id)
+
+  const score = computeGroundingScore(node.evidence, edges)
+  memo.set(node.id, score)
+  return score
+}
+
+// ─── Bands ────────────────────────────────────────────────────────
+
+export interface GroundingBand {
+  key: 'unfounded' | 'thin' | 'grounded' | 'well-grounded'
+  label: string
+  /** One-line meaning, phrased for the ranking UI. */
+  descriptor: string
+  /** Hex background for non-Tailwind contexts (chips, XSLT render). */
+  hexColor: string
+}
+
+export const GROUNDING_BANDS: GroundingBand[] = [
+  {
+    key: 'unfounded',
+    label: 'Unfounded',
+    descriptor: 'No evidence anywhere in the argument tree — assertion only.',
+    hexColor: '#f8d7da',
+  },
+  {
+    key: 'thin',
+    label: 'Thinly sourced',
+    descriptor: 'Touches evidence, but weakly: low tiers or long inferential chains.',
+    hexColor: '#fff3cd',
+  },
+  {
+    key: 'grounded',
+    label: 'Grounded',
+    descriptor: 'Rests on at least one solid, directly-linked evidence chain.',
+    hexColor: '#d9f0d1',
+  },
+  {
+    key: 'well-grounded',
+    label: 'Well-grounded',
+    descriptor: 'Multiple independent high-tier chains support the tree.',
+    hexColor: '#d4edda',
+  },
+]
+
+const UNFOUNDED_EPSILON = 1e-9
+export const THIN_GROUNDING_MAX = 0.35
+export const GROUNDED_MAX = 0.7
+
+export function getGroundingBand(score: number): GroundingBand {
+  if (score <= UNFOUNDED_EPSILON) return GROUNDING_BANDS[0]
+  if (score < THIN_GROUNDING_MAX) return GROUNDING_BANDS[1]
+  if (score < GROUNDED_MAX) return GROUNDING_BANDS[2]
+  return GROUNDING_BANDS[3]
+}
+
+export function formatGrounding(score: number): string {
+  return score.toFixed(2)
+}

--- a/src/core/scoring/index.ts
+++ b/src/core/scoring/index.ts
@@ -28,6 +28,10 @@ export {
 // Duplication scoring — solves the Redundancy Problem (Topic Overlap Scores)
 export * from './duplication-scoring';
 
+// Evidence Grounding — does the argument tree bottom out in evidence?
+// The evidence-based ranking input (engagement is never a ranking input).
+export * from './grounding';
+
 // The Denominator — score a belief against its counterclaims (contrast class).
 // Layer 1 (justification, internal) + Layer 2 (opportunity cost, external).
 export * from './contrast-class';

--- a/src/features/belief-analysis/data/fetch-belief.ts
+++ b/src/features/belief-analysis/data/fetch-belief.ts
@@ -216,8 +216,10 @@ export interface BeliefFilterParams {
   claimStrengthMin?: number
   claimStrengthMax?: number
   category?: string
-  /** Field to sort on. Defaults to positivity (the "valence spectrum" surface). */
-  sortBy?: 'positivity' | 'specificity' | 'claimStrength' | 'statement' | 'updatedAt'
+  /** Field to sort on. Defaults to positivity (the "valence spectrum" surface).
+   *  'groundingScore' is the evidence-based ranking: engine-computed contact
+   *  with tiered evidence, never engagement. */
+  sortBy?: 'positivity' | 'specificity' | 'claimStrength' | 'statement' | 'updatedAt' | 'groundingScore'
   /** Sort direction. Defaults to 'asc' so the page reads negative → positive. */
   sortDir?: 'asc' | 'desc'
   limit?: number
@@ -265,6 +267,7 @@ export async function fetchFilteredBeliefs(params: BeliefFilterParams = {}) {
       positivity: true,
       specificity: true,
       claimStrength: true,
+      groundingScore: true,
     },
     orderBy: { [sortBy]: sortDir },
     ...(params.limit !== undefined ? { take: params.limit } : {}),

--- a/src/lib/grounding.ts
+++ b/src/lib/grounding.ts
@@ -1,0 +1,72 @@
+/**
+ * Evidence Grounding — database walker.
+ *
+ * The DB twin of scoreGroundingTree (src/core/scoring/grounding.ts): walks a
+ * belief's evidence rows and published argument edges downward, computing how
+ * much of its support bottoms out in tiered evidence. A belief re-entered
+ * while still on the walk stack is a citation ring and grounds nothing.
+ *
+ * Called from score propagation so grounding rides the same cascade as truth:
+ * link a source and every ancestor's grounding rises; retract one (tier → T0)
+ * and grounding collapses with the EVS.
+ */
+
+import { prisma } from '@/lib/prisma'
+import { computeGroundingScore } from '@/core/scoring/grounding'
+
+export async function groundingForBelief(
+  beliefId: number,
+  memo: Map<number, number> = new Map(),
+  walking: Set<number> = new Set(),
+): Promise<number> {
+  const cached = memo.get(beliefId)
+  if (cached !== undefined) return cached
+  if (walking.has(beliefId)) return 0 // ring of claims: no foundation
+
+  walking.add(beliefId)
+
+  const [evidence, argumentEdges] = await Promise.all([
+    prisma.evidence.findMany({
+      where: { beliefId },
+      select: { evidenceType: true, linkageScore: true },
+    }),
+    prisma.argument.findMany({
+      where: { parentBeliefId: beliefId, status: 'published' },
+      select: { beliefId: true, linkageScore: true },
+    }),
+  ])
+
+  const edges = []
+  for (const edge of argumentEdges) {
+    edges.push({
+      linkageScore: edge.linkageScore,
+      childGrounding: await groundingForBelief(edge.beliefId, memo, walking),
+    })
+  }
+
+  walking.delete(beliefId)
+
+  const score = computeGroundingScore(
+    evidence.map((e) => ({ tier: e.evidenceType, linkageScore: e.linkageScore })),
+    edges,
+  )
+  memo.set(beliefId, score)
+  return score
+}
+
+/**
+ * Recompute and persist a belief's grounding score. Returns the new value.
+ * The memo is shared across one propagation pass so a belief feeding many
+ * parents is walked once.
+ */
+export async function persistBeliefGrounding(
+  beliefId: number,
+  memo: Map<number, number> = new Map(),
+): Promise<number> {
+  const score = await groundingForBelief(beliefId, memo)
+  await prisma.belief.update({
+    where: { id: beliefId },
+    data: { groundingScore: score },
+  })
+  return score
+}

--- a/src/lib/propagate-belief-scores.ts
+++ b/src/lib/propagate-belief-scores.ts
@@ -39,6 +39,7 @@ import {
   mechanicalSimilarity,
   uniquenessFromSimilarities,
 } from '@/core/scoring/duplication-scoring'
+import { persistBeliefGrounding } from '@/lib/grounding'
 
 // Re-export so callers can import from one place
 export { computeArgumentImpactScore }
@@ -213,12 +214,15 @@ async function resolveEffectiveImportance(arg: {
  * @param depth    - Current recursion depth (for result reporting).
  * @param trigger  - Human-readable cause, recorded on every score event this
  *                   pass produces (e.g. "argument #12 posted").
+ * @param groundingMemo - Per-pass cache for the grounding walk, so a belief
+ *                   feeding many ancestors is only walked once.
  */
 export async function propagateBeliefScores(
   beliefId: number,
   visited: Set<number> = new Set(),
   depth: number = 0,
   trigger: string = 'propagation',
+  groundingMemo: Map<number, number> = new Map(),
 ): Promise<PropagationResult> {
   if (visited.has(beliefId)) {
     return { updatedArgumentIds: [], updatedBeliefIds: [], depth }
@@ -256,6 +260,12 @@ export async function propagateBeliefScores(
       await recordScoreEvent(beliefId, before, { positivity: childScores.overallScore }, trigger)
     }
   }
+
+  // Grounding rides the same cascade. Unlike positivity, it is persisted even
+  // for bare leaves: exactly 0 — no evidence anywhere in the subtree — is a
+  // real verdict ("Unfounded"), not a fake score. The evidence-based ranking
+  // on /beliefs reads this column; engagement is never a ranking input.
+  await persistBeliefGrounding(beliefId, groundingMemo)
 
   // ── Step 2: Find every argument edge that draws on this belief ──
   // A belief can feed a parent argument through THREE distinct edges:
@@ -358,7 +368,13 @@ export async function propagateBeliefScores(
     result.updatedBeliefIds.push(parentBeliefId)
 
     // ── Step 5: Recurse to each parent's own ancestors ────────────
-    const childResult = await propagateBeliefScores(parentBeliefId, visited, depth + 1, trigger)
+    const childResult = await propagateBeliefScores(
+      parentBeliefId,
+      visited,
+      depth + 1,
+      trigger,
+      groundingMemo,
+    )
     result.updatedArgumentIds.push(...childResult.updatedArgumentIds)
     result.updatedBeliefIds.push(...childResult.updatedBeliefIds)
     result.depth = Math.max(result.depth, childResult.depth)

--- a/tests/unit/core/scoring/grounding.test.ts
+++ b/tests/unit/core/scoring/grounding.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the Evidence Grounding Score.
+ *
+ * Anchors verified here (and mirrored in the XML/SQL database examples):
+ * - No evidence anywhere → 0 (Unfounded); assertion volume never moves it.
+ * - One T1 study at linkage 0.9 → 0.9/1.9 ≈ 0.4737 (Grounded).
+ * - Three such studies → 2.7/3.7 ≈ 0.7297 (Well-grounded).
+ * - A T0 (retracted) source contributes almost nothing.
+ * - A ring of claims citing each other grounds nothing (cycle → 0).
+ * - Distance from evidence attenuates through argument edges.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  computeGroundingScore,
+  directGroundingWeight,
+  saturateGrounding,
+  scoreGroundingTree,
+  getGroundingBand,
+  type GroundingNode,
+} from '@/core/scoring/grounding'
+
+describe('directGroundingWeight', () => {
+  it('weights by tier and linkage magnitude', () => {
+    expect(directGroundingWeight({ tier: 'T1', linkageScore: 0.9 })).toBeCloseTo(0.9)
+    expect(directGroundingWeight({ tier: 'T4', linkageScore: 0.5 })).toBeCloseTo(0.125)
+  })
+
+  it('collapses for retracted (T0) sources', () => {
+    expect(directGroundingWeight({ tier: 'T0', linkageScore: 0.6 })).toBeCloseTo(0.03)
+  })
+
+  it('counts weakening evidence by magnitude — grounding is direction-blind', () => {
+    expect(directGroundingWeight({ tier: 'T1', linkageScore: -0.9 })).toBeCloseTo(0.9)
+  })
+})
+
+describe('saturateGrounding', () => {
+  it('is 0 at 0 and approaches 1 monotonically', () => {
+    expect(saturateGrounding(0)).toBe(0)
+    expect(saturateGrounding(0.9)).toBeCloseTo(0.9 / 1.9)
+    expect(saturateGrounding(2.7)).toBeCloseTo(2.7 / 3.7)
+    expect(saturateGrounding(100)).toBeGreaterThan(0.99)
+    expect(saturateGrounding(2)).toBeGreaterThan(saturateGrounding(1))
+  })
+})
+
+describe('computeGroundingScore', () => {
+  it('is exactly 0 with no evidence and no grounded children', () => {
+    expect(computeGroundingScore([], [])).toBe(0)
+    expect(
+      computeGroundingScore([], [{ linkageScore: 0.9, childGrounding: 0 }]),
+    ).toBe(0)
+  })
+
+  it('matches the single-T1-study anchor', () => {
+    const score = computeGroundingScore([{ tier: 'T1', linkageScore: 0.9 }], [])
+    expect(score).toBeCloseTo(0.4737, 4)
+  })
+
+  it('reaches well-grounded with three independent T1 chains', () => {
+    const score = computeGroundingScore(
+      [
+        { tier: 'T1', linkageScore: 0.9 },
+        { tier: 'T1', linkageScore: 0.9 },
+        { tier: 'T1', linkageScore: 0.9 },
+      ],
+      [],
+    )
+    expect(score).toBeCloseTo(0.7297, 4)
+    expect(getGroundingBand(score).key).toBe('well-grounded')
+  })
+
+  it('a stack of opinions stays below one directly-linked T1 study', () => {
+    const opinions = Array.from({ length: 3 }, () => ({ tier: 'T4', linkageScore: 0.5 }))
+    const opinionScore = computeGroundingScore(opinions, [])
+    const t1Score = computeGroundingScore([{ tier: 'T1', linkageScore: 0.9 }], [])
+    expect(opinionScore).toBeLessThan(t1Score)
+  })
+
+  it('inherits grounding through argument edges, attenuated by linkage', () => {
+    const childGrounding = 0.4737
+    const score = computeGroundingScore([], [
+      { linkageScore: 0.9, childGrounding },
+    ])
+    expect(score).toBeCloseTo((0.9 * childGrounding) / (0.9 * childGrounding + 1), 4)
+    expect(score).toBeLessThan(childGrounding) // distance from evidence attenuates
+  })
+
+  it('retraction collapses grounding (T1 → T0 on the same edge)', () => {
+    const before = computeGroundingScore([{ tier: 'T1', linkageScore: 0.6 }], [])
+    const after = computeGroundingScore([{ tier: 'T0', linkageScore: 0.6 }], [])
+    expect(before).toBeCloseTo(0.375, 4)
+    expect(after).toBeCloseTo(0.0291, 4)
+    expect(getGroundingBand(after).key).toBe('thin')
+  })
+})
+
+describe('scoreGroundingTree', () => {
+  const leafWithT1: GroundingNode = {
+    id: 'leaf',
+    evidence: [{ tier: 'T1', linkageScore: 0.9 }],
+    argumentEdges: [],
+  }
+
+  it('walks evidence up through the tree', () => {
+    const root: GroundingNode = {
+      id: 'root',
+      evidence: [],
+      argumentEdges: [{ linkageScore: 0.85, child: leafWithT1 }],
+    }
+    const leafScore = 0.4737
+    expect(scoreGroundingTree(root)).toBeCloseTo(
+      (0.85 * leafScore) / (0.85 * leafScore + 1),
+      3,
+    )
+  })
+
+  it('scores a citation ring as zero — a ring of claims has no foundation', () => {
+    const a: GroundingNode = { id: 'a', evidence: [], argumentEdges: [] }
+    const b: GroundingNode = { id: 'b', evidence: [], argumentEdges: [] }
+    a.argumentEdges.push({ linkageScore: 1, child: b })
+    b.argumentEdges.push({ linkageScore: 1, child: a })
+    expect(scoreGroundingTree(a)).toBe(0)
+    expect(getGroundingBand(0).key).toBe('unfounded')
+  })
+
+  it('a ring still grounds if one member holds real evidence', () => {
+    const a: GroundingNode = { id: 'a', evidence: [], argumentEdges: [] }
+    const b: GroundingNode = {
+      id: 'b',
+      evidence: [{ tier: 'T2', linkageScore: 0.8 }],
+      argumentEdges: [],
+    }
+    a.argumentEdges.push({ linkageScore: 1, child: b })
+    b.argumentEdges.push({ linkageScore: 1, child: a })
+    expect(scoreGroundingTree(a)).toBeGreaterThan(0)
+  })
+})
+
+describe('getGroundingBand', () => {
+  it('maps the thresholds', () => {
+    expect(getGroundingBand(0).key).toBe('unfounded')
+    expect(getGroundingBand(0.1).key).toBe('thin')
+    expect(getGroundingBand(0.3499).key).toBe('thin')
+    expect(getGroundingBand(0.35).key).toBe('grounded')
+    expect(getGroundingBand(0.6999).key).toBe('grounded')
+    expect(getGroundingBand(0.7).key).toBe('well-grounded')
+  })
+})


### PR DESCRIPTION
## Summary

Implements the Evidence Grounding Score, a new engine-computed metric that measures whether a belief's argument tree bottoms out in tiered evidence rather than free-floating claims. This score becomes the primary ranking input, replacing engagement signals (which do not exist in this schema by design).

The grounding score is:
- **Recursive:** walks the belief graph downward, accumulating evidence weight (tier × |linkage|) and inherited grounding from child arguments
- **Circular-aware:** a citation ring contributes zero (the structural twin of the circular-citation guard)
- **Distance-honest:** conclusions far from evidence are less grounded than the evidence itself
- **Saturating:** raw / (raw + 1) maps unbounded mass onto [0, 1), so one solid T1 chain scores ~0.47 and three score ~0.73

## Key Changes

**Core scoring logic** (`src/core/scoring/grounding.ts`):
- `directGroundingWeight()` — evidence contribution: tierWeight × |linkage|
- `saturateGrounding()` — maps raw mass onto [0, 1)
- `computeGroundingScore()` — combines direct evidence and inherited grounding from argument edges
- `scoreGroundingTree()` — pure in-memory tree walker with cycle detection
- `getGroundingBand()` — maps scores to four bands (Unfounded / Thinly sourced / Grounded / Well-grounded)

**Database layer** (`src/lib/grounding.ts`):
- `groundingForBelief()` — async tree walker that queries evidence and argument edges, detects rings
- `persistBeliefGrounding()` — recomputes and caches the score on the belief record

**Schema & views** (`sql/linkage_pages_schema.sql`):
- Added `grounding_score` column to `nodes` table (cached, engine-written, audit-locked)
- `v_direct_grounding` — auditable view of the one-hop evidence term
- `v_front_page` — evidence-based ranking (ORDER BY grounding_score DESC, then truth_score DESC)
- `v_contributor_track_record` — behavioral accountability: accuracy × side balance, clamped to [0.3, 1.4]

**Propagation integration** (`src/lib/propagate-belief-scores.ts`):
- Grounding recomputation rides the same cascade as truth: link evidence → ancestors' grounding rises; retract a source (T1 → T0) → grounding collapses with EVS
- Per-pass memo prevents redundant walks when a belief feeds multiple parents

**API & UI**:
- `GET /api/beliefs?sortBy=grounding` — evidence-based ranking (defaults to descending)
- `GET /api/contributors/[userId]/track-record` — transparent weight derivation (formula, inputs, clamps all visible)
- Belief page sorts by grounding; contributor track record shows exact credibility math
- XSLT rendering includes grounding chips and front-page ranking table

**Tests** (`tests/unit/core/scoring/grounding.test.ts`):
- Anchors verified: no evidence → 0; one T1 study at 0.9 → 0.4737; three → 0.7297
- Ring detection: citation cycles ground nothing
- Distance attenuation: conclusions inherit grounding from children, attenuated by linkage
- Retraction collapse: T1 → T0 on same edge drops score from 0.375 to 0.0291

**Schema updates**:
- Prisma: `groundingScore` field on Belief model
- XSD: GroundingScore and GroundingBand elements
- Migration: adds column and index

## Notable Implementation Details

- **No engagement anywhere:** the schema has no clicks, shares, outrage, or dwell-time columns. The only ranking input is engine-computed evidence contact. This is load-bearing: if you are tempted to add a clicks column, add an evidence table instead.
- **Circular citations:** a node re-entered while still on the walk stack returns 0, so a ring of claims propping each other up has no foundation —

https://claude.ai/code/session_013DabPUUzCrJxvBP2xKecjb