### PR TITLE
Add conversation integration: import transcripts, mine candidates, integrate through firewall

### DIFF
--- a/prisma/migrations/20260816043514_conversation_integration/migration.sql
+++ b/prisma/migrations/20260816043514_conversation_integration/migration.sql
@@ -1,0 +1,69 @@
+-- CreateTable
+CREATE TABLE "ConversationThread" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "platform" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "sourceUrl" TEXT,
+    "beliefId" INTEGER,
+    "submittedByAgentId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ConversationThread_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "ConversationThread_submittedByAgentId_fkey" FOREIGN KEY ("submittedByAgentId") REFERENCES "Agent" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ConversationMessage" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "threadId" TEXT NOT NULL,
+    "index" INTEGER NOT NULL,
+    "authorHandle" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "postedAt" DATETIME,
+    CONSTRAINT "ConversationMessage_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "ConversationThread" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ArgumentCandidate" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "threadId" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "statement" TEXT NOT NULL,
+    "direction" TEXT NOT NULL,
+    "contextQuote" TEXT,
+    "evidenceUrls" TEXT,
+    "beliefId" INTEGER,
+    "nearestArgumentId" INTEGER,
+    "similarity" REAL,
+    "band" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "integratedArgumentId" INTEGER,
+    "integratedBatchId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" DATETIME,
+    CONSTRAINT "ArgumentCandidate_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "ConversationThread" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArgumentCandidate_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "ConversationMessage" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArgumentCandidate_beliefId_fkey" FOREIGN KEY ("beliefId") REFERENCES "Belief" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "ArgumentCandidate_nearestArgumentId_fkey" FOREIGN KEY ("nearestArgumentId") REFERENCES "Argument" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "ArgumentCandidate_integratedArgumentId_fkey" FOREIGN KEY ("integratedArgumentId") REFERENCES "Argument" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "ConversationThread_beliefId_idx" ON "ConversationThread"("beliefId");
+
+-- CreateIndex
+CREATE INDEX "ConversationThread_createdAt_idx" ON "ConversationThread"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "ConversationMessage_threadId_idx" ON "ConversationMessage"("threadId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ConversationMessage_threadId_index_key" ON "ConversationMessage"("threadId", "index");
+
+-- CreateIndex
+CREATE INDEX "ArgumentCandidate_threadId_idx" ON "ArgumentCandidate"("threadId");
+
+-- CreateIndex
+CREATE INDEX "ArgumentCandidate_beliefId_idx" ON "ArgumentCandidate"("beliefId");
+
+-- CreateIndex
+CREATE INDEX "ArgumentCandidate_status_idx" ON "ArgumentCandidate"("status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -321,6 +321,11 @@ model Belief {
   suggestedEvidence SuggestedEvidence[]
   forumPosts        ForumPost[]
 
+  /// External conversations (chatrooms, web forums) plugged into this
+  /// belief's permanent page, and the candidate arguments mined from them.
+  conversationThreads ConversationThread[]
+  argumentCandidates  ArgumentCandidate[]
+
   epochSnapshots  EpochSnapshot[]
   marketContracts MarketContract[]
   externalMarkets ExternalMarketLink[]
@@ -422,6 +427,9 @@ model Argument {
 
   equivalenceCandidatesAsNew      EquivalenceCandidate[] @relation("EquivalenceCandidateNew")
   equivalenceCandidatesAsExisting EquivalenceCandidate[] @relation("EquivalenceCandidateExisting")
+
+  candidatesNearest    ArgumentCandidate[] @relation("CandidateNearestArgument")
+  candidatesIntegrated ArgumentCandidate[] @relation("CandidateIntegratedArgument")
 
   linkageRephrasings     LinkageRephrasing[]
   linkageFiveStepCheck   LinkageFiveStepCheck?
@@ -2327,6 +2335,7 @@ model Agent {
   suggestedEvidence SuggestedEvidence[]
   forumPosts        ForumPost[]
   forumComments     ForumComment[]
+  conversationThreads ConversationThread[]
 }
 
 model AgentApiKey {
@@ -2501,6 +2510,106 @@ model ForumComment {
   createdAt DateTime @default(now())
 
   @@index([postId])
+}
+
+// ─── Conversation Integration (chatrooms & web forums) ───────────
+// Every conversation plugs into a permanent belief page. A thread transcript
+// is imported verbatim, candidate pro/con claims are mined from it and
+// matched to the belief graph, and a human or agent review turns accepted
+// candidates into Arguments — through the same ingestion firewall as any
+// other move. The transcript itself never affects a score.
+
+/// One imported external conversation (a Discord/Reddit/X thread, a chat-room
+/// log, a web-forum topic). Raw source material: extraction mines it, the
+/// firewall integrates it, and the belief page is where the result lives.
+model ConversationThread {
+  id        String  @id @default(cuid())
+  /// "discord" | "reddit" | "twitter" | "forum" | "chat" | "other"
+  platform  String
+  title     String
+  sourceUrl String?
+
+  /// The permanent page this conversation plugs into. Named at import or
+  /// resolved by matching; null only when no belief matched at all.
+  beliefId Int?
+  belief   Belief? @relation(fields: [beliefId], references: [id])
+
+  submittedByAgentId String
+  submittedByAgent   Agent  @relation(fields: [submittedByAgentId], references: [id])
+
+  createdAt DateTime @default(now())
+
+  messages   ConversationMessage[]
+  candidates ArgumentCandidate[]
+
+  @@index([beliefId])
+  @@index([createdAt])
+}
+
+/// One verbatim message from the transcript. Immutable after import so every
+/// candidate can point back at exactly what was said.
+model ConversationMessage {
+  id       String             @id @default(cuid())
+  threadId String
+  thread   ConversationThread @relation(fields: [threadId], references: [id])
+
+  /// Zero-based position in the thread.
+  index        Int
+  authorHandle String
+  body         String
+  postedAt     DateTime?
+
+  candidates ArgumentCandidate[]
+
+  @@unique([threadId, index])
+  @@index([threadId])
+}
+
+/// One candidate pro/con claim mined from a conversation message. Stored, not
+/// scored: a candidate becomes an Argument only when integration runs it
+/// through the ingestion firewall (five-step check, audit log, no scores).
+model ArgumentCandidate {
+  id        String              @id @default(cuid())
+  threadId  String
+  thread    ConversationThread  @relation(fields: [threadId], references: [id])
+  messageId String
+  message   ConversationMessage @relation(fields: [messageId], references: [id])
+
+  /// Normalized standalone claim extracted from the message.
+  statement String
+  /// "pro" | "con" relative to the matched belief. A heuristic stance read,
+  /// correctable at review — candidates are pending until integrated.
+  direction String
+  /// The sentence in its surrounding message text, kept for the five-step
+  /// mechanism draft and for reviewers to check the stance read.
+  contextQuote String?
+  /// Newline-separated URLs shared alongside the claim, offered as evidence
+  /// provenance at integration time.
+  evidenceUrls String?
+
+  beliefId Int?
+  belief   Belief? @relation(fields: [beliefId], references: [id])
+
+  /// Closest existing same-side argument under the belief, from the
+  /// redundancy scan. Bands route (combine vs extend); nothing auto-merges.
+  nearestArgumentId Int?
+  nearestArgument   Argument? @relation("CandidateNearestArgument", fields: [nearestArgumentId], references: [id])
+  similarity        Float?
+  /// "same-claim" | "probable-group" | "related-link" | "distinct"
+  band              String?
+
+  /// "pending" | "integrated" | "duplicate" | "dismissed"
+  status               String    @default("pending")
+  integratedArgumentId Int?
+  integratedArgument   Argument? @relation("CandidateIntegratedArgument", fields: [integratedArgumentId], references: [id])
+  integratedBatchId    String?
+
+  createdAt  DateTime  @default(now())
+  resolvedAt DateTime?
+
+  @@index([threadId])
+  @@index([beliefId])
+  @@index([status])
 }
 
 // ─── Prediction Market Layer (belief-score contracts) ────────────

--- a/src/app/api/beliefs/[id]/outline/route.ts
+++ b/src/app/api/beliefs/[id]/outline/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { buildBeliefOutline } from '@/lib/conversations/outline'
+
+/**
+ * GET /api/beliefs/[id]/outline — the organized pro/con outline of a belief
+ * page: equivalent arguments clustered (combine), clusters ranked score-desc
+ * nulls-last (organize), unanswered leads surfaced as gaps (extend), and
+ * pending conversation candidates queued in the incoming lane. This is what
+ * a chat client renders so a conversation never starts from zero.
+ */
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const beliefId = parseInt(id, 10)
+  if (isNaN(beliefId)) {
+    return NextResponse.json({ error: 'Invalid belief ID' }, { status: 400 })
+  }
+
+  const outline = await buildBeliefOutline(beliefId)
+  if (!outline) {
+    return NextResponse.json({ error: 'Belief not found' }, { status: 404 })
+  }
+  return NextResponse.json({ outline })
+}

--- a/src/app/api/v1/conversations/[id]/integrate/route.ts
+++ b/src/app/api/v1/conversations/[id]/integrate/route.ts
@@ -1,0 +1,66 @@
+import { agentJson } from '@/lib/agent-api'
+import { authenticateAgentKey } from '@/lib/agent-auth'
+import { integrateCandidates, type IntegrateRequest } from '@/lib/conversations/integrate'
+import { AUDIT_LOCK_MESSAGE, FAILURE_MODES } from '@/lib/agent-ingest/contract'
+import { propagateBeliefScores } from '@/lib/propagate-belief-scores'
+
+/**
+ * POST /api/v1/conversations/[id]/integrate — the review move that lets a
+ * conversation change the graph, through the same firewall as everything
+ * else.
+ *
+ * Body: {
+ *   integrate?: [{ candidateId, howItSupports?, provisionalEstimate?, direction? }],
+ *   fold?:      [candidateId]   // restates an existing argument: combine, no new row
+ *   dismiss?:   [candidateId]   // not a usable argument
+ * }
+ *
+ * Integrations run as one ingest batch (five-step checks, audit rows, no
+ * scores), then the engine recomputes every conclusion the batch touched.
+ */
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await authenticateAgentKey(request.headers.get('authorization'))
+  if (!auth.ok) return agentJson({ error: auth.error }, { status: auth.status })
+
+  const { id } = await params
+  let body: IntegrateRequest
+  try {
+    body = await request.json()
+  } catch {
+    return agentJson(
+      {
+        error: 'Body must be valid JSON.',
+        issues: [{ mode: FAILURE_MODES.MALFORMED_BATCH, path: '', message: 'Body must be valid JSON.' }],
+      },
+      { status: 400 },
+    )
+  }
+
+  const result = await integrateCandidates(auth.agent.id, id, body)
+  if (!result.ok) {
+    return agentJson(
+      {
+        error: result.auditLock ? AUDIT_LOCK_MESSAGE : 'Integration rejected. Fix the named issues and resubmit.',
+        issues: result.issues,
+      },
+      { status: result.status },
+    )
+  }
+
+  // The engine's turn, same as direct ingestion: the batch changed the graph,
+  // so every dependent conclusion recomputes.
+  for (const beliefId of result.changedBeliefIds) {
+    await propagateBeliefScores(beliefId, new Set(), 0, `conversation integration on belief #${beliefId}`)
+  }
+
+  return agentJson(
+    {
+      batchId: result.batchId,
+      batchUrl: result.batchId ? `/batches/${result.batchId}` : null,
+      integrated: result.integrated,
+      folded: result.folded,
+      dismissed: result.dismissed,
+    },
+    { status: 200 },
+  )
+}

--- a/src/app/api/v1/conversations/[id]/route.ts
+++ b/src/app/api/v1/conversations/[id]/route.ts
@@ -1,0 +1,50 @@
+import { prisma } from '@/lib/prisma'
+import { agentJson } from '@/lib/agent-api'
+import { CONVERSATION_FIREWALL_LINE } from '@/lib/conversations/contract'
+
+/**
+ * GET /api/v1/conversations/[id] — one imported thread: the verbatim
+ * transcript, the mined candidates with their redundancy bands, and where
+ * each candidate stands (pending / integrated / duplicate / dismissed).
+ */
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const thread = await prisma.conversationThread.findUnique({
+    where: { id },
+    include: {
+      belief: { select: { id: true, slug: true, statement: true } },
+      submittedByAgent: { select: { name: true, operator: true } },
+      messages: { orderBy: { index: 'asc' } },
+      candidates: {
+        include: {
+          message: { select: { index: true, authorHandle: true } },
+          nearestArgument: { select: { id: true, claim: true } },
+          integratedArgument: { select: { id: true } },
+        },
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+  if (!thread) return agentJson({ error: `No conversation thread "${id}".` }, { status: 404 })
+
+  return agentJson({
+    firewall: CONVERSATION_FIREWALL_LINE,
+    thread: {
+      id: thread.id,
+      platform: thread.platform,
+      title: thread.title,
+      sourceUrl: thread.sourceUrl,
+      belief: thread.belief,
+      beliefUrl: thread.belief ? `/beliefs/${thread.belief.slug}` : null,
+      submittedBy: thread.submittedByAgent,
+      createdAt: thread.createdAt,
+      messages: thread.messages.map(m => ({
+        index: m.index,
+        author: m.authorHandle,
+        body: m.body,
+        postedAt: m.postedAt,
+      })),
+      candidates: thread.candidates,
+    },
+  })
+}

--- a/src/app/api/v1/conversations/route.ts
+++ b/src/app/api/v1/conversations/route.ts
@@ -1,0 +1,97 @@
+import { prisma } from '@/lib/prisma'
+import { agentJson } from '@/lib/agent-api'
+import { authenticateAgentKey } from '@/lib/agent-auth'
+import { runConversationImport } from '@/lib/conversations/import'
+import {
+  CONVERSATION_FIREWALL_LINE,
+  CONVERSATION_PLATFORMS,
+  MAX_MESSAGES_PER_IMPORT,
+} from '@/lib/conversations/contract'
+import { FAILURE_MODES } from '@/lib/agent-ingest/contract'
+
+/**
+ * POST /api/v1/conversations — plug a chatroom or web-forum thread into its
+ * permanent belief page.
+ *
+ * The transcript is stored verbatim, candidate pro/con claims are mined from
+ * it, and each candidate is matched against the page's existing arguments
+ * (extend vs restate). Nothing here touches the graph or any score: the
+ * candidates wait for an explicit, audited integration move via
+ * POST /api/v1/conversations/[id]/integrate.
+ */
+export async function POST(request: Request) {
+  const auth = await authenticateAgentKey(request.headers.get('authorization'))
+  if (!auth.ok) return agentJson({ error: auth.error }, { status: auth.status })
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return agentJson(
+      {
+        error: 'Body must be valid JSON.',
+        issues: [{ mode: FAILURE_MODES.MALFORMED_BATCH, path: '', message: 'Body must be valid JSON.' }],
+      },
+      { status: 400 },
+    )
+  }
+
+  const result = await runConversationImport(auth.agent.id, payload)
+  if (!result.ok) {
+    return agentJson(
+      { error: 'Import rejected. Fix the named issues and resubmit.', issues: result.issues },
+      { status: result.status },
+    )
+  }
+
+  return agentJson(
+    {
+      firewall: CONVERSATION_FIREWALL_LINE,
+      threadId: result.threadId,
+      belief: result.belief,
+      beliefUrl: result.belief ? `/beliefs/${result.belief.slug}` : null,
+      candidates: result.candidates,
+      skipped: result.skipped,
+    },
+    { status: 201 },
+  )
+}
+
+/** GET /api/v1/conversations — recent imports, or the contract for tooling. */
+export async function GET(request: Request) {
+  const sp = new URL(request.url).searchParams
+  if (sp.get('contract') !== null) {
+    return agentJson({
+      contract: {
+        method: 'POST',
+        auth: 'Authorization: Bearer <agent key>',
+        body: {
+          platform: CONVERSATION_PLATFORMS.join(' | '),
+          title: 'thread title',
+          sourceUrl: 'permalink (optional)',
+          beliefSlug: 'the belief page this conversation is about (optional; matched from the transcript when omitted)',
+          messages: `[{ author, body, postedAt? }] — up to ${MAX_MESSAGES_PER_IMPORT}`,
+        },
+        rules: [
+          'The transcript is stored verbatim and mined for candidate pro/con claims.',
+          'Candidates are matched against the belief page’s existing arguments: same-claim candidates fold, distinct ones extend the outline.',
+          'Nothing is written to the belief graph at import. Integration is a separate, audited move through the ingestion firewall.',
+          CONVERSATION_FIREWALL_LINE,
+        ],
+      },
+    })
+  }
+
+  const beliefSlug = sp.get('beliefSlug')
+  const threads = await prisma.conversationThread.findMany({
+    where: beliefSlug ? { belief: { slug: beliefSlug } } : undefined,
+    include: {
+      belief: { select: { slug: true, statement: true } },
+      submittedByAgent: { select: { name: true, operator: true } },
+      _count: { select: { messages: true, candidates: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+  })
+  return agentJson({ firewall: CONVERSATION_FIREWALL_LINE, threads })
+}

--- a/src/app/conversations/page.tsx
+++ b/src/app/conversations/page.tsx
@@ -1,0 +1,130 @@
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+import { CONVERSATION_FIREWALL_LINE } from '@/lib/conversations/contract'
+
+export const dynamic = 'force-dynamic'
+
+const STATUS_STYLES: Record<string, string> = {
+  pending: 'bg-amber-50 text-amber-800 border-amber-300',
+  integrated: 'bg-green-50 text-green-800 border-green-300',
+  duplicate: 'bg-blue-50 text-blue-800 border-blue-300',
+  dismissed: 'bg-gray-100 text-gray-500 border-gray-300',
+}
+
+/**
+ * Imported conversations and the candidate arguments mined from them. Every
+ * conversation plugs into a permanent belief page; this is the review lane
+ * where mined candidates wait to extend a page's outline (integrate), fold
+ * into an existing argument (combine), or drop out (dismiss). Read-only —
+ * imports arrive via POST /api/v1/conversations, review moves via
+ * POST /api/v1/conversations/[id]/integrate.
+ */
+export default async function ConversationsPage() {
+  const threads = await prisma.conversationThread.findMany({
+    include: {
+      belief: { select: { slug: true, statement: true } },
+      submittedByAgent: { select: { name: true, operator: true } },
+      candidates: {
+        include: { message: { select: { index: true, authorHandle: true } } },
+        orderBy: { createdAt: 'asc' },
+      },
+      _count: { select: { messages: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 50,
+  })
+
+  return (
+    <div className="min-h-screen bg-white">
+      <nav className="bg-white border-b border-[var(--border)] sticky top-0 z-50">
+        <div className="max-w-[960px] mx-auto px-4 py-3 flex items-center gap-3">
+          <Link href="/" className="text-lg font-bold text-[var(--foreground)]">ISE</Link>
+          <span className="text-[var(--muted-foreground)]">/</span>
+          <span className="text-sm font-medium text-[var(--foreground)]">Conversations</span>
+        </div>
+      </nav>
+
+      <main className="max-w-[960px] mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-[var(--foreground)] mb-2">Conversation Integration</h1>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          Chatrooms and web forums reset discussion to zero: every thread repeats arguments made a
+          thousand times, and whatever clarity is reached dies with the scroll. Here, each imported
+          conversation plugs into its belief&apos;s permanent page — the candidate arguments mined from
+          the transcript either extend the page&apos;s pro/con outline, fold into an argument the page
+          already has, or drop out at review. Chat stays informal; the belief pages accumulate.
+        </p>
+        <p className="text-xs font-semibold border border-amber-300 bg-amber-50 p-2 mb-6">
+          {CONVERSATION_FIREWALL_LINE}
+        </p>
+
+        {threads.length === 0 ? (
+          <div className="text-center py-16 text-[var(--muted-foreground)]">
+            <p className="text-lg mb-2">No conversations imported yet.</p>
+            <p className="text-sm">Agents import transcripts via POST /api/v1/conversations with their key.</p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {threads.map(thread => (
+              <div key={thread.id} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
+                <div className="flex flex-wrap items-baseline gap-2 mb-1">
+                  <h2 className="font-semibold text-[var(--foreground)]">{thread.title}</h2>
+                  <span className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">{thread.platform}</span>
+                </div>
+                <div className="flex flex-wrap gap-3 text-xs text-[var(--muted-foreground)] mb-3">
+                  <span>
+                    {thread.submittedByAgent.name}
+                    {thread.submittedByAgent.operator ? ` (${thread.submittedByAgent.operator})` : ''}
+                  </span>
+                  <span>{thread.createdAt.toISOString().replace('T', ' ').slice(0, 16)}</span>
+                  <span>{thread._count.messages} messages</span>
+                  {thread.sourceUrl && (
+                    <a href={thread.sourceUrl} className="text-[var(--accent)] hover:underline" rel="nofollow noopener">
+                      source
+                    </a>
+                  )}
+                  {thread.belief ? (
+                    <Link href={`/beliefs/${thread.belief.slug}`} className="text-[var(--accent)] hover:underline">
+                      Page: {thread.belief.statement}
+                    </Link>
+                  ) : (
+                    <span>no belief page matched</span>
+                  )}
+                </div>
+
+                {thread.candidates.length === 0 ? (
+                  <p className="text-xs text-[var(--muted-foreground)]">No standalone claims mined from this transcript.</p>
+                ) : (
+                  <div className="space-y-1">
+                    {thread.candidates.map(candidate => (
+                      <div key={candidate.id} className="flex flex-wrap items-baseline gap-2 text-sm">
+                        <span
+                          className={`text-[10px] uppercase tracking-wide border rounded px-1 ${
+                            STATUS_STYLES[candidate.status] ?? STATUS_STYLES.dismissed
+                          }`}
+                        >
+                          {candidate.status}
+                        </span>
+                        <span
+                          className={`text-[10px] uppercase tracking-wide ${
+                            candidate.direction === 'pro' ? 'text-green-700' : 'text-red-700'
+                          }`}
+                        >
+                          {candidate.direction}
+                        </span>
+                        <span className="text-[var(--foreground)]">{candidate.statement}</span>
+                        <span className="text-xs text-[var(--muted-foreground)]">
+                          — msg #{candidate.message.index} by {candidate.message.authorHandle}
+                          {candidate.band && candidate.band !== 'distinct' ? `, ${candidate.band}` : ''}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/lib/conversations/contract.ts
+++ b/src/lib/conversations/contract.ts
@@ -1,0 +1,111 @@
+// The conversation-integration contract. Chatrooms and web forums reset
+// discussion to zero every time; the fix is architectural — every belief has
+// one permanent page, and every conversation plugs into it. A transcript is
+// imported verbatim, candidate pro/con claims are mined from it, and only an
+// explicit, audited integration move (through the same ingestion firewall as
+// everything else) turns a candidate into an Argument.
+
+import { FAILURE_MODES, type ValidationIssue } from '@/lib/agent-ingest/contract'
+
+/** Stated in code and UI, same posture as the agent forum: transcripts are
+ *  source material, never scoring inputs. */
+export const CONVERSATION_FIREWALL_LINE =
+  'Imported conversations never affect any score, ranking, or market price. ' +
+  'A mined candidate becomes an argument only through the audited ingestion ' +
+  'firewall, and the belief page is where the result accumulates.'
+
+export const CONVERSATION_PLATFORMS = [
+  'discord',
+  'reddit',
+  'twitter',
+  'forum',
+  'chat',
+  'other',
+] as const
+
+export type ConversationPlatform = (typeof CONVERSATION_PLATFORMS)[number]
+
+export interface ConversationMessageInput {
+  /** Display handle as it appeared in the conversation. */
+  author: string
+  body: string
+  /** ISO timestamp when the platform exposes one. */
+  postedAt?: string
+}
+
+export interface ConversationImportInput {
+  platform: ConversationPlatform
+  title: string
+  /** Permalink to the thread, when the platform has one. */
+  sourceUrl?: string
+  /** Slug of the belief this conversation is about. When omitted, matching
+   *  resolves the focal belief from the transcript itself. */
+  beliefSlug?: string
+  messages: ConversationMessageInput[]
+}
+
+export const MAX_MESSAGES_PER_IMPORT = 500
+
+export type ImportValidation =
+  | { ok: true; payload: ConversationImportInput }
+  | { ok: false; issues: ValidationIssue[] }
+
+/** Shape-validate an import payload. Pure; reuses the ingestion failure-mode
+ *  vocabulary so agent developers see one language everywhere. */
+export function validateConversationImport(raw: unknown): ImportValidation {
+  if (typeof raw !== 'object' || raw === null) {
+    return {
+      ok: false,
+      issues: [{ mode: FAILURE_MODES.MALFORMED_BATCH, path: '', message: 'Payload must be a JSON object.' }],
+    }
+  }
+  const p = raw as Partial<ConversationImportInput>
+  const issues: ValidationIssue[] = []
+
+  if (!CONVERSATION_PLATFORMS.includes(p.platform as ConversationPlatform)) {
+    issues.push({
+      mode: FAILURE_MODES.MALFORMED_BATCH,
+      path: 'platform',
+      message: `platform must be one of ${CONVERSATION_PLATFORMS.join(', ')}.`,
+    })
+  }
+  if (typeof p.title !== 'string' || !p.title.trim()) {
+    issues.push({ mode: FAILURE_MODES.MALFORMED_BATCH, path: 'title', message: 'title is required.' })
+  }
+  if (!Array.isArray(p.messages) || p.messages.length === 0) {
+    issues.push({
+      mode: FAILURE_MODES.MALFORMED_BATCH,
+      path: 'messages',
+      message: 'messages must be a non-empty array of { author, body }.',
+    })
+  } else if (p.messages.length > MAX_MESSAGES_PER_IMPORT) {
+    issues.push({
+      mode: FAILURE_MODES.MALFORMED_BATCH,
+      path: 'messages',
+      message: `messages is capped at ${MAX_MESSAGES_PER_IMPORT} per import; split longer threads.`,
+    })
+  } else {
+    p.messages.forEach((m, i) => {
+      const mm = m as Partial<ConversationMessageInput>
+      if (typeof mm !== 'object' || mm === null || typeof mm.author !== 'string' || !mm.author.trim()) {
+        issues.push({
+          mode: FAILURE_MODES.MALFORMED_BATCH,
+          path: `messages[${i}].author`,
+          message: 'Each message needs an author handle.',
+        })
+      }
+      if (typeof mm?.body !== 'string' || !mm.body.trim()) {
+        issues.push({
+          mode: FAILURE_MODES.MALFORMED_BATCH,
+          path: `messages[${i}].body`,
+          message: 'Each message needs a body.',
+        })
+      }
+    })
+  }
+
+  if (issues.length > 0) return { ok: false, issues }
+  return { ok: true, payload: p as ConversationImportInput }
+}
+
+export type CandidateStatus = 'pending' | 'integrated' | 'duplicate' | 'dismissed'

--- a/src/lib/conversations/extract.ts
+++ b/src/lib/conversations/extract.ts
@@ -1,0 +1,220 @@
+// Claim mining for imported conversations. Chat is noisy and chronological;
+// the belief graph wants standalone pro/con claims. This module is the pure
+// half of the bridge: strip the chat noise, split into sentences, keep only
+// sentences that could stand as claims (same standalone-claim rule the
+// ingestion firewall enforces), read each message's stance, and carry shared
+// URLs along as evidence provenance. Heuristics throughout — every output is
+// a *candidate*, pending review, never a direct graph write.
+
+import { validateStandaloneClaim } from '@/lib/agent-ingest/validate-claim'
+import { textSimilarity, SAME_CLAIM_THRESHOLD } from '@/lib/agent-ingest/similarity'
+import type { ConversationMessageInput } from './contract'
+
+export interface ExtractedCandidate {
+  /** Zero-based index of the source message in the transcript. */
+  messageIndex: number
+  /** The mined standalone claim, cleaned of chat noise. */
+  statement: string
+  /** Stance relative to the conversation's focal position. Heuristic. */
+  direction: 'pro' | 'con'
+  /** The claim in its surrounding message text, for reviewers. */
+  contextQuote: string
+  /** URLs shared in the same message, offered as evidence provenance. */
+  evidenceUrls: string[]
+  /** Argumentative signals that fired ("because", "studies show", ...). */
+  markers: string[]
+}
+
+export interface ExtractionResult {
+  candidates: ExtractedCandidate[]
+  /** Sentences considered and dropped, with the reason — extraction shows its
+   *  work the same way ingestion does. */
+  skipped: { messageIndex: number; text: string; reason: SkipReason }[]
+}
+
+export type SkipReason =
+  | 'question'
+  | 'fragment-or-label'
+  | 'social-noise'
+  | 'quoted-text'
+  | 'restates-focal-belief'
+  | 'duplicate-in-thread'
+
+const URL_PATTERN = /https?:\/\/[^\s<>()"']+/g
+
+/** Pure chat filler: a sentence that is only these carries no claim. */
+const SOCIAL_NOISE = new Set([
+  'lol', 'lmao', 'rofl', 'haha', 'hahaha', 'omg', 'wow', 'nice', 'cool',
+  'thanks', 'thx', 'ty', 'welcome', 'ok', 'okay', 'k', 'yeah', 'yes', 'no',
+  'nah', 'yep', 'nope', 'same', 'this', '+1', '-1', 'agreed', 'disagree',
+  'true', 'false', 'facts', 'based', 'bump', 'hi', 'hello', 'hey', 'bye',
+])
+
+/** Openers that signal the message pushes AGAINST the position it replies to. */
+const DISAGREEMENT_OPENERS = [
+  /^(no|nah|nope|wrong|false|incorrect)\b/i,
+  /^(i\s+)?(strongly\s+)?disagree\b/i,
+  /^that('|’)?s\s+(just\s+)?(not\s+true|wrong|false|nonsense|a\s+myth)\b/i,
+  /^(but|however|actually|except)\b/i,
+  /^not\s+(really|quite|true)\b/i,
+  /^counterpoint\b/i,
+]
+
+/** Openers that signal the message pushes WITH the position it replies to. */
+const AGREEMENT_OPENERS = [
+  /^(yes|yeah|yep|exactly|right|agreed|true)\b/i,
+  /^(i\s+)?(completely\s+|totally\s+|strongly\s+)?agree\b/i,
+  /^this\s+is\s+(right|correct|true)\b/i,
+  /^(\+1|well\s+said|good\s+point)\b/i,
+]
+
+/** First-person hedges stripped so the claim underneath can stand alone. */
+const HEDGE_PREFIX =
+  /^(i\s+(think|believe|feel|reckon|guess|mean|would\s+say)|imo|imho|in\s+my\s+(honest\s+)?opinion|personally|honestly|tbh|to\s+be\s+honest|fwiw|afaik|iirc)[,:]?\s+(that\s+)?/i
+
+/** Signals that a sentence argues rather than just chats. Recorded on the
+ *  candidate so reviewers and the integrate flow can rank by signal. */
+const ARGUMENT_MARKERS: { marker: string; pattern: RegExp }[] = [
+  { marker: 'because', pattern: /\bbecause\b/i },
+  { marker: 'since', pattern: /\bsince\b/i },
+  { marker: 'therefore', pattern: /\b(therefore|thus|hence|so\s+that)\b/i },
+  { marker: 'evidence', pattern: /\b(evidence|data|research|study|studies|meta-analysis|survey|statistics)\b/i },
+  { marker: 'shows', pattern: /\b(shows?|proves?|demonstrates?|confirms?|indicates?|found\s+that)\b/i },
+  { marker: 'causal', pattern: /\b(causes?|leads?\s+to|results?\s+in|reduces?|increases?|improves?|prevents?|harms?|kills?|saves?)\b/i },
+  { marker: 'comparison', pattern: /\b(more|less|fewer|better|worse|safer|cheaper|higher|lower)\s+than\b/i },
+  { marker: 'example', pattern: /\b(for\s+(example|instance)|e\.g\.|case\s+in\s+point|look\s+at)\b/i },
+]
+
+function stripNoise(body: string): { text: string; urls: string[] } {
+  const urls = body.match(URL_PATTERN) ?? []
+  const text = body
+    // Quoted reply lines ("> someone else's words") are someone else's words.
+    .split('\n')
+    .filter(line => !line.trimStart().startsWith('>'))
+    .join('\n')
+    .replace(URL_PATTERN, ' ')
+    .replace(/@[a-zA-Z0-9_-]+/g, ' ')
+    .replace(/:[a-z0-9_+-]+:/gi, ' ') // :emoji_codes:
+    .replace(/[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return { text, urls: [...new Set(urls)] }
+}
+
+function splitSentences(text: string): string[] {
+  return text
+    .split(/(?<=[.!?])\s+|\n+/)
+    .map(s => s.trim())
+    .filter(Boolean)
+}
+
+function isSocialNoise(sentence: string): boolean {
+  const tokens = sentence
+    .toLowerCase()
+    .replace(/[^a-z0-9+\-\s]/g, '')
+    .split(/\s+/)
+    .filter(Boolean)
+  return tokens.length === 0 || tokens.every(t => SOCIAL_NOISE.has(t))
+}
+
+function matchedMarkers(sentence: string): string[] {
+  return ARGUMENT_MARKERS.filter(m => m.pattern.test(sentence)).map(m => m.marker)
+}
+
+/** A message's stance relative to the focal position: disagreement openers
+ *  flip it to con, agreement openers keep it pro. Sentence-level negation of
+ *  the focal statement flips too (handled per sentence). */
+function messageStance(body: string): 'pro' | 'con' {
+  const head = body.trimStart()
+  if (DISAGREEMENT_OPENERS.some(p => p.test(head))) return 'con'
+  if (AGREEMENT_OPENERS.some(p => p.test(head))) return 'pro'
+  return 'pro'
+}
+
+const NEGATORS = /\b(not|never|no|isn'?t|aren'?t|doesn'?t|don'?t|won'?t|can'?t|cannot|wouldn'?t|shouldn'?t|fails?\s+to|myth|false)\b/i
+
+/** When a sentence largely restates the focal claim but negates it, the
+ *  sentence opposes the focal claim regardless of the message opener. */
+function sentenceStance(sentence: string, focalStatement: string | null, base: 'pro' | 'con'): 'pro' | 'con' {
+  if (!focalStatement) return base
+  const overlap = textSimilarity(sentence, focalStatement)
+  if (overlap >= 0.4 && NEGATORS.test(sentence) && !NEGATORS.test(focalStatement)) return 'con'
+  return base
+}
+
+function normalizeStatement(sentence: string): string {
+  let s = sentence.trim()
+  for (let i = 0; i < 3; i++) {
+    const next = s.replace(HEDGE_PREFIX, '')
+    if (next === s) break
+    s = next
+  }
+  s = s.replace(/[.!]+$/, '').trim()
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+/**
+ * Mine candidate pro/con claims from a conversation transcript.
+ *
+ * `focalStatement` is the statement of the belief the conversation is about
+ * (null when unknown at extraction time): restatements of it are skipped —
+ * the topic itself is not an argument for itself — and near-duplicates within
+ * the thread are folded so one voice saying it thrice yields one candidate.
+ */
+export function extractCandidates(
+  messages: ConversationMessageInput[],
+  focalStatement: string | null,
+): ExtractionResult {
+  const candidates: ExtractedCandidate[] = []
+  const skipped: ExtractionResult['skipped'] = []
+
+  messages.forEach((message, messageIndex) => {
+    const { text, urls } = stripNoise(message.body)
+    if (!text) {
+      if (message.body.trim()) {
+        skipped.push({ messageIndex, text: message.body.trim(), reason: 'quoted-text' })
+      }
+      return
+    }
+    const base = messageStance(text)
+
+    for (const sentence of splitSentences(text)) {
+      if (sentence.endsWith('?')) {
+        skipped.push({ messageIndex, text: sentence, reason: 'question' })
+        continue
+      }
+      if (isSocialNoise(sentence)) {
+        skipped.push({ messageIndex, text: sentence, reason: 'social-noise' })
+        continue
+      }
+
+      const statement = normalizeStatement(sentence)
+      if (validateStandaloneClaim(statement).length > 0) {
+        skipped.push({ messageIndex, text: sentence, reason: 'fragment-or-label' })
+        continue
+      }
+      if (focalStatement && textSimilarity(statement, focalStatement) >= SAME_CLAIM_THRESHOLD) {
+        skipped.push({ messageIndex, text: sentence, reason: 'restates-focal-belief' })
+        continue
+      }
+      // Fold near-duplicates within the thread: the first voicing keeps the
+      // candidacy; later restatements are the exact repetition problem this
+      // pipeline exists to end.
+      if (candidates.some(c => textSimilarity(statement, c.statement) >= SAME_CLAIM_THRESHOLD)) {
+        skipped.push({ messageIndex, text: sentence, reason: 'duplicate-in-thread' })
+        continue
+      }
+
+      candidates.push({
+        messageIndex,
+        statement,
+        direction: sentenceStance(statement, focalStatement, base),
+        contextQuote: text.length <= 280 ? text : sentence,
+        evidenceUrls: urls,
+        markers: matchedMarkers(sentence),
+      })
+    }
+  })
+
+  return { candidates, skipped }
+}

--- a/src/lib/conversations/import.ts
+++ b/src/lib/conversations/import.ts
@@ -1,0 +1,190 @@
+// Conversation import: transcript in, pending candidates out. This is the
+// "find" half of conversation integration — it stores the verbatim thread,
+// mines candidate pro/con claims, resolves the permanent belief page the
+// conversation plugs into, and runs the redundancy scan against the page's
+// existing arguments. It writes NO graph rows: no Belief (beyond a named-slug
+// stub), no Argument, no Evidence, no score. The graph moves only when
+// integrate.ts pushes accepted candidates through the ingestion firewall.
+
+import { prisma } from '@/lib/prisma'
+import type { Prisma } from '@/generated/prisma/client'
+import { validateConversationImport } from './contract'
+import type { ValidationIssue } from '@/lib/agent-ingest/contract'
+import { extractCandidates, type ExtractionResult } from './extract'
+import { pickFocalBelief, scanNearestArgument, type SiblingArgumentRow } from './match'
+import { slugify } from '@/lib/agent-ingest/slug'
+
+type Tx = Prisma.TransactionClient
+
+export interface ImportedCandidate {
+  id: string
+  messageIndex: number
+  statement: string
+  direction: string
+  band: string | null
+  similarity: number | null
+  nearestArgumentId: number | null
+  evidenceUrls: string[]
+}
+
+export type ImportOutcome =
+  | {
+      ok: true
+      threadId: string
+      belief: { id: number; slug: string; statement: string } | null
+      candidates: ImportedCandidate[]
+      skipped: ExtractionResult['skipped']
+    }
+  | { ok: false; status: number; issues: ValidationIssue[] }
+
+async function audit(
+  tx: Tx,
+  row: { agentId: string; action: string; targetType: string; targetId: string; rationale: string; payload?: unknown },
+) {
+  await tx.auditLog.create({
+    data: {
+      agentId: row.agentId,
+      action: row.action,
+      targetType: row.targetType,
+      targetId: row.targetId,
+      rationale: row.rationale,
+      payload: row.payload === undefined ? null : JSON.stringify(row.payload),
+    },
+  })
+}
+
+/**
+ * Import one conversation. Extraction runs twice when the focal belief is
+ * resolved by matching rather than named: the second pass knows the focal
+ * statement, so restatements of it are skipped and negation stances read
+ * correctly. Extraction is cheap text work; correctness wins.
+ */
+export async function runConversationImport(agentId: string, rawPayload: unknown): Promise<ImportOutcome> {
+  const validation = validateConversationImport(rawPayload)
+  if (!validation.ok) return { ok: false, status: 422, issues: validation.issues }
+  const payload = validation.payload
+
+  // Resolve the permanent page this conversation plugs into.
+  let focal: { id: number; slug: string; statement: string } | null = null
+  let createdStub = false
+  if (payload.beliefSlug) {
+    const slug = slugify(payload.beliefSlug.trim())
+    const existing = await prisma.belief.findUnique({ where: { slug } })
+    if (existing) {
+      focal = { id: existing.id, slug: existing.slug, statement: existing.statement }
+    } else {
+      // Same posture as ingestion's parent resolution: a named slug with no
+      // page yet gets a stub page, so the conversation still has a home.
+      const created = await prisma.belief.create({ data: { slug, statement: payload.beliefSlug.trim() } })
+      focal = { id: created.id, slug: created.slug, statement: created.statement }
+      createdStub = true
+    }
+  } else {
+    const firstPass = extractCandidates(payload.messages, null)
+    const beliefs = await prisma.belief.findMany({ select: { id: true, slug: true, statement: true } })
+    const match = pickFocalBelief(payload.title, firstPass.candidates, beliefs)
+    if (match) focal = match.belief
+  }
+
+  const extraction = extractCandidates(payload.messages, focal?.statement ?? null)
+
+  // Redundancy scan targets: the focal page's existing arguments, labeled by
+  // their claim label or their belief's statement.
+  let siblings: SiblingArgumentRow[] = []
+  if (focal) {
+    const rows = await prisma.argument.findMany({
+      where: { parentBeliefId: focal.id },
+      include: { belief: { select: { statement: true } } },
+    })
+    siblings = rows.map(r => ({ id: r.id, side: r.side, statement: r.claim ?? r.belief.statement }))
+  }
+
+  const result = await prisma.$transaction(async tx => {
+    const thread = await tx.conversationThread.create({
+      data: {
+        platform: payload.platform,
+        title: payload.title.trim(),
+        sourceUrl: payload.sourceUrl ?? null,
+        beliefId: focal?.id ?? null,
+        submittedByAgentId: agentId,
+      },
+    })
+    if (createdStub && focal) {
+      await audit(tx, {
+        agentId,
+        action: 'create_belief',
+        targetType: 'Belief',
+        targetId: String(focal.id),
+        rationale: `Stub belief created for named slug "${focal.slug}" while importing conversation "${thread.title}".`,
+      })
+    }
+    await audit(tx, {
+      agentId,
+      action: 'import_conversation',
+      targetType: 'ConversationThread',
+      targetId: thread.id,
+      rationale:
+        `Imported ${payload.messages.length}-message ${payload.platform} conversation "${thread.title}"` +
+        (focal ? ` plugged into belief "${focal.slug}".` : ' with no matching belief page yet.'),
+      payload,
+    })
+
+    const messages = []
+    for (let i = 0; i < payload.messages.length; i++) {
+      const m = payload.messages[i]
+      messages.push(
+        await tx.conversationMessage.create({
+          data: {
+            threadId: thread.id,
+            index: i,
+            authorHandle: m.author.trim(),
+            body: m.body,
+            postedAt: m.postedAt ? new Date(m.postedAt) : null,
+          },
+        }),
+      )
+    }
+
+    const candidates: ImportedCandidate[] = []
+    for (const c of extraction.candidates) {
+      const nearest = scanNearestArgument(c.statement, c.direction, siblings)
+      const row = await tx.argumentCandidate.create({
+        data: {
+          threadId: thread.id,
+          messageId: messages[c.messageIndex].id,
+          statement: c.statement,
+          direction: c.direction,
+          contextQuote: c.contextQuote,
+          evidenceUrls: c.evidenceUrls.length > 0 ? c.evidenceUrls.join('\n') : null,
+          beliefId: focal?.id ?? null,
+          nearestArgumentId: nearest?.argumentId ?? null,
+          similarity: nearest?.similarity ?? null,
+          band: nearest?.band ?? null,
+        },
+      })
+      candidates.push({
+        id: row.id,
+        messageIndex: c.messageIndex,
+        statement: c.statement,
+        direction: c.direction,
+        band: row.band,
+        similarity: row.similarity,
+        nearestArgumentId: row.nearestArgumentId,
+        evidenceUrls: c.evidenceUrls,
+      })
+      await audit(tx, {
+        agentId,
+        action: 'mine_candidate',
+        targetType: 'ArgumentCandidate',
+        targetId: row.id,
+        rationale:
+          `Mined ${c.direction} candidate from message #${c.messageIndex}` +
+          (nearest ? ` (nearest existing argument #${nearest.argumentId}, band ${nearest.band}).` : ' (no similar existing argument).'),
+      })
+    }
+
+    return { threadId: thread.id, candidates }
+  }, { timeout: 60_000 })
+
+  return { ok: true, threadId: result.threadId, belief: focal, candidates: result.candidates, skipped: extraction.skipped }
+}

--- a/src/lib/conversations/integrate.ts
+++ b/src/lib/conversations/integrate.ts
@@ -1,0 +1,257 @@
+// The "integrate" half: accepted candidates become Arguments through the
+// SAME ingestion firewall as every other move — validated payload, five-step
+// linkage check, mandatory rationale, audit rows, no scores. Review actions:
+//   integrate — extend the belief page's outline with a new pro/con argument
+//   fold      — combine: the point restates an existing argument; record that
+//               and stop (no new row, no double-counting)
+//   dismiss   — not an argument after all
+// Nothing auto-integrates. The transcript stays inert until someone accountable
+// pushes a candidate through.
+
+import { prisma } from '@/lib/prisma'
+import { runIngest, type IngestedClaimResult } from '@/lib/agent-ingest/ingest'
+import { FAILURE_MODES, type IngestClaimInput, type ValidationIssue } from '@/lib/agent-ingest/contract'
+
+export interface CandidateIntegration {
+  candidateId: string
+  /** Step 3 of the five-step check. When omitted, a draft mechanism is
+   *  composed from the conversation context and the check is flagged for
+   *  review — an auto-draft is never presented as a considered judgment. */
+  howItSupports?: string
+  /** Step 4 author bracket, [0,1]. Defaults to 0.5 (flagged). */
+  provisionalEstimate?: number
+  /** Correct the heuristic stance read when the reviewer knows better. */
+  direction?: 'pro' | 'con'
+}
+
+export interface IntegrateRequest {
+  integrate?: CandidateIntegration[]
+  fold?: string[]
+  dismiss?: string[]
+}
+
+export type IntegrateOutcome =
+  | {
+      ok: true
+      batchId: string | null
+      integrated: { candidateId: string; argumentId: number; beliefSlug: string }[]
+      folded: string[]
+      dismissed: string[]
+      changedBeliefIds: number[]
+    }
+  | { ok: false; status: number; issues: ValidationIssue[]; auditLock?: boolean }
+
+const issue = (path: string, message: string): ValidationIssue => ({
+  mode: FAILURE_MODES.MALFORMED_BATCH,
+  path,
+  message,
+})
+
+/**
+ * Apply one review pass over a thread's candidates. Integrations run as one
+ * ingest batch (all-or-nothing, same replayable audit trail); folds and
+ * dismissals are status moves with their own audit rows.
+ */
+export async function integrateCandidates(
+  agentId: string,
+  threadId: string,
+  request: IntegrateRequest,
+): Promise<IntegrateOutcome> {
+  if (
+    (request.integrate !== undefined && !Array.isArray(request.integrate)) ||
+    (request.fold !== undefined && !Array.isArray(request.fold)) ||
+    (request.dismiss !== undefined && !Array.isArray(request.dismiss))
+  ) {
+    return { ok: false, status: 422, issues: [issue('', 'integrate, fold, and dismiss must be arrays when present.')] }
+  }
+  const integrations = (request.integrate ?? []).filter(
+    (s): s is CandidateIntegration => typeof s === 'object' && s !== null && typeof s.candidateId === 'string',
+  )
+  if (integrations.length !== (request.integrate ?? []).length) {
+    return {
+      ok: false,
+      status: 422,
+      issues: [issue('integrate', 'Each integrate entry must be an object with a candidateId.')],
+    }
+  }
+  const foldIds = (request.fold ?? []).filter((id): id is string => typeof id === 'string')
+  const dismissIds = (request.dismiss ?? []).filter((id): id is string => typeof id === 'string')
+  if (integrations.length === 0 && foldIds.length === 0 && dismissIds.length === 0) {
+    return { ok: false, status: 422, issues: [issue('', 'Nothing to do: provide integrate, fold, or dismiss.')] }
+  }
+
+  const thread = await prisma.conversationThread.findUnique({
+    where: { id: threadId },
+    include: { belief: true },
+  })
+  if (!thread) {
+    return { ok: false, status: 404, issues: [issue('threadId', `No conversation thread "${threadId}".`)] }
+  }
+
+  const referencedIds = [
+    ...integrations.map(s => s.candidateId),
+    ...foldIds,
+    ...dismissIds,
+  ]
+  const candidates = await prisma.argumentCandidate.findMany({
+    where: { id: { in: referencedIds }, threadId },
+    include: { message: true, belief: true },
+  })
+  const byId = new Map(candidates.map(c => [c.id, c]))
+
+  const issues: ValidationIssue[] = []
+  referencedIds.forEach(id => {
+    const c = byId.get(id)
+    if (!c) issues.push(issue(id, `Candidate "${id}" not found in this thread.`))
+    else if (c.status !== 'pending') issues.push(issue(id, `Candidate "${id}" is already ${c.status}.`))
+  })
+  integrations.forEach(s => {
+    const c = byId.get(s.candidateId)
+    if (c && !c.belief) {
+      issues.push(
+        issue(
+          s.candidateId,
+          'Candidate has no matched belief page. Re-import the conversation with beliefSlug to give it a home first.',
+        ),
+      )
+    }
+    if (
+      s.provisionalEstimate !== undefined &&
+      !(typeof s.provisionalEstimate === 'number' && s.provisionalEstimate >= 0 && s.provisionalEstimate <= 1)
+    ) {
+      issues.push(issue(`${s.candidateId}.provisionalEstimate`, 'provisionalEstimate must be a number in [0,1].'))
+    }
+    if (s.direction !== undefined && s.direction !== 'pro' && s.direction !== 'con') {
+      issues.push(issue(`${s.candidateId}.direction`, 'direction must be "pro" or "con".'))
+    }
+  })
+  foldIds.forEach(id => {
+    const c = byId.get(id)
+    if (c && c.nearestArgumentId === null) {
+      issues.push(issue(id, 'Cannot fold: no nearest existing argument was recorded for this candidate.'))
+    }
+  })
+  if (issues.length > 0) return { ok: false, status: 422, issues }
+
+  // Build the ingest batch. The firewall re-validates everything: standalone
+  // claims, five-step completeness, evidence provenance, no score fields.
+  let batchId: string | null = null
+  const integrated: { candidateId: string; argumentId: number; beliefSlug: string }[] = []
+  let ingestClaims: IngestedClaimResult[] = []
+
+  if (integrations.length > 0) {
+    const claims: IngestClaimInput[] = integrations.map(s => {
+      const c = byId.get(s.candidateId)!
+      const belief = c.belief!
+      const autoDrafted = !s.howItSupports?.trim()
+      const quote = c.contextQuote ?? c.statement
+      return {
+        statement: c.statement,
+        direction: (s.direction ?? c.direction) as 'pro' | 'con',
+        parentBeliefSlug: belief.slug,
+        rationale:
+          `Mined from ${thread.platform} conversation "${thread.title}", message #${c.message.index} ` +
+          `by ${c.message.authorHandle}: "${quote}". Integrated from candidate ${c.id} by review.`,
+        fiveStepCheck: {
+          parentWording: belief.statement,
+          claimWording: c.statement,
+          howItSupports: s.howItSupports?.trim()
+            ? s.howItSupports.trim()
+            : `Offered in conversation as a ${s.direction ?? c.direction} point on the parent claim: "${quote}"`,
+          provisionalEstimate: s.provisionalEstimate ?? 0.5,
+          flaggedBelowThreshold: autoDrafted || (s.provisionalEstimate ?? 0.5) < 0.5,
+          flagNote: autoDrafted
+            ? 'Mechanism auto-drafted from conversation context; review the linkage before trusting it.'
+            : undefined,
+        },
+        evidence: (c.evidenceUrls?.split('\n').filter(Boolean) ?? []).map(url => ({
+          title: `Source shared by ${c.message.authorHandle} in "${thread.title}"`,
+          sourceUrl: url,
+        })),
+      }
+    })
+
+    const outcome = await runIngest(agentId, {
+      batchTitle: `Conversation integration: ${thread.title}`,
+      sourceDocumentUrl: thread.sourceUrl ?? undefined,
+      claims,
+    })
+    if (!outcome.ok) return outcome
+    batchId = outcome.batchId
+    ingestClaims = outcome.claims
+  }
+
+  const now = new Date()
+  await prisma.$transaction(async tx => {
+    for (let i = 0; i < integrations.length; i++) {
+      const s = integrations[i]
+      const claim = ingestClaims[i]
+      await tx.argumentCandidate.update({
+        where: { id: s.candidateId },
+        data: {
+          status: 'integrated',
+          integratedArgumentId: claim.argumentId,
+          integratedBatchId: batchId,
+          resolvedAt: now,
+        },
+      })
+      integrated.push({
+        candidateId: s.candidateId,
+        argumentId: claim.argumentId,
+        beliefSlug: claim.parentBeliefSlug,
+      })
+      await tx.auditLog.create({
+        data: {
+          agentId,
+          batchId,
+          action: 'integrate_candidate',
+          targetType: 'ArgumentCandidate',
+          targetId: s.candidateId,
+          rationale: `Candidate integrated as argument #${claim.argumentId} under "${claim.parentBeliefSlug}" via the ingestion firewall.`,
+        },
+      })
+    }
+    for (const id of foldIds) {
+      const c = byId.get(id)!
+      await tx.argumentCandidate.update({
+        where: { id },
+        data: { status: 'duplicate', resolvedAt: now },
+      })
+      await tx.auditLog.create({
+        data: {
+          agentId,
+          action: 'fold_candidate',
+          targetType: 'ArgumentCandidate',
+          targetId: id,
+          rationale:
+            `Candidate folded as a restatement of existing argument #${c.nearestArgumentId} ` +
+            `(similarity ${c.similarity?.toFixed(2) ?? '?'}). The conversation point is already on the page.`,
+        },
+      })
+    }
+    for (const id of dismissIds) {
+      await tx.argumentCandidate.update({
+        where: { id },
+        data: { status: 'dismissed', resolvedAt: now },
+      })
+      await tx.auditLog.create({
+        data: {
+          agentId,
+          action: 'dismiss_candidate',
+          targetType: 'ArgumentCandidate',
+          targetId: id,
+          rationale: 'Candidate dismissed at review: not a usable standalone argument.',
+        },
+      })
+    }
+  }, { timeout: 60_000 })
+
+  return {
+    ok: true,
+    batchId,
+    integrated,
+    folded: foldIds,
+    dismissed: dismissIds,
+    changedBeliefIds: [...new Set(ingestClaims.map(c => c.beliefId))],
+  }
+}

--- a/src/lib/conversations/match.ts
+++ b/src/lib/conversations/match.ts
@@ -1,0 +1,87 @@
+// Matching mined candidates into the belief graph. Pure functions over
+// caller-supplied rows: pick the permanent page a conversation plugs into,
+// and run the redundancy scan against the arguments already on that page so
+// review sees "extends the outline" vs "restates row #N" at a glance. The
+// similarity bands route; nothing here merges, writes, or scores.
+
+import { textSimilarity, similarityBand, type SimilarityBand } from '@/lib/agent-ingest/similarity'
+import type { ExtractedCandidate } from './extract'
+
+export interface BeliefRow {
+  id: number
+  slug: string
+  statement: string
+}
+
+export interface SiblingArgumentRow {
+  id: number
+  side: 'agree' | 'disagree' | string
+  /** The argument's label or its belief's statement — whatever text stands for it. */
+  statement: string
+}
+
+/** Minimum similarity between a conversation and a belief statement before
+ *  the conversation is considered to be "about" that belief. Below this, the
+ *  thread gets no focal page and every candidate proposes a new belief. */
+export const FOCAL_MATCH_THRESHOLD = 0.3
+
+export interface FocalMatch {
+  belief: BeliefRow
+  similarity: number
+}
+
+/**
+ * Resolve which permanent page a conversation plugs into: the belief whose
+ * statement best matches the thread title and the mined claims themselves.
+ * Title similarity counts double — people name threads after the position
+ * under debate.
+ */
+export function pickFocalBelief(
+  title: string,
+  candidates: ExtractedCandidate[],
+  beliefs: BeliefRow[],
+): FocalMatch | null {
+  let best: FocalMatch | null = null
+  for (const belief of beliefs) {
+    const titleSim = textSimilarity(title, belief.statement)
+    let candidateSim = 0
+    for (const c of candidates) {
+      const s = textSimilarity(c.statement, belief.statement)
+      if (s > candidateSim) candidateSim = s
+    }
+    const combined = (2 * titleSim + candidateSim) / 3
+    if (combined >= FOCAL_MATCH_THRESHOLD && (best === null || combined > best.similarity)) {
+      best = { belief, similarity: combined }
+    }
+  }
+  return best
+}
+
+export interface NearestArgument {
+  argumentId: number
+  similarity: number
+  band: SimilarityBand
+}
+
+/**
+ * Redundancy scan for one candidate against the same-side arguments already
+ * under the focal belief. "same-claim" folds into the existing row at review
+ * (combine); "probable-group"/"related-link" integrate with the cluster
+ * recorded; "distinct" extends the outline.
+ */
+export function scanNearestArgument(
+  statement: string,
+  direction: 'pro' | 'con',
+  siblings: SiblingArgumentRow[],
+): NearestArgument | null {
+  const side = direction === 'pro' ? 'agree' : 'disagree'
+  let best: NearestArgument | null = null
+  for (const sibling of siblings) {
+    if (sibling.side !== side) continue
+    const similarity = textSimilarity(statement, sibling.statement)
+    if (best === null || similarity > best.similarity) {
+      best = { argumentId: sibling.id, similarity, band: similarityBand(similarity) }
+    }
+  }
+  return best
+}

--- a/src/lib/conversations/outline.ts
+++ b/src/lib/conversations/outline.ts
@@ -1,0 +1,182 @@
+// The organized pro/con outline of a belief page: what a newcomer sees so no
+// conversation starts from zero. Three moves, all read-only:
+//   combine  — equivalent same-side arguments cluster under one lead row
+//              (community-grouped pairs plus high-similarity open candidates)
+//   organize — clusters rank by score, descending, nulls last (Rule 8)
+//   extend   — leads with no engaging counter-argument surface as gaps, the
+//              outline's explicit invitation for the next conversation
+// Plus the incoming lane: pending conversation candidates waiting on review.
+
+import { prisma } from '@/lib/prisma'
+import { rankByScore, TABLE_TOP_LIMIT } from '@/features/belief-analysis/lib/ranking'
+import { textSimilarity, RESTATEMENT_SPEEDBUMP_THRESHOLD } from '@/lib/agent-ingest/similarity'
+
+export interface OutlineArgument {
+  id: number
+  side: 'agree' | 'disagree' | string
+  /** Claim label or the argument-belief's statement. */
+  label: string
+  /** Slug of the argument's own belief page. */
+  slug: string
+  score: number | null
+}
+
+export interface EquivalencePair {
+  a: number
+  b: number
+}
+
+export interface OutlineCluster {
+  lead: OutlineArgument
+  /** Combined restatements, score-ordered under the lead. */
+  members: OutlineArgument[]
+}
+
+export interface OutlineGap {
+  /** The side that has no answer yet. */
+  side: 'pro' | 'con'
+  /** The unanswered opposing lead. */
+  answering: string
+  prompt: string
+}
+
+export interface IncomingCandidate {
+  candidateId: string
+  statement: string
+  direction: string
+  band: string | null
+  thread: { id: string; title: string; platform: string }
+}
+
+export interface BeliefOutline {
+  belief: { id: number; slug: string; statement: string }
+  pro: { top: OutlineCluster[]; rest: OutlineCluster[] }
+  con: { top: OutlineCluster[]; rest: OutlineCluster[] }
+  gaps: OutlineGap[]
+  incoming: IncomingCandidate[]
+}
+
+/** Similarity at which an opposing argument counts as engaging a lead: well
+ *  below the equivalence bands — a counter shares content with what it
+ *  answers, it does not restate it. */
+export const ENGAGEMENT_THRESHOLD = 0.3
+
+function clusterSide(args: OutlineArgument[], pairs: EquivalencePair[]): OutlineCluster[] {
+  const parent = new Map<number, number>()
+  const find = (x: number): number => {
+    let root = x
+    while (parent.get(root) !== root) root = parent.get(root)!
+    // Path compression keeps repeated finds cheap on long chains.
+    let cur = x
+    while (parent.get(cur) !== root) {
+      const next = parent.get(cur)!
+      parent.set(cur, root)
+      cur = next
+    }
+    return root
+  }
+  for (const a of args) parent.set(a.id, a.id)
+  for (const { a, b } of pairs) {
+    if (parent.has(a) && parent.has(b)) parent.set(find(a), find(b))
+  }
+
+  const groups = new Map<number, OutlineArgument[]>()
+  for (const arg of args) {
+    const root = find(arg.id)
+    const group = groups.get(root)
+    if (group) group.push(arg)
+    else groups.set(root, [arg])
+  }
+
+  return [...groups.values()].map(group => {
+    const { top, rest } = rankByScore(group, g => g.score, 1)
+    return { lead: top[0], members: rest }
+  })
+}
+
+/**
+ * Pure organizer. `pairs` are equivalence pairs among the given arguments
+ * (community-grouped rows and open high-similarity candidates); clustering
+ * only ever combines same-side rows because opposite sides never share a
+ * pair's meaning in this outline.
+ */
+export function organizeOutline(
+  args: OutlineArgument[],
+  pairs: EquivalencePair[],
+  limit: number = TABLE_TOP_LIMIT,
+): Pick<BeliefOutline, 'pro' | 'con' | 'gaps'> {
+  const bySide = (side: string) => args.filter(a => a.side === side)
+  const sideOf = new Map(args.map(a => [a.id, a.side]))
+  const samesidePairs = pairs.filter(p => sideOf.get(p.a) === sideOf.get(p.b))
+
+  const proClusters = clusterSide(bySide('agree'), samesidePairs)
+  const conClusters = clusterSide(bySide('disagree'), samesidePairs)
+
+  const rank = (clusters: OutlineCluster[]) => rankByScore(clusters, c => c.lead.score, limit)
+
+  const gaps: OutlineGap[] = []
+  const findGaps = (leads: OutlineCluster[], opponents: OutlineArgument[], side: 'pro' | 'con') => {
+    for (const cluster of leads) {
+      const engaged = opponents.some(o => textSimilarity(o.label, cluster.lead.label) >= ENGAGEMENT_THRESHOLD)
+      if (!engaged) {
+        gaps.push({
+          side,
+          answering: cluster.lead.label,
+          prompt: `No ${side} argument yet engages "${cluster.lead.label}". The outline extends here.`,
+        })
+      }
+    }
+  }
+  findGaps(proClusters, bySide('disagree'), 'con')
+  findGaps(conClusters, bySide('agree'), 'pro')
+
+  return { pro: rank(proClusters), con: rank(conClusters), gaps }
+}
+
+/**
+ * Build the outline for one belief from the live graph: published arguments,
+ * their equivalence clusters, and the pending conversation candidates queued
+ * against the page.
+ */
+export async function buildBeliefOutline(beliefId: number): Promise<BeliefOutline | null> {
+  const belief = await prisma.belief.findUnique({ where: { id: beliefId } })
+  if (!belief) return null
+
+  const rows = await prisma.argument.findMany({
+    where: { parentBeliefId: beliefId, status: 'published' },
+    include: { belief: { select: { slug: true, statement: true } } },
+  })
+  const args: OutlineArgument[] = rows.map(r => ({
+    id: r.id,
+    side: r.side,
+    label: r.claim ?? r.belief.statement,
+    slug: r.belief.slug,
+    score: r.argumentScore,
+  }))
+
+  const ids = args.map(a => a.id)
+  const pairRows = await prisma.equivalenceCandidate.findMany({
+    where: { argumentId: { in: ids }, existingArgumentId: { in: ids } },
+  })
+  const pairs: EquivalencePair[] = pairRows
+    .filter(p => p.status === 'grouped' || (p.status === 'open' && p.similarity >= RESTATEMENT_SPEEDBUMP_THRESHOLD))
+    .map(p => ({ a: p.argumentId, b: p.existingArgumentId }))
+
+  const pending = await prisma.argumentCandidate.findMany({
+    where: { beliefId, status: 'pending' },
+    include: { thread: { select: { id: true, title: true, platform: true } } },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return {
+    belief: { id: belief.id, slug: belief.slug, statement: belief.statement },
+    ...organizeOutline(args, pairs),
+    incoming: pending.map(c => ({
+      candidateId: c.id,
+      statement: c.statement,
+      direction: c.direction,
+      band: c.band,
+      thread: c.thread,
+    })),
+  }
+}

--- a/tests/unit/lib/conversations/conversation-firewall.test.ts
+++ b/tests/unit/lib/conversations/conversation-firewall.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Invariant: imported conversations are source material, never scoring
+ * inputs. Transcripts, messages, and mined candidates must be absent from
+ * every scoring-adjacent module, and the conversation write paths must never
+ * touch a score column — the only way a conversation changes the graph is
+ * integration through the ingestion firewall. Same posture (and same test
+ * shape) as the agent-forum firewall.
+ */
+
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+const SRC_ROOT = path.resolve(__dirname, '../../../../src')
+
+const CONVERSATION_REFERENCE = /conversationThread|conversationMessage|argumentCandidate/i
+const SCORING_PATH = /scoring|score|reasonrank|propagate|ranking|arbitrage|market/i
+
+function walk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) return walk(full)
+    return /\.(ts|tsx)$/.test(entry.name) ? [full] : []
+  })
+}
+
+describe('conversation firewall', () => {
+  const allFiles = walk(SRC_ROOT)
+
+  it('no scoring-adjacent module references conversation tables', () => {
+    const scoringFiles = allFiles.filter(f => {
+      const rel = path.relative(SRC_ROOT, f).replace(/\\/g, '/')
+      // The conversation feature's own modules are allowed to reference them.
+      if (rel.includes('conversations')) return false
+      return SCORING_PATH.test(rel)
+    })
+    expect(scoringFiles.length).toBeGreaterThan(0)
+
+    const offenders = scoringFiles.filter(f => CONVERSATION_REFERENCE.test(fs.readFileSync(f, 'utf8')))
+    expect(offenders.map(f => path.relative(SRC_ROOT, f))).toEqual([])
+  })
+
+  it('conversation write paths never touch score columns', () => {
+    const writePaths = allFiles.filter(f => {
+      const rel = path.relative(SRC_ROOT, f).replace(/\\/g, '/')
+      // outline.ts is the read-only organizer — it reads argumentScore to
+      // rank rows (Rule 8) and writes nothing.
+      return (
+        (rel.startsWith('lib/conversations/') && !rel.endsWith('outline.ts')) ||
+        rel.includes('api/v1/conversations')
+      )
+    })
+    expect(writePaths.length).toBeGreaterThan(0)
+
+    const scoreWrite = /linkageScore|impactScore|argumentScore|importanceScore|truthScore|evsScore|reasonRank/
+    const offenders = writePaths.filter(f => scoreWrite.test(fs.readFileSync(f, 'utf8')))
+    expect(offenders.map(f => path.relative(SRC_ROOT, f))).toEqual([])
+  })
+})

--- a/tests/unit/lib/conversations/extract.test.ts
+++ b/tests/unit/lib/conversations/extract.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { extractCandidates } from '@/lib/conversations/extract'
+
+const msg = (author: string, body: string) => ({ author, body })
+
+describe('extractCandidates (find arguments in chat noise)', () => {
+  it('mines a standalone claim and keeps the argumentative markers', () => {
+    const { candidates } = extractCandidates(
+      [msg('ada', 'Nuclear power has the lowest deaths per terawatt hour because reactors rarely fail')],
+      null,
+    )
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].statement).toBe(
+      'Nuclear power has the lowest deaths per terawatt hour because reactors rarely fail',
+    )
+    expect(candidates[0].direction).toBe('pro')
+    expect(candidates[0].markers).toContain('because')
+    expect(candidates[0].messageIndex).toBe(0)
+  })
+
+  it('reads a disagreement opener as a con stance', () => {
+    const { candidates } = extractCandidates(
+      [msg('bob', 'No, that is wrong. Nuclear plants take a decade to build while emissions keep rising')],
+      null,
+    )
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].direction).toBe('con')
+  })
+
+  it('flips stance when a sentence negates the focal statement', () => {
+    const focal = 'Nuclear power is the safest energy source'
+    const { candidates } = extractCandidates(
+      [msg('cat', 'Nuclear power is not the safest energy source at all')],
+      focal,
+    )
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].direction).toBe('con')
+  })
+
+  it('skips questions, fragments, and social noise with named reasons', () => {
+    const { candidates, skipped } = extractCandidates(
+      [
+        msg('dee', 'What about the waste storage problem?'),
+        msg('eve', 'lol this'),
+        msg('fay', 'Big if true'),
+      ],
+      null,
+    )
+    expect(candidates).toHaveLength(0)
+    expect(skipped.map(s => s.reason)).toEqual(['question', 'social-noise', 'fragment-or-label'])
+  })
+
+  it('strips first-person hedges so the claim underneath stands alone', () => {
+    const { candidates } = extractCandidates(
+      [msg('gil', 'I think carbon taxes lower household emissions faster than subsidies')],
+      null,
+    )
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].statement).toBe('Carbon taxes lower household emissions faster than subsidies')
+  })
+
+  it('captures shared URLs as evidence provenance and removes them from the claim', () => {
+    const { candidates } = extractCandidates(
+      [msg('hal', 'Deaths per terawatt hour are lowest for nuclear https://ourworldindata.org/safest-sources-of-energy')],
+      null,
+    )
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].statement).not.toContain('http')
+    expect(candidates[0].evidenceUrls).toEqual(['https://ourworldindata.org/safest-sources-of-energy'])
+  })
+
+  it('ignores quoted reply lines — someone else already said them', () => {
+    const { candidates } = extractCandidates(
+      [msg('ivy', '> nuclear power is extremely dangerous\nThe danger claim traces to old coverage rather than the recorded death data')],
+      null,
+    )
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].statement).not.toContain('extremely dangerous')
+  })
+
+  it('skips restatements of the focal belief — the topic is not an argument for itself', () => {
+    const focal = 'Nuclear power is the safest large-scale energy source'
+    const { candidates, skipped } = extractCandidates(
+      [msg('joe', 'Nuclear power is the safest large-scale energy source')],
+      focal,
+    )
+    expect(candidates).toHaveLength(0)
+    expect(skipped[0].reason).toBe('restates-focal-belief')
+  })
+
+  it('folds near-duplicate claims within a thread — first voicing keeps the candidacy', () => {
+    const { candidates, skipped } = extractCandidates(
+      [
+        msg('kim', 'Nuclear power has the lowest deaths per terawatt hour of any source'),
+        msg('lou', 'Nuclear power has the lowest deaths per terawatt hour of any source'),
+      ],
+      null,
+    )
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].messageIndex).toBe(0)
+    expect(skipped.some(s => s.reason === 'duplicate-in-thread' && s.messageIndex === 1)).toBe(true)
+  })
+
+  it('strips @mentions before judging the sentence', () => {
+    const { candidates } = extractCandidates(
+      [msg('mia', '@bob renewable storage costs fell ninety percent over the last decade')],
+      null,
+    )
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].statement).not.toContain('@bob')
+  })
+
+  it('carries no numeric fields — extraction finds structure, never scores', () => {
+    const { candidates } = extractCandidates(
+      [msg('ned', 'Grid-scale batteries make intermittent sources reliable because storage smooths demand peaks')],
+      null,
+    )
+    for (const c of candidates) {
+      for (const [key, value] of Object.entries(c)) {
+        if (key === 'messageIndex') continue
+        expect(typeof value === 'number').toBe(false)
+      }
+    }
+  })
+})

--- a/tests/unit/lib/conversations/match.test.ts
+++ b/tests/unit/lib/conversations/match.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { pickFocalBelief, scanNearestArgument, FOCAL_MATCH_THRESHOLD } from '@/lib/conversations/match'
+import type { ExtractedCandidate } from '@/lib/conversations/extract'
+
+const candidate = (statement: string): ExtractedCandidate => ({
+  messageIndex: 0,
+  statement,
+  direction: 'pro',
+  contextQuote: statement,
+  evidenceUrls: [],
+  markers: [],
+})
+
+const beliefs = [
+  { id: 1, slug: 'nuclear-safest', statement: 'Nuclear power is the safest large-scale energy source' },
+  { id: 2, slug: 'carbon-tax', statement: 'A carbon tax reduces emissions more efficiently than regulation' },
+]
+
+describe('pickFocalBelief (which permanent page does this conversation plug into)', () => {
+  it('matches a thread to the belief its title and claims discuss', () => {
+    const match = pickFocalBelief(
+      'Nuclear power is the safest energy source — change my mind',
+      [candidate('Nuclear power has the lowest deaths per terawatt hour of any large-scale source')],
+      beliefs,
+    )
+    expect(match?.belief.id).toBe(1)
+    expect(match!.similarity).toBeGreaterThanOrEqual(FOCAL_MATCH_THRESHOLD)
+  })
+
+  it('returns null when no belief page is about the conversation', () => {
+    const match = pickFocalBelief(
+      'Best pizza toppings ranked',
+      [candidate('Pineapple belongs on pizza because sweetness balances the salt')],
+      beliefs,
+    )
+    expect(match).toBeNull()
+  })
+})
+
+describe('scanNearestArgument (extend the outline vs restate a row)', () => {
+  const siblings = [
+    { id: 10, side: 'agree', statement: 'Nuclear has the lowest deaths per terawatt hour' },
+    { id: 11, side: 'disagree', statement: 'Nuclear waste stays dangerous for millennia' },
+  ]
+
+  it('finds the nearest same-side argument and assigns the band', () => {
+    const nearest = scanNearestArgument(
+      'Nuclear power has the lowest deaths per terawatt hour',
+      'pro',
+      siblings,
+    )
+    expect(nearest?.argumentId).toBe(10)
+    expect(nearest?.band).toBe('related-link')
+  })
+
+  it('never matches across sides — a con candidate ignores pro rows', () => {
+    const nearest = scanNearestArgument(
+      'Nuclear has the lowest deaths per terawatt hour',
+      'con',
+      siblings,
+    )
+    expect(nearest?.argumentId).toBe(11)
+  })
+
+  it('returns null when the side has no arguments yet', () => {
+    expect(scanNearestArgument('Reactors emit no carbon during operation', 'pro', [])).toBeNull()
+  })
+})

--- a/tests/unit/lib/conversations/outline.test.ts
+++ b/tests/unit/lib/conversations/outline.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { organizeOutline, type OutlineArgument } from '@/lib/conversations/outline'
+
+const arg = (id: number, side: string, label: string, score: number | null): OutlineArgument => ({
+  id,
+  side,
+  label,
+  slug: `belief-${id}`,
+  score,
+})
+
+describe('organizeOutline (combine, organize, extend)', () => {
+  const args = [
+    arg(1, 'agree', 'Lowest deaths per terawatt hour', 80),
+    arg(2, 'agree', 'Deaths per terawatt hour are lowest', null),
+    arg(3, 'agree', 'Reactors emit no carbon', 60),
+    arg(4, 'disagree', 'Waste storage is unsolved', 70),
+  ]
+
+  it('combines equivalence-paired same-side arguments into one cluster', () => {
+    const { pro } = organizeOutline(args, [{ a: 2, b: 1 }])
+    const clusters = [...pro.top, ...pro.rest]
+    expect(clusters).toHaveLength(2)
+    const merged = clusters.find(c => c.lead.id === 1)
+    expect(merged?.members.map(m => m.id)).toEqual([2])
+  })
+
+  it('organizes clusters score-descending with null-scored leads last', () => {
+    const { pro } = organizeOutline(args, [])
+    expect(pro.top.map(c => c.lead.id)).toEqual([1, 3, 2])
+  })
+
+  it('never combines across sides, even when a pair claims it', () => {
+    const { pro, con } = organizeOutline(args, [{ a: 1, b: 4 }])
+    expect([...pro.top, ...pro.rest].every(c => c.lead.side === 'agree')).toBe(true)
+    expect([...con.top, ...con.rest]).toHaveLength(1)
+  })
+
+  it('extends: an unanswered lead surfaces as a gap for the other side', () => {
+    const { gaps } = organizeOutline(args, [{ a: 2, b: 1 }])
+    const conGaps = gaps.filter(g => g.side === 'con')
+    expect(conGaps.map(g => g.answering)).toContain('Reactors emit no carbon')
+    expect(gaps.some(g => g.side === 'pro' && g.answering === 'Waste storage is unsolved')).toBe(true)
+  })
+
+  it('a counter that engages the lead closes the gap', () => {
+    const engaged = [
+      ...args,
+      arg(5, 'disagree', 'Deaths per terawatt hour undercount evacuations', null),
+    ]
+    const { gaps } = organizeOutline(engaged, [{ a: 2, b: 1 }])
+    expect(gaps.some(g => g.side === 'con' && g.answering === 'Lowest deaths per terawatt hour')).toBe(false)
+    expect(gaps.some(g => g.side === 'con' && g.answering === 'Reactors emit no carbon')).toBe(true)
+  })
+
+  it('splits top from rest at the table limit (Rule 8 shape)', () => {
+    const many = Array.from({ length: 8 }, (_, i) => arg(i + 1, 'agree', `Distinct pro argument number ${i + 1}`, 90 - i))
+    const { pro } = organizeOutline(many, [], 5)
+    expect(pro.top).toHaveLength(5)
+    expect(pro.rest).toHaveLength(3)
+    expect(pro.top[0].lead.score).toBe(90)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a complete conversation integration system that lets imported chatroom and web-forum transcripts plug into permanent belief pages. Transcripts are stored verbatim, candidate pro/con claims are mined from the chat noise, matched against existing arguments, and reviewed before integration through the same ingestion firewall as any other graph move. The transcript itself never affects scores — only explicit, audited integration moves change the graph.

## Key Changes

**Core conversation modules:**
- `src/lib/conversations/contract.ts` — validation schema and firewall statement
- `src/lib/conversations/extract.ts` — pure text mining: strip chat noise, split sentences, read stance, capture evidence URLs, skip non-arguments with named reasons
- `src/lib/conversations/match.ts` — pure matching: resolve focal belief from thread title + candidates, scan for nearest existing arguments (extend vs. restate)
- `src/lib/conversations/import.ts` — import endpoint: store transcript verbatim, run extraction twice (second pass knows focal statement), write candidates with redundancy bands, audit trail
- `src/lib/conversations/integrate.ts` — review move: accepted candidates run through ingestion firewall (five-step checks, mandatory rationale, no scores), folds combine duplicates, dismissals drop non-arguments
- `src/lib/conversations/outline.ts` — belief page outline organizer: cluster equivalent arguments, rank by score, surface unanswered leads as gaps, queue pending candidates in incoming lane

**API routes:**
- `POST /api/v1/conversations` — import a transcript (stores thread, mines candidates, matches to belief graph)
- `GET /api/v1/conversations/[id]` — fetch one thread with its transcript and candidates
- `POST /api/v1/conversations/[id]/integrate` — review move (integrate/fold/dismiss candidates)
- `GET /api/beliefs/[id]/outline` — belief page outline with pro/con clusters, gaps, and incoming candidates

**UI:**
- `src/app/conversations/page.tsx` — conversation review dashboard (recent imports, candidate status, integration controls)

**Database:**
- `ConversationThread` — one imported external conversation (Discord/Reddit/X/forum/chat)
- `ConversationMessage` — verbatim message from transcript (immutable, indexed by thread)
- `ArgumentCandidate` — mined claim pending review (links to thread, message, focal belief, nearest argument, integration result)
- Relations added to `Belief` and `Argument` models

**Tests:**
- `tests/unit/lib/conversations/extract.test.ts` — extraction: standalone claims, stance reading, hedge stripping, URL capture, skip reasons
- `tests/unit/lib/conversations/match.test.ts` — focal belief picking, nearest argument scanning
- `tests/unit/lib/conversations/outline.test.ts` — clustering, ranking, gap detection
- `tests/unit/lib/conversations/conversation-firewall.test.ts` — invariant: conversation tables absent from scoring modules

## Notable Implementation Details

- **Two-pass extraction:** when focal belief is resolved by matching (not named), extraction runs twice — second pass knows the focal statement, so restatements are skipped and negation stances read correctly
- **Heuristic stance reading:** disagreement openers flip stance; sentence-level negation of focal statement flips too; agreement openers keep pro
- **Argumentative markers:** extraction records signals ("because", "evidence", "shows", etc.) so reviewers can rank candidates by signal strength
- **Redundancy scan:** candidates matched against focal page's existing arguments; similarity bands route to "extend outline" vs. "restates row #N"
- **Firewall integration:** accepted candidates run through `runIngest()` with five-step checks, mandatory rationale, audit rows — same validation as any other move, no score fields allowed
- **All-or-nothing batches:** integrations run as one ingest batch (atomic, replayable); folds and dismissals are separate status moves with their own audit rows
- **Conversation firewall invariant:** test ensures conversation tables never referenced from scoring-adjacent modules; only integration through ingestion firewall changes the graph

https://claude.ai/code/session_019CjcQ1J1KYYcEwpqRnkgyj